### PR TITLE
/my-references UX pass: mobile drawer scroll fix + React best-practices sweep + Wikipedia title fix

### DIFF
--- a/functions/lib/extract/pipeline.ts
+++ b/functions/lib/extract/pipeline.ts
@@ -32,5 +32,27 @@ export function runExtractionPipeline(html: string, url: string): PipelineResult
     URL: url,
     ...merged,
   };
+
+  // Wikipedia quirk: JSON-LD `headline` is the article description, not the title
+  // (e.g. <https://en.wikipedia.org/wiki/Citation> → "reference to a source").
+  // The <title> tag has the correct value, and the heuristic signal already
+  // strips the " - Wikipedia" suffix via TITLE_SEP.
+  if (isWikipediaHost(url)) {
+    const heuristic = named.find((s) => s.name === 'heuristic');
+    if (heuristic?.fields.title) {
+      final.title = heuristic.fields.title;
+      signals.title = 'heuristic';
+    }
+  }
+
   return { csl: final, signals };
+}
+
+function isWikipediaHost(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === 'wikipedia.org' || host.endsWith('.wikipedia.org');
+  } catch {
+    return false;
+  }
 }

--- a/src/components/react/Drawer.tsx
+++ b/src/components/react/Drawer.tsx
@@ -43,7 +43,11 @@ const DrawerContent = React.forwardRef<
         <DrawerPrimitive.Content
             ref={ref}
             className={cn(
-                "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+                // `max-h-[97vh] overflow-hidden` bounds the drawer's box so its
+                // children can't render past the top of the viewport. Combined
+                // with `flex flex-col`, a child marked `flex-1 min-h-0` can
+                // safely become the scroll container for overflowing content.
+                "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto max-h-[97vh] flex-col overflow-hidden rounded-t-[10px] border bg-background",
                 className
             )}
             {...props}

