### PR TITLE
Fix mobile drawer regressions reported on prod (max-h not compiled, form overflow, header wrap)

### DIFF
--- a/src/components/react/EditCitationForm.tsx
+++ b/src/components/react/EditCitationForm.tsx
@@ -63,7 +63,7 @@ export default function EditCitationForm({ source, setSources, currentRef }: Pro
 
     return (
         <div className="flex flex-col gap-4 w-full pt-8">
-            <div className="grid grid-cols-[130px_1fr] items-center gap-4">
+            <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
                 <span className="flex flex-col leading-4 text-sm">
                     Source Type
                     <span className="text-xs text-muted-foreground">Required</span>
@@ -73,7 +73,7 @@ export default function EditCitationForm({ source, setSources, currentRef }: Pro
                     value={TYPE_OPTIONS.find((o) => o.value === local.type)}
                     onChange={(o: CitationOption) => handleTypeChange(o.value)}
                     placeholder="Source Type"
-                    className="min-w-[7rem]"
+                    className="min-w-0 sm:min-w-[7rem]"
                 />
             </div>
             <Line className="my-4" />

--- a/src/components/react/EditCitationFormComponents.tsx
+++ b/src/components/react/EditCitationFormComponents.tsx
@@ -91,7 +91,7 @@ export const Contributors = ({ source, setSources }: ContributorsProps) => {
     const handleDelete = (idx: number) => update(authors.filter((_, i) => i !== idx));
 
     return (
-        <div className="grid grid-cols-[130px_1fr] gap-4">
+        <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:gap-4">
             <span className="flex flex-col leading-4 text-sm h-9 justify-center">
                 Contributors
                 <span className="text-xs text-muted-foreground">Recommended</span>
@@ -162,7 +162,7 @@ export const Contributors = ({ source, setSources }: ContributorsProps) => {
 };
 
 const LabelledInput = ({ label, value, onChange, recommended }: { label: string; value: string; onChange: (v: string) => void; recommended?: boolean }) => (
-    <label className="grid grid-cols-[110px_1fr] items-center gap-4">
+    <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[110px_1fr] sm:items-center sm:gap-4">
         <span className="flex flex-col leading-4 text-sm">
             {label}
             {recommended && <span className="text-xs text-muted-foreground">Recommended</span>}
@@ -180,7 +180,7 @@ const LabelledInput = ({ label, value, onChange, recommended }: { label: string;
  */
 export const Title = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 Title
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -205,7 +205,7 @@ export const Title = ({ value, onChange, isRequired, isRecommended }: TextCompon
  */
 export const Name = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 Name
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -230,7 +230,7 @@ export const Name = ({ value, onChange, isRequired, isRecommended }: TextCompone
  */
 export const WebsiteName = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 Website Name
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -255,7 +255,7 @@ export const WebsiteName = ({ value, onChange, isRequired, isRecommended }: Text
  */
 export const Edition = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 Edition
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -280,7 +280,7 @@ export const Edition = ({ value, onChange, isRequired, isRecommended }: TextComp
  */
 export const VolumeNumber = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 Volume Number
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -306,7 +306,7 @@ export const VolumeNumber = ({ value, onChange, isRequired, isRecommended }: Tex
  */
 export const Publsiher = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 Publisher
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -331,7 +331,7 @@ export const Publsiher = ({ value, onChange, isRequired, isRecommended }: TextCo
  */
 export const Medium = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 Medium
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -356,7 +356,7 @@ export const Medium = ({ value, onChange, isRequired, isRecommended }: TextCompo
  */
 export const DOI = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 DOI
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -381,7 +381,7 @@ export const DOI = ({ value, onChange, isRequired, isRecommended }: TextComponen
  */
 export const URL = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
-        <label className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 URL
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
@@ -466,13 +466,13 @@ export const PublicationDate = ({ value, onChange, isRequired, isRecommended }: 
     };
 
     return (
-        <div className="grid grid-cols-[130px_1fr] items-center gap-4">
+        <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
                 Publication Date
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <div className="grid grid-cols-[1fr_1fr_1fr] items-center gap-4">
+            <div className="grid grid-cols-[minmax(0,3.5rem)_minmax(0,1fr)_minmax(0,3.5rem)] items-center gap-2 sm:gap-4">
                 <Input
                     placeholder="Year"
                     type="text"
@@ -486,7 +486,7 @@ export const PublicationDate = ({ value, onChange, isRequired, isRecommended }: 
                     value={month ? months[parseInt(month) - 1] : undefined}
                     onChange={(option) => handleChange('month', option.value)}
                     placeholder="Month"
-                    className="min-w-[7rem]"
+                    className="min-w-0"
                 />
                 <Input
                     placeholder="Day"
@@ -566,14 +566,14 @@ export const AccessDate = ({ value, onChange, isRequired, isRecommended }: DateC
     };
 
     return (
-        <div className="grid grid-cols-[130px_1fr] gap-4">
+        <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:gap-4">
             <span className="flex flex-col leading-4 text-sm h-9 justify-center">
                 Access Date
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
             <div className="">
-                <div className="grid grid-cols-[1fr_1fr_1fr] items-center gap-4">
+                <div className="grid grid-cols-[minmax(0,3.5rem)_minmax(0,1fr)_minmax(0,3.5rem)] items-center gap-2 sm:gap-4">
                     <Input
                         placeholder="Year"
                         type="text"
@@ -587,7 +587,7 @@ export const AccessDate = ({ value, onChange, isRequired, isRecommended }: DateC
                         value={month ? months[parseInt(month) - 1] : undefined}
                         onChange={(option) => handleChange('month', option.value)}
                         placeholder="Month"
-                        className="min-w-[7rem]"
+                        className="min-w-0"
                     />
                     <Input
                         placeholder="Day"

--- a/src/components/react/EditReferenceDialogDrawer.tsx
+++ b/src/components/react/EditReferenceDialogDrawer.tsx
@@ -65,7 +65,7 @@ const Content = ({
     // the long form scrolls off the bottom of the viewport unreachable.
     const sizing = isDesktop ? 'max-h-[65vh]' : 'min-h-0 flex-1';
     return (
-        <ScrollArea className={`mx-auto w-full ${sizing} p-8 pt-0 pb-0`}>
+        <ScrollArea className={`mx-auto w-full ${sizing} px-4 sm:px-8 pt-0 pb-0`}>
             {/* key forces a fresh form instance when the slot is reused with a
                 different source (defense in depth — the parent <ReferenceItem
                 key={uuid}> already isolates per source, but cheap insurance). */}

--- a/src/styles/references.module.css
+++ b/src/styles/references.module.css
@@ -316,11 +316,24 @@
     .citationSourceContainer {
         padding-inline: 10px;
     }
+    /* Stack header rows on mobile: "X sources" line, then action buttons,
+       then Add Manually. The default 1fr/auto/auto grid squeezes the source
+       count until it line-wraps when Add Manually is wide. */
+    .referenceTitle {
+        grid-template-columns: 1fr auto;
+        row-gap: 14px;
+    }
+    /* The Add Manually button (always last child) spans the full mobile row. */
+    .referenceTitle > :last-child {
+        grid-column: 1 / -1;
+        justify-self: stretch;
+        margin-left: 0 !important;
+    }
     .citationSourceWrapper {
         margin-left: 36px;
     }
     .citationSource {
-        text-indent: -36px; 
+        text-indent: -36px;
     }
 }
 

--- a/src/styles/tailwind-output.css
+++ b/src/styles/tailwind-output.css
@@ -614,6 +614,10 @@ video {
   border-width: 0;
 }
 
+.visible {
+  visibility: visible;
+}
+
 .collapse {
   visibility: collapse;
 }
@@ -798,6 +802,14 @@ video {
   max-height: 65vh;
 }
 
+.max-h-\[97vh\] {
+  max-height: 97vh;
+}
+
+.min-h-0 {
+  min-height: 0px;
+}
+
 .w-2\.5 {
   width: 0.625rem;
 }
@@ -827,8 +839,8 @@ video {
   width: 100%;
 }
 
-.min-w-\[7rem\] {
-  min-width: 7rem;
+.min-w-0 {
+  min-width: 0px;
 }
 
 .max-w-\[850px\] {
@@ -884,16 +896,8 @@ video {
           user-select: none;
 }
 
-.grid-cols-\[110px_1fr\] {
-  grid-template-columns: 110px 1fr;
-}
-
-.grid-cols-\[130px_1fr\] {
-  grid-template-columns: 130px 1fr;
-}
-
-.grid-cols-\[1fr_1fr_1fr\] {
-  grid-template-columns: 1fr 1fr 1fr;
+.grid-cols-\[minmax\(0\2c 3\.5rem\)_minmax\(0\2c 1fr\)_minmax\(0\2c 3\.5rem\)\] {
+  grid-template-columns: minmax(0,3.5rem) minmax(0,1fr) minmax(0,3.5rem);
 }
 
 .flex-col {
@@ -914,6 +918,10 @@ video {
 
 .justify-between {
   justify-content: space-between;
+}
+
+.gap-1 {
+  gap: 0.25rem;
 }
 
 .gap-1\.5 {
@@ -1083,10 +1091,6 @@ video {
 
 .p-6 {
   padding: 1.5rem;
-}
-
-.p-8 {
-  padding: 2rem;
 }
 
 .p-\[1px\] {
@@ -1480,12 +1484,36 @@ video {
 }
 
 @media (min-width: 640px) {
+  .sm\:grid {
+    display: grid;
+  }
+
+  .sm\:min-w-\[7rem\] {
+    min-width: 7rem;
+  }
+
+  .sm\:grid-cols-\[110px_1fr\] {
+    grid-template-columns: 110px 1fr;
+  }
+
+  .sm\:grid-cols-\[130px_1fr\] {
+    grid-template-columns: 130px 1fr;
+  }
+
   .sm\:flex-row {
     flex-direction: row;
   }
 
+  .sm\:items-center {
+    align-items: center;
+  }
+
   .sm\:justify-end {
     justify-content: flex-end;
+  }
+
+  .sm\:gap-4 {
+    gap: 1rem;
   }
 
   .sm\:space-x-2 > :not([hidden]) ~ :not([hidden]) {
@@ -1496,6 +1524,11 @@ video {
 
   .sm\:rounded-lg {
     border-radius: var(--radius);
+  }
+
+  .sm\:px-8 {
+    padding-left: 2rem;
+    padding-right: 2rem;
   }
 
   .sm\:text-left {


### PR DESCRIPTION
## Summary

Three mobile-drawer bugs reported on production immediately after #5 merged:

1. **Drawer opens scrolled to bottom; scrolling up dismisses it.** ← caused by #5
2. **Form fields cut off horizontally inside the drawer.** ← pre-existing, exposed by the drawer-scroll fix making them reachable
3. **"X sources" label wraps to two lines on mobile.** ← pre-existing, made more annoying by the new selection-model render

### Root cause of #1 (the regression I introduced)

The \`max-h-[97vh]\` class I added to \`DrawerContent\` in #5 was **never compiled into \`tailwind-output.css\`**. This project pre-compiles Tailwind via \`npm run build-tailwind\` and the result is checked in — that step wasn't re-run before #5 landed (I excluded the regenerated CSS file from the commit thinking the line-ending warnings were noise).

Without the max-height rule, DrawerContent grew to its content height (1038px in an 852px viewport), so its top rendered off-screen at y=-188, and the ScrollArea Viewport had no overflow to scroll (clientHeight=scrollHeight=940). Vaul then treated any drag as a dismiss because the inner element had zero scroll headroom — hence "scroll up = drawer closes".

CDP-probe receipts:
| Metric | Before fix | After fix |
|---|---|---|
| DrawerContent computed `maxHeight` | `none` | `826px` |
| DrawerContent height | 1038px | 824px |
| DrawerContent boundingTop | -188 | +25 (on-screen) |
| Viewport clientHeight | 940 (= content) | 730 (bounded) |
| Viewport scrollHeight | 940 | 1230 (now scrolls) |
| Form scrollWidth | 509 | 360 (fits drawer) |
| "1 source" line count | 2 | 1 |
| Synthetic swipe up → scrollTop | 0 (drawer dismissed) | 255 (scrolls, drawer stays open) |

### Fixes

**Bug 1 — tailwind-output.css**
- Re-ran \`npm run build-tailwind\`. Diff is 49 insertions / 16 deletions adding `max-h-[97vh]`, `min-h-0`, `min-w-0`, `visible`, plus the new `sm:` and `minmax()` variants used below.

**Bug 2 — form overflow**
- `EditCitationFormComponents.tsx` & `EditCitationForm.tsx`: every `grid grid-cols-[130px_1fr] items-center gap-4` row now uses `flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4` — labels stack above inputs on mobile (< 640px), side-by-side on desktop.
- `PublicationDate` / `AccessDate`: inner date grid changed from `grid-cols-[1fr_1fr_1fr]` with `min-w-[7rem]` on Month to `grid-cols-[minmax(0,3.5rem)_minmax(0,1fr)_minmax(0,3.5rem)]` with `min-w-0` so Year/Day get just enough room and Month flexes.
- `EditReferenceDialogDrawer` Content: padding `p-8 pt-0 pb-0` → `px-4 sm:px-8 pt-0 pb-0` so mobile reclaims 32px of horizontal room.

**Bug 3 — header wrap**
- `references.module.css` @ max-width 650px: `.referenceTitle` drops from `1fr auto auto` to `1fr auto`; the last child (Add Manually) spans both columns on its own row and the `ml-7` is zeroed so it fills cleanly.

## Tests

- `npm test` → 198/198 still passing (no behavior change in JS, only layout)
- CDP probe (recreated for this round) verified all three bugs both before and after — synthetic touch dispatch confirmed swipe-up no longer dismisses the drawer

## Why this slipped past #5's pre-merge review

The review subagent inspected the diff against shipped behavior — but neither it nor the drawer-fix subagent's CDP probe caught it because the drawer-fix subagent ran its probe against `astro dev`, which apparently has different Tailwind-compilation behavior than the production build. The class was visible in the rendered HTML in both cases; only the production-built CSS was missing the matching rule.

Project memory updated: \`build-tailwind-step\` — whenever you add a new arbitrary Tailwind class (\`max-h-[97vh]\`, etc.) or a new \`sm:\` variant, you MUST re-run \`npm run build-tailwind\` and commit \`src/styles/tailwind-output.css\`. Dev server hides the gap.

## Test plan

- [x] Probe re-verified all three on mobile viewport (393×852)
- [ ] Cloudflare Pages preview deploy: open \`/my-references\` on mobile, confirm drawer behavior + form layout + header layout