--- a/src/components/react/EditCitationForm.tsx
+++ b/src/components/react/EditCitationForm.tsx
@@ -30,9 +30,14 @@ const TYPE_OPTIONS: CitationOption[] = [
 interface Props {
     source: StoredSource;
     setSources: (s: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => void;
+    // Parent ref populated with the latest in-flight CSL on every render. The
+    // dialog/drawer reads it on close to decide empty-vs-flush before the
+    // debounced 500ms timer would have fired — otherwise typed input is lost
+    // (citation removed as "still empty") or stale (form unmount cancels timer).
+    currentRef?: React.MutableRefObject<CSLItem | null>;
 }
 
-export default function EditCitationForm({ source, setSources }: Props) {
+export default function EditCitationForm({ source, setSources, currentRef }: Props) {
     const [local, setLocal] = useState<CSLItem>(source.csl);
 
     // Read the latest `local` via ref inside the debounced flush so the 500ms
@@ -40,7 +45,10 @@ export default function EditCitationForm({ source, setSources }: Props) {
     // intervening patches happened (functional setLocal + ref instead of
     // closure-captured `local` avoids dropping characters under rapid typing).
     const localRef = useRef(local);
-    useEffect(() => { localRef.current = local; }, [local]);
+    useEffect(() => {
+        localRef.current = local;
+        if (currentRef) currentRef.current = local;
+    }, [local, currentRef]);
 
     const debouncedSet = useDebounce(() => {
         setSources((prev) => prev.map((s) => s.uuid === source.uuid ? { ...s, csl: localRef.current } : s));

--- a/src/components/react/EditCitationForm.tsx
+++ b/src/components/react/EditCitationForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useEffect, useRef } from 'react';
 import type { StoredSource } from '../../lib/references/storage';
 import type { CSLItem } from '../../lib/citations/csl-types';
 import {
@@ -35,15 +35,21 @@ interface Props {
 export default function EditCitationForm({ source, setSources }: Props) {
     const [local, setLocal] = useState<CSLItem>(source.csl);
 
-    const debouncedSet = useDebounce((next: CSLItem) => {
-        setSources((prev) => prev.map((s) => s.uuid === source.uuid ? { ...s, csl: next } : s));
+    // Read the latest `local` via ref inside the debounced flush so the 500ms
+    // timer always writes the most recent state, regardless of how many
+    // intervening patches happened (functional setLocal + ref instead of
+    // closure-captured `local` avoids dropping characters under rapid typing).
+    const localRef = useRef(local);
+    useEffect(() => { localRef.current = local; }, [local]);
+
+    const debouncedSet = useDebounce(() => {
+        setSources((prev) => prev.map((s) => s.uuid === source.uuid ? { ...s, csl: localRef.current } : s));
     }, 500);
 
     const patch = useCallback((p: Partial<CSLItem>) => {
-        const next = { ...local, ...p } as CSLItem;
-        setLocal(next);
-        debouncedSet(next);
-    }, [local, debouncedSet]);
+        setLocal((prev) => ({ ...prev, ...p } as CSLItem));
+        debouncedSet();
+    }, [debouncedSet]);
 
     const handleTypeChange = (t: CSLItem['type']) => patch({ type: t });
 

--- a/src/components/react/EditReferenceDialogDrawer.tsx
+++ b/src/components/react/EditReferenceDialogDrawer.tsx
@@ -10,6 +10,7 @@ import {
 import { useMediaQuery } from '@react-hook/media-query'
 import EditCitationForm from "./EditCitationForm"
 import type { StoredSource } from '../../lib/references/storage';
+import type { CSLItem } from '../../lib/citations/csl-types';
 import { ScrollArea } from "./ScrollArea";
 import { Line } from "./EditCitationFormComponents"
 import { Pencil, RefreshCw } from "lucide-react"
@@ -50,10 +51,12 @@ const Content = ({
     source,
     setSources,
     isDesktop,
+    currentRef,
 }: {
     source: StoredSource;
     setSources: SetSources;
     isDesktop: boolean;
+    currentRef: React.MutableRefObject<CSLItem | null>;
 }) => {
     // On desktop the Dialog is centered and doesn't otherwise constrain its
     // own height, so the ScrollArea caps at 65vh. On mobile the Drawer is
@@ -66,7 +69,7 @@ const Content = ({
             {/* key forces a fresh form instance when the slot is reused with a
                 different source (defense in depth — the parent <ReferenceItem
                 key={uuid}> already isolates per source, but cheap insurance). */}
-            <EditCitationForm key={source.uuid} source={source} setSources={setSources} />
+            <EditCitationForm key={source.uuid} source={source} setSources={setSources} currentRef={currentRef} />
             <Line className="my-8" />
             <div className="flex gap-2 items-center pb-8 text-muted-foreground ">
                 <RefreshCw size={16} strokeWidth={1.8} />
@@ -90,11 +93,23 @@ const EditReferenceDialogDrawer = forwardRef<HTMLButtonElement, EditReferenceDia
     const [open, setOpen] = React.useState(false);
     const isDesktop = useMediaQuery("(min-width: 900px)");
 
+    // EditCitationForm populates this on every keystroke. We read it on close
+    // to decide empty-vs-flush before the form's 500ms debounce would fire,
+    // otherwise a fast tap-outside drops the typed input (citation removed as
+    // "still empty", or last keystroke lost when the unmount cleanup cancels
+    // the pending timer).
+    const currentRef = React.useRef<CSLItem | null>(null);
+
     const handleOpenChange = (newOpen: boolean) => {
-        if (!newOpen && isEmptyCitation(source)) {
-            // Functional setter — no `sources` prop required, and safe under
-            // concurrent updates (e.g. an in-flight URL fetch resolving).
-            setSources((prev) => prev.filter((s) => s.uuid !== source.uuid));
+        if (!newOpen) {
+            const current = currentRef.current ?? source.csl;
+            if (isEmptyCitation({ ...source, csl: current })) {
+                setSources((prev) => prev.filter((s) => s.uuid !== source.uuid));
+            } else if (current !== source.csl) {
+                // Flush the in-flight edit so the typed value isn't dropped
+                // when the form unmounts (which clears the debounce timer).
+                setSources((prev) => prev.map((s) => s.uuid === source.uuid ? { ...s, csl: current } : s));
+            }
         }
         setOpen(newOpen);
     };
@@ -109,7 +124,7 @@ const EditReferenceDialogDrawer = forwardRef<HTMLButtonElement, EditReferenceDia
                 </DialogTrigger>
                 <DialogContent className="p-0">
                     <Header isDesktop />
-                    <Content source={source} setSources={setSources} isDesktop />
+                    <Content source={source} setSources={setSources} isDesktop currentRef={currentRef} />
                 </DialogContent>
             </Dialog>
         );
@@ -122,7 +137,7 @@ const EditReferenceDialogDrawer = forwardRef<HTMLButtonElement, EditReferenceDia
             </DrawerTrigger>
             <DrawerContent>
                 <Header isDesktop={false} />
-                <Content source={source} setSources={setSources} isDesktop={false} />
+                <Content source={source} setSources={setSources} isDesktop={false} currentRef={currentRef} />
             </DrawerContent>
         </Drawer>
     );

--- a/src/components/react/EditReferenceDialogDrawer.tsx
+++ b/src/components/react/EditReferenceDialogDrawer.tsx
@@ -1,39 +1,80 @@
 import React, { forwardRef } from "react"
-import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle, DrawerTrigger } from "./Drawer"
+import { Drawer, DrawerContent, DrawerHeader, DrawerTitle, DrawerTrigger } from "./Drawer"
 import {
     Dialog,
     DialogContent,
-    DialogDescription,
     DialogHeader,
     DialogTitle,
     DialogTrigger,
 } from "./Dialog"
 import { useMediaQuery } from '@react-hook/media-query'
-import { Button } from "./Button"
 import EditCitationForm from "./EditCitationForm"
 import type { StoredSource } from '../../lib/references/storage';
 import { ScrollArea } from "./ScrollArea";
 import { Line } from "./EditCitationFormComponents"
-import { Check, Pencil, RefreshCw } from "lucide-react"
+import { Pencil, RefreshCw } from "lucide-react"
+
+type SetSources = (next: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => void;
 
 interface EditReferenceDialogDrawerProps {
     source: StoredSource;
-    sources: StoredSource[];
-    setSources: (sources: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => void;
+    setSources: SetSources;
 }
 
-const Content = ({ source, setSources }: { source: StoredSource; setSources: EditReferenceDialogDrawerProps['setSources'] }) => {
+// Hoisted out of the forwardRef body so its component identity is stable across
+// renders of the parent — otherwise Radix would remount the Trigger and its
+// click handler on every re-render of the surrounding row.
+const TriggerButton = forwardRef<HTMLButtonElement, { onClick: () => void }>(({ onClick }, ref) => (
+    <button
+        ref={ref}
+        className="flex gap-[5px] items-center text-[var(--color-text-light)] hover:text-[var(--color-text-primary)]"
+        onClick={onClick}
+    >
+        <Pencil className="w-[20px] h-[20px]" />
+        <span>Edit</span>
+    </button>
+));
+TriggerButton.displayName = 'EditReferenceTriggerButton';
+
+const Header = ({ isDesktop }: { isDesktop: boolean }) => {
+    const HeaderComponent = isDesktop ? DialogHeader : DrawerHeader;
+    const TitleComponent = isDesktop ? DialogTitle : DrawerTitle;
     return (
-        <ScrollArea className="mx-auto w-full w-full max-h-[65vh] h-full p-8 pt-0 pb-0">
-            <EditCitationForm source={source} setSources={setSources} />
+        <HeaderComponent className="m-0 p-5 px-8 shadow-sm border-b border-border border-b-solid">
+            <TitleComponent>Edit Citation</TitleComponent>
+        </HeaderComponent>
+    );
+};
+
+const Content = ({
+    source,
+    setSources,
+    isDesktop,
+}: {
+    source: StoredSource;
+    setSources: SetSources;
+    isDesktop: boolean;
+}) => {
+    // On desktop the Dialog is centered and doesn't otherwise constrain its
+    // own height, so the ScrollArea caps at 65vh. On mobile the Drawer is
+    // already bounded (max-h-[97vh]) and is `flex flex-col`, so the ScrollArea
+    // fills the remaining vertical space via `flex-1 min-h-0` — without that,
+    // the long form scrolls off the bottom of the viewport unreachable.
+    const sizing = isDesktop ? 'max-h-[65vh]' : 'min-h-0 flex-1';
+    return (
+        <ScrollArea className={`mx-auto w-full ${sizing} p-8 pt-0 pb-0`}>
+            {/* key forces a fresh form instance when the slot is reused with a
+                different source (defense in depth — the parent <ReferenceItem
+                key={uuid}> already isolates per source, but cheap insurance). */}
+            <EditCitationForm key={source.uuid} source={source} setSources={setSources} />
             <Line className="my-8" />
             <div className="flex gap-2 items-center pb-8 text-muted-foreground ">
                 <RefreshCw size={16} strokeWidth={1.8} />
                 <p className="text-xs leading-none">All changes are saved automatically.</p>
             </div>
         </ScrollArea>
-    )
-}
+    );
+};
 
 const isEmptyCitation = (source: StoredSource): boolean => {
     const c = source.csl;
@@ -45,68 +86,46 @@ const isEmptyCitation = (source: StoredSource): boolean => {
     return noAuthors && noTitle && noContainer && noUrl && noYear;
 };
 
-const EditReferenceDialogDrawer = forwardRef<HTMLButtonElement, EditReferenceDialogDrawerProps>(({ source, sources, setSources }, ref) => {
+const EditReferenceDialogDrawer = forwardRef<HTMLButtonElement, EditReferenceDialogDrawerProps>(({ source, setSources }, ref) => {
     const [open, setOpen] = React.useState(false);
     const isDesktop = useMediaQuery("(min-width: 900px)");
 
     const handleOpenChange = (newOpen: boolean) => {
         if (!newOpen && isEmptyCitation(source)) {
-            const updatedSources = sources.filter(s => s.uuid !== source.uuid);
-            setSources(updatedSources);
+            // Functional setter — no `sources` prop required, and safe under
+            // concurrent updates (e.g. an in-flight URL fetch resolving).
+            setSources((prev) => prev.filter((s) => s.uuid !== source.uuid));
         }
         setOpen(newOpen);
     };
 
-    const HeaderComponent = isDesktop ? DialogHeader : DrawerHeader;
-    const TitleComponent = isDesktop ? DialogTitle : DrawerTitle;
-    const DescriptionComponent = isDesktop ? DialogDescription : DrawerDescription;
-
-    const Header = () => {
-        return (
-            <HeaderComponent className="m-0 p-5 px-8 shadow-sm border-b border-border border-b-solid">
-                <TitleComponent>Edit Citation</TitleComponent>
-            </HeaderComponent>
-        )
-    }
-
-    const TriggerButton = () => {
-        return (
-            <button
-                ref={ref}
-                className="flex gap-[5px] items-center text-[var(--color-text-light)] hover:text-[var(--color-text-primary)]"
-                onClick={() => setOpen(true)}
-            >
-                <Pencil className="w-[20px] h-[20px]" />
-                <span>Edit</span>
-            </button>
-        )
-    }
+    const openDrawer = React.useCallback(() => setOpen(true), []);
 
     if (isDesktop) {
         return (
             <Dialog open={open} onOpenChange={handleOpenChange}>
                 <DialogTrigger asChild>
-                    <TriggerButton />
+                    <TriggerButton ref={ref} onClick={openDrawer} />
                 </DialogTrigger>
                 <DialogContent className="p-0">
-                    <Header />
-                    <Content source={source} setSources={setSources} />
+                    <Header isDesktop />
+                    <Content source={source} setSources={setSources} isDesktop />
                 </DialogContent>
             </Dialog>
-        )
+        );
     }
 
     return (
         <Drawer open={open} onOpenChange={handleOpenChange}>
             <DrawerTrigger asChild>
-                <TriggerButton />
+                <TriggerButton ref={ref} onClick={openDrawer} />
             </DrawerTrigger>
             <DrawerContent>
-                <Header />
-                <Content source={source} setSources={setSources} />
+                <Header isDesktop={false} />
+                <Content source={source} setSources={setSources} isDesktop={false} />
             </DrawerContent>
         </Drawer>
-    )
+    );
 });
 
 EditReferenceDialogDrawer.displayName = 'EditReferenceDialogDrawer';

--- a/src/components/react/ReferenceItem.tsx
+++ b/src/components/react/ReferenceItem.tsx
@@ -1,28 +1,19 @@
-import React, { useEffect, useRef } from 'react';
+import React, { memo, useEffect, useRef } from 'react';
 import EditReferenceDialogDrawer from './EditReferenceDialogDrawer';
 import { useFormattedCitation } from '../../lib/citations/useFormattedCitation';
 import type { StoredSource } from '../../lib/references/storage';
 import type { SupportedStyle, RichText } from '../../lib/citations/csl-types';
 import styles from '../../styles/references.module.css';
 import { Clipboard, Globe } from 'lucide-react';
+import { escapeHtml, richTextToHtml } from './richText';
 
 interface Props {
     source: StoredSource;
-    sources: StoredSource[];
-    index: number;
+    checked: boolean;
+    onToggle: (uuid: string, checked: boolean) => void;
     citationFormat: SupportedStyle;
-    onCheckChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
     setSources: (s: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => void;
     autoOpenEdit?: boolean;
-}
-
-function richTextToHtml(rt: RichText[]): string {
-    return rt.map((seg) => seg.italic ? `<i>${escapeHtml(seg.text)}</i>` : escapeHtml(seg.text)).join('');
-}
-
-function escapeHtml(s: string): string {
-    return s.replace(/[&<>"']/g, (c) =>
-        c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c === '"' ? '&quot;' : '&#39;');
 }
 
 function copyRichText(rt: RichText[]) {
@@ -41,7 +32,7 @@ function copyRichText(rt: RichText[]) {
     sel?.removeAllRanges();
 }
 
-export default function ReferenceItem({ source, sources, index, citationFormat, onCheckChange, setSources, autoOpenEdit }: Props) {
+function ReferenceItem({ source, checked, onToggle, citationFormat, setSources, autoOpenEdit }: Props) {
     const editButtonRef = useRef<HTMLButtonElement>(null);
     const { formatted, loading, error } = useFormattedCitation(source, citationFormat);
 
@@ -63,11 +54,13 @@ export default function ReferenceItem({ source, sources, index, citationFormat, 
             <label className={styles.citation}>
                 <input
                     type="checkbox"
-                    id={`source-${index}`}
+                    id={`source-${source.uuid}`}
                     className={styles.checkboxElement}
-                    onChange={onCheckChange}
+                    checked={checked}
+                    onChange={(e) => onToggle(source.uuid, e.target.checked)}
+                    aria-label="Select this reference"
                 />
-                <div className={styles.checkbox}></div>
+                <div className={styles.checkbox} aria-hidden="true"></div>
                 <div className={styles.citationSourceWrapper}>
                     <pre
                         className={styles.citationSource}
@@ -90,7 +83,7 @@ export default function ReferenceItem({ source, sources, index, citationFormat, 
                     <Clipboard className={styles.icon} />
                     <span>Copy</span>
                 </button>
-                <EditReferenceDialogDrawer source={source} sources={sources} setSources={setSources} ref={editButtonRef} />
+                <EditReferenceDialogDrawer source={source} setSources={setSources} ref={editButtonRef} />
                 {source.csl.URL && (
                     <a
                         className={styles.button}
@@ -107,3 +100,8 @@ export default function ReferenceItem({ source, sources, index, citationFormat, 
         </li>
     );
 }
+
+// Memoized so editing one citation doesn't re-render every row. `source`,
+// `setSources`, and `onToggle` identities are stable per uuid; `checked` and
+// `autoOpenEdit` are primitives that only change for the affected row.
+export default memo(ReferenceItem);

--- a/src/components/react/References.tsx
+++ b/src/components/react/References.tsx
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styles from '../../styles/references.module.css';
 import citationStyles from '../citationStyles';
 import Dropdown from './Dropdown';
@@ -7,27 +7,27 @@ import ReferenceItem from './ReferenceItem';
 import { useReferences } from '../../lib/references/useReferences';
 import type { StoredSource } from '../../lib/references/storage';
 import type { SupportedStyle } from '../../lib/citations/csl-types';
+import { formatCitation } from '../../lib/citations/useFormattedCitation';
 import { Clipboard, Plus, Trash2 } from 'lucide-react';
 import { cn } from './utils';
 import { Button } from './Button';
+import { richTextToHtml } from './richText';
 
 function emptySource(): StoredSource {
     const id = crypto.randomUUID();
     return { uuid: id, csl: { id, type: 'webpage' } };
 }
 
-function escape(s: string): string {
-    return s.replace(/[&<>"']/g, (c) => c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c === '"' ? '&quot;' : '&#39;');
-}
-
 export default function References() {
     const {
         sources,
         sourceCount,
-        checkedCount,
+        selected,
+        selectedCount,
         citationFormat,
         setSources,
-        setCheckedCount,
+        toggleSelected,
+        selectAll,
         setCitationFormat,
         handleDelete,
     } = useReferences();
@@ -35,33 +35,25 @@ export default function References() {
     const citationFormatRef = useRef<HTMLInputElement>(null);
     const selectAllRef = useRef<HTMLInputElement>(null);
 
-    const handleSelectAll = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const checkboxes = document.querySelectorAll(`.${styles.citationSourceItem} input[type="checkbox"]`);
-        const checked = event.target.checked;
-        checkboxes.forEach((cb: any) => { cb.checked = checked; });
-        setCheckedCount(checked ? sources.length : 0);
-    };
-
-    const handleCheckChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-        const amount = checkedCount + (event.target.checked ? 1 : -1);
-        setCheckedCount(amount);
-        if (selectAllRef.current) selectAllRef.current.checked = amount === sources.length;
-    };
+    // `indeterminate` has no React prop; sync it imperatively when selection changes.
+    useEffect(() => {
+        if (selectAllRef.current) {
+            selectAllRef.current.indeterminate = selectedCount > 0 && selectedCount < sourceCount;
+        }
+    }, [selectedCount, sourceCount]);
 
     const handleCopySelected = async () => {
-        const selected = sources.filter((_, i) => (document.querySelector(`#source-${i}`) as HTMLInputElement | null)?.checked);
-        if (!selected.length) return;
-        // Request formatted versions in parallel
-        const results = await Promise.all(selected.map(async (s) => {
-            const res = await fetch('/api/format', {
-                method: 'POST',
-                headers: { 'content-type': 'application/json' },
-                body: JSON.stringify({ csl: s.csl, style: citationFormat }),
-            });
-            if (!res.ok) return '';
-            const body = await res.json();
-            return (body.formatted as Array<{ text: string; italic?: boolean }>)
-                .map((seg) => seg.italic ? `<i>${escape(seg.text)}</i>` : escape(seg.text)).join('');
+        const items = sources.filter((s) => selected.has(s.uuid));
+        if (!items.length) return;
+        // Reuses the same module-level cache as the per-item hook, so visible
+        // items are zero-network.
+        const results = await Promise.all(items.map(async (s) => {
+            try {
+                const rt = await formatCitation({ uuid: s.uuid, csl: s.csl }, citationFormat);
+                return richTextToHtml(rt);
+            } catch {
+                return '';
+            }
         }));
         const tempDiv = document.createElement('div');
         tempDiv.style.cssText = 'position:fixed;left:-9999px;font-family:"Times New Roman",Times,serif;font-size:12pt;line-height:2;';
@@ -89,6 +81,8 @@ export default function References() {
         setLastAddedId(next.uuid);
     };
 
+    const allSelected = sourceCount > 0 && selectedCount === sourceCount;
+
     return (
         <div className={styles.container}>
             <CitationSearch includeDropdown={false} includeManualCite={false} ref={citationFormatRef} />
@@ -111,17 +105,18 @@ export default function References() {
                         <input
                             type="checkbox"
                             className={styles.checkboxElement}
-                            onChange={handleSelectAll}
+                            onChange={(e) => selectAll(e.target.checked)}
+                            checked={allSelected}
                             ref={selectAllRef}
                             aria-label="Select all references"
                         />
-                        <div className={styles.checkbox}></div>
+                        <div className={styles.checkbox} aria-hidden="true"></div>
                         <span>
                             {sourceCount} source{sourceCount === 1 ? '' : 's'}
-                            {checkedCount > 0 ? ' selected' : ''}
+                            {selectedCount > 0 ? ' selected' : ''}
                         </span>
                     </label>
-                    {checkedCount > 0 && (
+                    {selectedCount > 0 && (
                         <div className={styles.referenceTitleButtons}>
                             <button
                                 className={styles.button}
@@ -152,15 +147,14 @@ export default function References() {
                 </div>
                 {sources.length > 0 && (
                     <ul className={styles.citationSourceContainer} role="list">
-                        {sources.map((source, i) => (
+                        {sources.map((source) => (
                             <ReferenceItem
                                 key={source.uuid}
                                 source={source}
-                                sources={sources}
                                 setSources={setSources}
-                                index={i}
+                                checked={selected.has(source.uuid)}
+                                onToggle={toggleSelected}
                                 citationFormat={citationFormat}
-                                onCheckChange={handleCheckChange}
                                 autoOpenEdit={source.uuid === lastAddedId}
                             />
                         ))}

--- a/src/components/react/ScrollArea.tsx
+++ b/src/components/react/ScrollArea.tsx
@@ -7,12 +7,20 @@ const ScrollArea = React.forwardRef<
     React.ElementRef<typeof ScrollAreaPrimitive.Root>,
     React.ComponentPropsWithoutRef<typeof ScrollAreaPrimitive.Root>
 >(({ className, children, ...props }, ref) => (
+    // The Root is `flex flex-col` so its single in-flow child (the Viewport)
+    // becomes a flex item with a definite height. Without this, the Viewport's
+    // `height: 100%` (`h-full`) resolves against the Root's `auto` height and
+    // grows to fit content, defeating `overflow: scroll`. ScrollBar and Corner
+    // are `position: absolute` (set by Radix) so they don't participate in
+    // flex layout. Consumers must give the Root a bounded height — either an
+    // explicit `h-*` / `max-h-*`, or `flex-1 min-h-0` inside a flex parent —
+    // otherwise both Root and Viewport size to content as before.
     <ScrollAreaPrimitive.Root
         ref={ref}
-        className={cn("relative overflow-hidden", className)}
+        className={cn("relative flex flex-col overflow-hidden", className)}
         {...props}
     >
-        <ScrollAreaPrimitive.Viewport className="h-full w-full rounded-[inherit]">
+        <ScrollAreaPrimitive.Viewport className="min-h-0 w-full flex-1 rounded-[inherit]">
             {children}
         </ScrollAreaPrimitive.Viewport>
         <ScrollBar />

--- a/src/components/react/richText.ts
+++ b/src/components/react/richText.ts
@@ -1,0 +1,10 @@
+import type { RichText } from '../../lib/citations/csl-types';
+
+export function escapeHtml(s: string): string {
+    return s.replace(/[&<>"']/g, (c) =>
+        c === '&' ? '&amp;' : c === '<' ? '&lt;' : c === '>' ? '&gt;' : c === '"' ? '&quot;' : '&#39;');
+}
+
+export function richTextToHtml(rt: RichText[]): string {
+    return rt.map((seg) => seg.italic ? `<i>${escapeHtml(seg.text)}</i>` : escapeHtml(seg.text)).join('');
+}

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -11,6 +11,9 @@ export function useDebounce<T extends (...args: any[]) => void>(
     const timeoutRef = useRef<NodeJS.Timeout>();
     const callbackRef = useRef(callback);
     useEffect(() => { callbackRef.current = callback; }, [callback]);
+    useEffect(() => () => {
+        if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    }, []);
 
     return useCallback(
         ((...args: Parameters<T>) => {

--- a/src/hooks/useDebounce.ts
+++ b/src/hooks/useDebounce.ts
@@ -1,21 +1,22 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 
+// Returns a stable debounced function whose latest-callback semantics hold even
+// when consumers pass freshly-allocated callbacks each render. The previous
+// `[callback, delay]` deps caused the returned function to churn identity on
+// every render, defeating downstream memoization.
 export function useDebounce<T extends (...args: any[]) => void>(
     callback: T,
     delay: number
 ): T {
     const timeoutRef = useRef<NodeJS.Timeout>();
+    const callbackRef = useRef(callback);
+    useEffect(() => { callbackRef.current = callback; }, [callback]);
 
     return useCallback(
-        (...args: Parameters<T>) => {
-            if (timeoutRef.current) {
-                clearTimeout(timeoutRef.current);
-            }
-
-            timeoutRef.current = setTimeout(() => {
-                callback(...args);
-            }, delay);
-        },
-        [callback, delay]
-    ) as T;
-} 
+        ((...args: Parameters<T>) => {
+            if (timeoutRef.current) clearTimeout(timeoutRef.current);
+            timeoutRef.current = setTimeout(() => callbackRef.current(...args), delay);
+        }) as T,
+        [delay]
+    );
+}

--- a/src/lib/citations/useFormattedCitation.ts
+++ b/src/lib/citations/useFormattedCitation.ts
@@ -83,6 +83,9 @@ export function formatCitation(source: Args, style: SupportedStyle): Promise<Ric
   if (cached) return Promise.resolve(cached);
   const promise = inflight.get(key) ?? fetchFormatted(source.csl, style, key);
   inflight.set(key, promise);
-  promise.finally(() => inflight.delete(key));
+  // The hook-side .then/.catch absorbs the rejection on its own chain; this
+  // bookkeeping chain needs its own catch or rejections surface as uncaught
+  // when fetchFormatted fails (5xx, network) and no one else is awaiting `key`.
+  promise.finally(() => inflight.delete(key)).catch(() => { /* swallowed; caller's await sees it */ });
   return promise;
 }

--- a/src/lib/citations/useFormattedCitation.ts
+++ b/src/lib/citations/useFormattedCitation.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import type { CSLItem, RichText, SupportedStyle } from './csl-types';
 
 interface Args {
@@ -29,7 +29,13 @@ function cslFingerprint(csl: CSLItem): string {
 }
 
 export function useFormattedCitation(source: Args, style: SupportedStyle): State {
-  const key = `${source.uuid}::${style}::${cslFingerprint(source.csl)}`;
+  // Fingerprint the CSL once per content change so render-loop callers don't
+  // re-stringify on every render. `key` already encodes uuid+style+content,
+  // so it's the only effect dependency we need.
+  const key = useMemo(
+    () => `${source.uuid}::${style}::${cslFingerprint(source.csl)}`,
+    [source.uuid, source.csl, style],
+  );
   const [state, setState] = useState<State>(() => {
     const hit = cache.get(key);
     return hit
@@ -45,24 +51,38 @@ export function useFormattedCitation(source: Args, style: SupportedStyle): State
       return;
     }
     setState((s) => ({ ...s, loading: true, error: null }));
-    const promise = inflight.get(key) ?? (async () => {
-      const res = await fetch('/api/format', {
-        method: 'POST',
-        headers: { 'content-type': 'application/json' },
-        body: JSON.stringify({ csl: source.csl, style }),
-      });
-      if (!res.ok) throw new Error(`Format failed: HTTP ${res.status}`);
-      const body = await res.json() as { formatted: RichText[] };
-      cache.set(key, body.formatted);
-      return body.formatted;
-    })();
+    const promise = inflight.get(key) ?? fetchFormatted(source.csl, style, key);
     inflight.set(key, promise);
     promise
       .then((rt) => { if (!cancelled) setState({ formatted: rt, loading: false, error: null }); })
       .catch((e: Error) => { if (!cancelled) setState({ formatted: [], loading: false, error: e.message }); })
       .finally(() => inflight.delete(key));
     return () => { cancelled = true; };
-  }, [key, source.csl, style]);
+  }, [key]);
 
   return state;
+}
+
+// Cache-aware fetch used by the hook and exported for callers (e.g. Copy
+// Selected) that need the same memoization but outside the React tree.
+async function fetchFormatted(csl: CSLItem, style: SupportedStyle, key: string): Promise<RichText[]> {
+  const res = await fetch('/api/format', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ csl, style }),
+  });
+  if (!res.ok) throw new Error(`Format failed: HTTP ${res.status}`);
+  const body = await res.json() as { formatted: RichText[] };
+  cache.set(key, body.formatted);
+  return body.formatted;
+}
+
+export function formatCitation(source: Args, style: SupportedStyle): Promise<RichText[]> {
+  const key = `${source.uuid}::${style}::${cslFingerprint(source.csl)}`;
+  const cached = cache.get(key);
+  if (cached) return Promise.resolve(cached);
+  const promise = inflight.get(key) ?? fetchFormatted(source.csl, style, key);
+  inflight.set(key, promise);
+  promise.finally(() => inflight.delete(key));
+  return promise;
 }

--- a/src/lib/references/useReferences.ts
+++ b/src/lib/references/useReferences.ts
@@ -1,14 +1,16 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { loadSources, saveSources, type StoredSource } from './storage';
 import type { CSLItem, SupportedStyle } from '../citations/csl-types';
 
 export interface UseReferencesReturn {
   sources: StoredSource[];
   sourceCount: number;
-  checkedCount: number;
+  selected: ReadonlySet<string>;
+  selectedCount: number;
   citationFormat: SupportedStyle;
   setSources: (sources: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => void;
-  setCheckedCount: (count: number) => void;
+  toggleSelected: (uuid: string, checked: boolean) => void;
+  selectAll: (checked: boolean) => void;
   setCitationFormat: (format: SupportedStyle) => void;
   handleDelete: () => void;
 }
@@ -27,7 +29,7 @@ interface ApiEnvelope {
 
 export function useReferences(): UseReferencesReturn {
   const [sources, setSourcesState] = useState<StoredSource[]>([]);
-  const [checkedCount, setCheckedCount] = useState(0);
+  const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
   const [citationFormat, setCitationFormatState] = useState<SupportedStyle>('mla-9');
 
   const setSources = useCallback((next: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => {
@@ -42,23 +44,30 @@ export function useReferences(): UseReferencesReturn {
     setCitationFormatState(s);
   }, []);
 
-  const handleDelete = useCallback(() => {
-    const remaining: StoredSource[] = [];
-    sources.forEach((s, i) => {
-      const cb = document.querySelector(`#source-${i}`) as HTMLInputElement | null;
-      if (!cb?.checked) remaining.push(s);
+  const toggleSelected = useCallback((uuid: string, checked: boolean) => {
+    setSelected((prev) => {
+      if (checked === prev.has(uuid)) return prev;
+      const next = new Set(prev);
+      if (checked) next.add(uuid); else next.delete(uuid);
+      return next;
     });
-    setSources(remaining);
-    setCheckedCount(0);
-  }, [sources, setSources]);
+  }, []);
+
+  const selectAll = useCallback((checked: boolean) => {
+    setSelected(checked ? new Set(sources.map((s) => s.uuid)) : new Set());
+  }, [sources]);
+
+  const handleDelete = useCallback(() => {
+    setSources((prev) => prev.filter((s) => !selected.has(s.uuid)));
+    setSelected(new Set());
+  }, [selected, setSources]);
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     const styleParam = params.get('citationStyle');
     if (isSupportedStyle(styleParam)) setCitationFormatState(styleParam);
 
-    const existing = loadSources();
-    setSourcesState(existing);
+    setSourcesState(loadSources());
 
     const website = params.get('website');
     const book = params.get('book');
@@ -77,22 +86,40 @@ export function useReferences(): UseReferencesReturn {
       })
       .then((env) => {
         if (cancelled || !env?.csl) return;
-        if (existing.some((s) => s.uuid === env.uuid)) return;
-        const merged = [...existing, { uuid: env.uuid, csl: env.csl }];
-        setSources(merged);
+        // Functional updater (not a closed-over `existing`) so manual citations
+        // the user added between mount and fetch resolution aren't clobbered.
+        setSources((prev) => prev.some((s) => s.uuid === env.uuid)
+          ? prev
+          : [...prev, { uuid: env.uuid, csl: env.csl }]);
       })
       .catch((err) => console.error('Citation fetch failed', err));
     return () => { cancelled = true; };
   }, [setSources]);
 
-  return {
+  // Prune stale uuids when sources change (e.g. deletions outside handleDelete).
+  useEffect(() => {
+    setSelected((prev) => {
+      if (prev.size === 0) return prev;
+      const valid = new Set(sources.map((s) => s.uuid));
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (valid.has(id)) next.add(id); else changed = true;
+      }
+      return changed ? next : prev;
+    });
+  }, [sources]);
+
+  return useMemo(() => ({
     sources,
     sourceCount: sources.length,
-    checkedCount,
+    selected,
+    selectedCount: selected.size,
     citationFormat,
     setSources,
-    setCheckedCount,
+    toggleSelected,
+    selectAll,
     setCitationFormat,
     handleDelete,
-  };
+  }), [sources, selected, citationFormat, setSources, toggleSelected, selectAll, setCitationFormat, handleDelete]);
 }

--- a/src/lib/references/useReferences.ts
+++ b/src/lib/references/useReferences.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { loadSources, saveSources, type StoredSource } from './storage';
 import type { CSLItem, SupportedStyle } from '../citations/csl-types';
 
@@ -110,7 +110,10 @@ export function useReferences(): UseReferencesReturn {
     });
   }, [sources]);
 
-  return useMemo(() => ({
+  // No useMemo on the returned object: `selectAll` and `handleDelete` depend on
+  // state that changes on every meaningful update, so a memo never hits — it
+  // would only pay the shallow-compare cost without benefit.
+  return {
     sources,
     sourceCount: sources.length,
     selected,
@@ -121,5 +124,5 @@ export function useReferences(): UseReferencesReturn {
     selectAll,
     setCitationFormat,
     handleDelete,
-  }), [sources, selected, citationFormat, setSources, toggleSelected, selectAll, setCitationFormat, handleDelete]);
+  };
 }

--- a/tests/client/EditCitationForm.test.tsx
+++ b/tests/client/EditCitationForm.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import EditCitationForm from '../../src/components/react/EditCitationForm';
+import type { StoredSource } from '../../src/lib/references/storage';
+import type { CSLItem } from '../../src/lib/citations/csl-types';
+
+describe('EditCitationForm currentRef sync', () => {
+  // Regression: tap-outside-on-mobile / ESC closes the dialog before the form's
+  // 500ms debounce flushes typed input. Parent reads `currentRef` to decide
+  // empty-vs-flush before the form unmounts and the timer is cleared.
+
+  it('populates currentRef with the initial CSL after mount', () => {
+    const currentRef = React.createRef<CSLItem | null>() as React.MutableRefObject<CSLItem | null>;
+    currentRef.current = null;
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: { id: 'u1', type: 'webpage', title: 'Initial' },
+    };
+    render(<EditCitationForm source={source} setSources={() => {}} currentRef={currentRef} />);
+    expect(currentRef.current?.title).toBe('Initial');
+  });
+
+  it('updates currentRef synchronously after typed input (before debounce fires)', () => {
+    const currentRef = React.createRef<CSLItem | null>() as React.MutableRefObject<CSLItem | null>;
+    currentRef.current = null;
+    const setSources = vi.fn();
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: { id: 'u1', type: 'webpage' },
+    };
+    const { container } = render(
+      <EditCitationForm source={source} setSources={setSources} currentRef={currentRef} />,
+    );
+
+    // The Title field is the first text-like input; the form has many fields,
+    // so we locate by placeholder/label-style. Using container.querySelector
+    // since EditCitationFormComponents.tsx renders raw HTML inputs.
+    const titleInput = container.querySelector('input[type="text"]') as HTMLInputElement;
+    expect(titleInput).toBeTruthy();
+
+    fireEvent.change(titleInput, { target: { value: 'Hello' } });
+
+    // Ref should reflect the typed value immediately (no 500ms wait), so a
+    // parent reading it on a fast tap-outside gets the latest, not stale.
+    expect(currentRef.current?.title).toBe('Hello');
+
+    // The debounced setSources has NOT fired yet — confirming the ref-based
+    // flush path is the only way to recover this input on synchronous close.
+    expect(setSources).not.toHaveBeenCalled();
+  });
+});

--- a/tests/client/ReferenceItem.test.tsx
+++ b/tests/client/ReferenceItem.test.tsx
@@ -35,10 +35,9 @@ describe('ReferenceItem', () => {
     const { container } = render(
       <ReferenceItem
         source={source}
-        sources={[source]}
-        index={0}
+        checked={false}
+        onToggle={() => {}}
         citationFormat="mla-9"
-        onCheckChange={() => {}}
         setSources={() => {}}
       />,
     );

--- a/tests/client/useReferences.test.ts
+++ b/tests/client/useReferences.test.ts
@@ -55,4 +55,67 @@ describe('useReferences', () => {
     act(() => result.current.setCitationFormat('apa-7'));
     expect(result.current.citationFormat).toBe('apa-7');
   });
+
+  describe('selection (uuid-based, not DOM indices)', () => {
+    beforeEach(() => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify([
+        { uuid: 'a', csl: { id: 'a', type: 'webpage', title: 'A' } },
+        { uuid: 'b', csl: { id: 'b', type: 'webpage', title: 'B' } },
+        { uuid: 'c', csl: { id: 'c', type: 'webpage', title: 'C' } },
+      ]));
+    });
+
+    it('toggleSelected adds and removes uuids; selectedCount tracks size', async () => {
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.sourceCount).toBe(3));
+      expect(result.current.selectedCount).toBe(0);
+
+      act(() => result.current.toggleSelected('a', true));
+      act(() => result.current.toggleSelected('c', true));
+      expect(result.current.selectedCount).toBe(2);
+      expect(result.current.selected.has('a')).toBe(true);
+      expect(result.current.selected.has('b')).toBe(false);
+      expect(result.current.selected.has('c')).toBe(true);
+
+      act(() => result.current.toggleSelected('a', false));
+      expect(result.current.selectedCount).toBe(1);
+      expect(result.current.selected.has('a')).toBe(false);
+    });
+
+    it('selectAll(true) selects every source; selectAll(false) clears', async () => {
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.sourceCount).toBe(3));
+
+      act(() => result.current.selectAll(true));
+      expect(result.current.selectedCount).toBe(3);
+      ['a', 'b', 'c'].forEach((u) => expect(result.current.selected.has(u)).toBe(true));
+
+      act(() => result.current.selectAll(false));
+      expect(result.current.selectedCount).toBe(0);
+    });
+
+    it('handleDelete removes only selected uuids and clears selection', async () => {
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.sourceCount).toBe(3));
+
+      act(() => result.current.toggleSelected('b', true));
+      act(() => result.current.handleDelete());
+
+      expect(result.current.sources.map((s) => s.uuid)).toEqual(['a', 'c']);
+      expect(result.current.selectedCount).toBe(0);
+    });
+
+    it('selection survives list reordering by uuid (not index)', async () => {
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.sourceCount).toBe(3));
+
+      act(() => result.current.toggleSelected('b', true));
+      // Reorder: move 'b' to front
+      act(() => result.current.setSources((prev) => [prev[1], prev[0], prev[2]]));
+
+      // 'b' still selected even though its index changed from 1 to 0
+      expect(result.current.selected.has('b')).toBe(true);
+      expect(result.current.selectedCount).toBe(1);
+    });
+  });
 });

--- a/tests/extract/fixtures/wikipedia-article/expected.csl.json
+++ b/tests/extract/fixtures/wikipedia-article/expected.csl.json
@@ -1,6 +1,6 @@
 {
   "type": "webpage",
-  "title": "reference to a source",
+  "title": "Citation",
   "author": [{ "literal": "Contributors to Wikimedia projects" }],
   "issued": { "date-parts": [[2002, 10, 1]] },
   "publisher": "Wikimedia Foundation, Inc.",

--- a/tests/extract/pipeline.test.ts
+++ b/tests/extract/pipeline.test.ts
@@ -39,4 +39,41 @@ describe('runExtractionPipeline', () => {
     expect(result.csl.type).toBe('webpage');
     expect(result.csl.URL).toBe('https://example.com/p');
   });
+
+  describe('wikipedia title override', () => {
+    // Wikipedia's JSON-LD `headline` is the article description, not the title.
+    // The override prefers the heuristic <title> tag for *.wikipedia.org hosts.
+    const wikiHtml = `<html><head>
+      <title>Foo - Wikipedia</title>
+      <script type="application/ld+json">${JSON.stringify({
+        '@type': 'Article',
+        name: 'Foo',
+        headline: 'bar description not title',
+      })}</script>
+    </head></html>`;
+
+    it('prefers heuristic <title> over JSON-LD headline on en.wikipedia.org', () => {
+      const result = runExtractionPipeline(wikiHtml, 'https://en.wikipedia.org/wiki/Foo');
+      expect(result.csl.title).toBe('Foo');
+      expect(result.signals.title).toBe('heuristic');
+    });
+
+    it('applies on bare wikipedia.org host', () => {
+      const result = runExtractionPipeline(wikiHtml, 'https://wikipedia.org/wiki/Foo');
+      expect(result.csl.title).toBe('Foo');
+      expect(result.signals.title).toBe('heuristic');
+    });
+
+    it('does NOT apply on lookalike subdomain attacks', () => {
+      const result = runExtractionPipeline(wikiHtml, 'https://en.wikipedia.org.evil.com/Foo');
+      expect(result.csl.title).toBe('bar description not title');
+      expect(result.signals.title).toBe('jsonld');
+    });
+
+    it('does NOT apply on unrelated hosts', () => {
+      const result = runExtractionPipeline(wikiHtml, 'https://example.com/Foo');
+      expect(result.csl.title).toBe('bar description not title');
+      expect(result.signals.title).toBe('jsonld');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Focused UX pass on `/my-references`, three workstreams:

1. **Mobile drawer scroll bug** — opening the Edit Citation drawer on mobile rendered form fields beyond the viewport with no way to scroll. Root cause traced via Chrome DevTools Protocol probe + synthetic touch dispatch (not guesswork): `ScrollArea`'s Radix Viewport had `h-full`, which resolves percentage-height against the parent's `height` property — not its computed/clamped box — so against `DrawerContent`'s `h-auto` it resolved to `auto`, the Viewport grew to fit content, `scrollHeight === clientHeight`, and `overflow-y: scroll` had nothing to scroll. Compounding it, `DrawerContent` had no `max-height` and `overflow-y: visible`, so flex children stacked off-screen. Fix: bound DrawerContent (`max-h-[97vh] overflow-hidden`), restructure ScrollArea as `flex flex-col` Root with `flex-1 min-h-0` Viewport so it derives a definite height from flex layout. Incidentally fixes the same latent bug on desktop for long forms.

2. **React best-practices sweep** of the Phase 1 frontend surface (audit performed by a fresh-context subagent against the `react-best-practices` skill). All 5 HIGH and 3 MED findings addressed in-PR; 2 LOW deferred to follow-up (see below).

3. **Wikipedia title extraction fix** — JSON-LD `headline` on `*.wikipedia.org` is the article description, not the title. The existing fixture had the bug behavior frozen in (`/wiki/Citation` → "reference to a source"). Now extracts "Citation" via host-aware override that prefers the heuristic `<title>` (which already strips ` - Wikipedia` via TITLE_SEP). Fixture updated as regression test; 4 focused unit tests added for the override branch directly.

## What changed

### Mobile drawer fix (`Drawer.tsx`, `ScrollArea.tsx`, `EditReferenceDialogDrawer.tsx`)
- `DrawerContent`: `max-h-[97vh] overflow-hidden`
- `ScrollArea` Root: `flex flex-col`; Viewport: `flex-1 min-h-0` (was `h-full`)
- `EditReferenceDialogDrawer Content`: sizing varies by surface — desktop keeps `max-h-[65vh]`, mobile uses `min-h-0 flex-1`

### React best-practices fixes
- **`useDebounce`**: ref-based latest-callback so identity is stable across renders (`[delay]`-only deps); `useEffect` cleanup clears pending timer on unmount
- **`EditCitationForm`**: functional `setLocal` + `localRef`-via-effect so the 500ms debounced flush reads latest state under rapid typing; populates a parent-provided `currentRef` synchronously so the dialog can recover typed input on fast tap-outside (pre-existing drop-on-close bug, fixed here)
- **`useReferences`** URL effect: functional `setSources` so manual citations added between mount and fetch resolution aren't clobbered
- **`useReferences`** selection model: uuid-keyed `Set<string>` replacing DOM-query checkbox reads; `toggleSelected` / `selectAll` / `handleDelete` operate on uuids, so reordering or insertion mid-selection no longer misaligns the wrong-citation-deleted bug class; prune effect drops stale uuids when sources change; useMemo wrapper removed (deps changed every render — dead memo)
- **`ReferenceItem`**: dropped `sources` prop, wrapped in `React.memo` — editing one citation now only re-renders that row
- **`EditReferenceDialogDrawer`**: hoisted `TriggerButton` and `Header` to module scope (eliminates the pre-existing forwardRef warning and stops Radix from remounting the trigger every render); uses functional setter for empty-citation removal; `EditCitationForm` rendered with `key={source.uuid}` (defense-in-depth against form-state reuse)
- **`useFormattedCitation`**: memoize the fingerprint key (N citations × N renders no longer pays N stringifications per render); export `formatCitation()` so `Copy Selected` reuses the same module-level cache — was issuing N redundant `/api/format` requests
- **`richText.ts`**: shared `escapeHtml` + `richTextToHtml` (kills byte-identical duplicate in `References.tsx`)

### Wikipedia title fix (`pipeline.ts`, fixture, new tests)
- Host-aware override in `runExtractionPipeline`: for `*.wikipedia.org`, the heuristic `<title>` wins over JSON-LD `headline`
- 4 new unit tests in `tests/extract/pipeline.test.ts` exercise the override branch directly (en. + bare + lookalike subdomain attack + unrelated host)

## Tests

`npm test` → **198/198 passing** (was 188 on `main`):
- 4 new `useReferences` selection-model tests (toggle, selectAll, handleDelete-by-uuid, selection-survives-reorder)
- 4 new `pipeline.test.ts` wikipedia-override tests
- 2 new `EditCitationForm` currentRef-sync tests

## Pre-merge correctness review

Run twice (fresh-context subagent, prompt crafted via `prompt-engineering` skill):

**Round 1** — found 0 HIGH, 2 MED, 5 LOW, 1 NIT.
**Round 2 (post-fixes)** — all MEDs and 3 LOWs addressed. Deferred:
- LOW: `selectAll` reads `sources` from closure — self-corrects via the prune effect, edge case requires a citation to resolve in the same microtask as the user clicking Select-all on the empty checkbox.
- NIT: pre-existing `data-copy-selected` button-text race on rapid re-click — out of scope.

## Deferred (still tracked from Phase 1)

All items listed in the Phase 1 PR description remain deferred:
- SSRF blocking in `extract/fetch.ts`
- Body-size limits on `/api/format`
- Auth-token stripping from cache keys
- Google Books fixture re-vendor
- `ORG_SUFFIXES` regex tightening
- Phase 2 (style coverage) and Phase 3 (Analytics Engine + Firecrawl fallback)

The pre-existing `forwardRef` warning is **resolved** by the Header/TriggerButton hoist.

## Test plan

- [x] CI green (npm test)
- [x] Production build clean (npm run build)
- [ ] Cloudflare Pages preview deploy verified — drawer scrolls on mobile viewport (≤900px)
- [ ] Six Phase-1 probe URLs still render correctly on preview deploy (nytimes / wikipedia / .gov / academic landing / book ISBN / DOI)
- [ ] Wikipedia probe specifically returns "Citation" not "reference to a source"