### PR TITLE
Phase 1 loose-end refactors: regex / cache / closure / DateInput dedup

### DIFF
--- a/functions/lib/extract/author-parse.ts
+++ b/functions/lib/extract/author-parse.ts
@@ -1,6 +1,10 @@
 import type { CSLName } from '../csl-types';
 
-const ORG_SUFFIXES = /\b(Inc\.?|LLC|Ltd\.?|Corp\.?|Corporation|Foundation|Press|University|Institute|Society|Group|Company|Co\.?|Department|Office|Agency|Bureau|Commission)\b/i;
+// Anchored to end-of-string so suffix-shaped tokens only flag a name as an
+// org when they actually terminate it. A surname like "Co" in "Co, John" or a
+// middle name like "Foundation" in "Foundation House Smith" no longer
+// false-positives as a corporate author.
+const ORG_SUFFIXES = /\b(Inc\.?|LLC|Ltd\.?|Corp\.?|Corporation|Foundation|Press|University|Institute|Society|Group|Company|Co\.?|Department|Office|Agency|Bureau|Commission)\s*$/i;
 const PARTICLES = new Set([
   'von', 'de', 'del', 'della', 'van', 'la', 'le', 'der', 'den', 'di', 'da', 'du', 'dos', 'des',
 ]);

--- a/functions/lib/extract/author-parse.ts
+++ b/functions/lib/extract/author-parse.ts
@@ -3,8 +3,12 @@ import type { CSLName } from '../csl-types';
 // Anchored to end-of-string so suffix-shaped tokens only flag a name as an
 // org when they actually terminate it. A surname like "Co" in "Co, John" or a
 // middle name like "Foundation" in "Foundation House Smith" no longer
-// false-positives as a corporate author.
-const ORG_SUFFIXES = /\b(Inc\.?|LLC|Ltd\.?|Corp\.?|Corporation|Foundation|Press|University|Institute|Society|Group|Company|Co\.?|Department|Office|Agency|Bureau|Commission)\s*$/i;
+// false-positives as a corporate author. The trailing `[.\s]*` lets a stray
+// period close the match (e.g. "Wikimedia Foundation.") since several
+// alternations (Foundation, Press, University, Institute, Society, Group,
+// Company, Department, Office, Agency, Bureau, Commission) don't include an
+// optional `.` of their own.
+const ORG_SUFFIXES = /\b(Inc\.?|LLC|Ltd\.?|Corp\.?|Corporation|Foundation|Press|University|Institute|Society|Group|Company|Co\.?|Department|Office|Agency|Bureau|Commission)[.\s]*$/i;
 const PARTICLES = new Set([
   'von', 'de', 'del', 'della', 'van', 'la', 'le', 'der', 'den', 'di', 'da', 'du', 'dos', 'des',
 ]);

--- a/src/components/react/EditCitationForm.tsx
+++ b/src/components/react/EditCitationForm.tsx
@@ -11,9 +11,7 @@ import {
     AccessDate,
     Edition,
     VolumeNumber,
-    // TODO(typo): the named export below is misspelled `Publsiher` in EditCitationFormComponents.tsx.
-    // Aliased as Publisher here; rename the export in a follow-up PR.
-    Publsiher as Publisher,
+    Publisher,
     DOI,
 } from './EditCitationFormComponents';
 import { useDebounce } from '../../hooks/useDebounce';

--- a/src/components/react/EditCitationFormComponents.tsx
+++ b/src/components/react/EditCitationFormComponents.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useMemo } from "react";
 import { Input } from "./Input";
 import { cn } from "./utils";
 import { Button } from "./Button";
@@ -297,14 +297,13 @@ export const VolumeNumber = ({ value, onChange, isRequired, isRecommended }: Tex
 }
 
 /**
- * Publsiher component
- * TODO(typo): rename export from `Publsiher` to `Publisher` and update consumers in a follow-up.
+ * Publisher component
  * @param value - The value to display
  * @param onChange - The function to call when the value changes
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const Publsiher = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const Publisher = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -413,156 +412,107 @@ function buildCslDate(year: number, month: number, day: number): CSLDate | undef
     return undefined;
 }
 
-/**
- * Publication Date component — emits CSL-JSON `date-parts` shape.
- */
-export const PublicationDate = ({ value, onChange, isRequired, isRecommended }: DateComponentProps) => {
+// Reject 4-digit years that are clearly out of range (pre-1000, or beyond next
+// year). Returns '' to clear the input; shorter typed-in-progress values pass.
+function validateYear(value: string): string {
+    const yearNum = parseInt(value);
+    const currentYear = new Date().getFullYear();
+    if (value.length >= 4 && (yearNum > currentYear + 1 || yearNum < 1000)) {
+        return '';
+    }
+    return value;
+}
+
+// Reject day values outside 1–31. Returns '' to clear the input on bad input.
+function validateDay(value: string): string {
+    const dayNum = parseInt(value);
+    if (dayNum < 1 || dayNum > 31 || isNaN(dayNum)) {
+        return '';
+    }
+    return value;
+}
+
+function deriveDateParts(value: CSLDate | undefined): { year: string; month: string; day: string } {
     const parts = value?.['date-parts']?.[0];
-    const initialYear = parts?.[0] ? String(parts[0]) : '';
-    const initialMonth = parts?.[1] ? String(parts[1]) : '';
-    const initialDay = parts?.[2] ? String(parts[2]) : '';
-
-    const [year, setYear] = useState(initialYear);
-    const [month, setMonth] = useState(initialMonth);
-    const [day, setDay] = useState(initialDay);
-
-    const validateYear = (value: string) => {
-        const yearNum = parseInt(value);
-        const currentYear = new Date().getFullYear();
-        if (value.length >= 4) {
-            if (yearNum > currentYear + 1 || yearNum < 1000) {
-                return '';
-            }
-        }
-        return value;
+    return {
+        year: parts?.[0] ? String(parts[0]) : '',
+        month: parts?.[1] ? String(parts[1]) : '',
+        day: parts?.[2] ? String(parts[2]) : '',
     };
+}
 
-    const validateDay = (value: string) => {
-        const dayNum = parseInt(value);
-        if (dayNum < 1 || dayNum > 31 || isNaN(dayNum)) {
-            return '';
-        }
-        return value;
-    };
+/**
+ * Shared year/month/day input grid for PublicationDate and AccessDate.
+ * Year/month/day are derived from `value`; every edit emits via `onChange`
+ * with a fresh CSLDate (or undefined if no year is set).
+ */
+const DateInput = ({ value, onChange }: { value: CSLDate | undefined; onChange: (v: CSLDate | undefined) => void }) => {
+    const { year, month, day } = useMemo(() => deriveDateParts(value), [value]);
 
     const handleChange = (field: 'year' | 'month' | 'day', newValue: string) => {
-        let validatedValue = newValue;
+        let yearStr = year;
+        let monthStr = month;
+        let dayStr = day;
+        if (field === 'year') yearStr = validateYear(newValue);
+        else if (field === 'month') monthStr = newValue;
+        else if (field === 'day') dayStr = validateDay(newValue);
 
-        if (field === 'year') {
-            validatedValue = validateYear(newValue);
-            setYear(validatedValue);
-        } else if (field === 'month') {
-            setMonth(newValue);
-        } else if (field === 'day') {
-            validatedValue = validateDay(newValue);
-            setDay(validatedValue);
-        }
-
-        const yearVal = field === 'year' ? parseInt(validatedValue) || 0 : parseInt(year) || 0;
-        const monthVal = field === 'month' ? parseInt(newValue) || 0 : parseInt(month) || 0;
-        const dayVal = field === 'day' ? parseInt(validatedValue) || 0 : parseInt(day) || 0;
-
+        const yearVal = parseInt(yearStr) || 0;
+        const monthVal = parseInt(monthStr) || 0;
+        const dayVal = parseInt(dayStr) || 0;
         onChange(buildCslDate(yearVal, monthVal, dayVal));
     };
 
     return (
-        <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
-            <span className="flex flex-col leading-4 text-sm">
-                Publication Date
-                {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
-                {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
-            </span>
-            <div className="grid grid-cols-[minmax(0,3.5rem)_minmax(0,1fr)_minmax(0,3.5rem)] items-center gap-2 sm:gap-4">
-                <Input
-                    placeholder="Year"
-                    type="text"
-                    inputMode="numeric"
-                    pattern="[0-9]*"
-                    value={year}
-                    onChange={(e) => handleChange('year', e.target.value.replace(/\D/g, ''))}
-                />
-                <SimpleDropdown
-                    options={months}
-                    value={month ? months[parseInt(month) - 1] : undefined}
-                    onChange={(option) => handleChange('month', option.value)}
-                    placeholder="Month"
-                    className="min-w-0"
-                />
-                <Input
-                    placeholder="Day"
-                    type="text"
-                    inputMode="numeric"
-                    pattern="[0-9]*"
-                    value={day}
-                    onChange={(e) => handleChange('day', e.target.value.replace(/\D/g, ''))}
-                />
-            </div>
+        <div className="grid grid-cols-[minmax(0,3.5rem)_minmax(0,1fr)_minmax(0,3.5rem)] items-center gap-2 sm:gap-4">
+            <Input
+                placeholder="Year"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={year}
+                onChange={(e) => handleChange('year', e.target.value.replace(/\D/g, ''))}
+            />
+            <SimpleDropdown
+                options={months}
+                value={month ? months[parseInt(month) - 1] : undefined}
+                onChange={(option) => handleChange('month', option.value)}
+                placeholder="Month"
+                className="min-w-0"
+            />
+            <Input
+                placeholder="Day"
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                value={day}
+                onChange={(e) => handleChange('day', e.target.value.replace(/\D/g, ''))}
+            />
         </div>
     );
 };
 
 /**
+ * Publication Date component — emits CSL-JSON `date-parts` shape.
+ */
+export const PublicationDate = ({ value, onChange, isRequired, isRecommended }: DateComponentProps) => (
+    <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
+        <span className="flex flex-col leading-4 text-sm">
+            Publication Date
+            {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
+            {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
+        </span>
+        <DateInput value={value} onChange={onChange} />
+    </div>
+);
+
+/**
  * Access Date component — emits CSL-JSON `date-parts` shape.
  */
 export const AccessDate = ({ value, onChange, isRequired, isRecommended }: DateComponentProps) => {
-    const parts = value?.['date-parts']?.[0];
-    const initialYear = parts?.[0] ? String(parts[0]) : '';
-    const initialMonth = parts?.[1] ? String(parts[1]) : '';
-    const initialDay = parts?.[2] ? String(parts[2]) : '';
-
-    const [year, setYear] = useState(initialYear);
-    const [month, setMonth] = useState(initialMonth);
-    const [day, setDay] = useState(initialDay);
-
-    const validateYear = (value: string) => {
-        const yearNum = parseInt(value);
-        const currentYear = new Date().getFullYear();
-        if (value.length >= 4) {
-            if (yearNum > currentYear + 1 || yearNum < 1000) {
-                return '';
-            }
-        }
-        return value;
-    };
-
-    const validateDay = (value: string) => {
-        const dayNum = parseInt(value);
-        if (dayNum < 1 || dayNum > 31 || isNaN(dayNum)) {
-            return '';
-        }
-        return value;
-    };
-
-    const handleChange = (field: 'year' | 'month' | 'day', newValue: string) => {
-        let validatedValue = newValue;
-
-        if (field === 'year') {
-            validatedValue = validateYear(newValue);
-            setYear(validatedValue);
-        } else if (field === 'month') {
-            setMonth(newValue);
-        } else if (field === 'day') {
-            validatedValue = validateDay(newValue);
-            setDay(validatedValue);
-        }
-
-        const yearVal = field === 'year' ? parseInt(validatedValue) || 0 : parseInt(year) || 0;
-        const monthVal = field === 'month' ? parseInt(newValue) || 0 : parseInt(month) || 0;
-        const dayVal = field === 'day' ? parseInt(validatedValue) || 0 : parseInt(day) || 0;
-
-        onChange(buildCslDate(yearVal, monthVal, dayVal));
-    };
-
     const handleSetToToday = () => {
         const today = new Date();
-        const y = today.getFullYear();
-        const m = today.getMonth() + 1;
-        const d = today.getDate();
-
-        setYear(String(y));
-        setMonth(String(m));
-        setDay(String(d));
-        onChange(buildCslDate(y, m, d));
+        onChange(buildCslDate(today.getFullYear(), today.getMonth() + 1, today.getDate()));
     };
 
     return (
@@ -572,32 +522,8 @@ export const AccessDate = ({ value, onChange, isRequired, isRecommended }: DateC
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <div className="">
-                <div className="grid grid-cols-[minmax(0,3.5rem)_minmax(0,1fr)_minmax(0,3.5rem)] items-center gap-2 sm:gap-4">
-                    <Input
-                        placeholder="Year"
-                        type="text"
-                        inputMode="numeric"
-                        pattern="[0-9]*"
-                        value={year}
-                        onChange={(e) => handleChange('year', e.target.value.replace(/\D/g, ''))}
-                    />
-                    <SimpleDropdown
-                        options={months}
-                        value={month ? months[parseInt(month) - 1] : undefined}
-                        onChange={(option) => handleChange('month', option.value)}
-                        placeholder="Month"
-                        className="min-w-0"
-                    />
-                    <Input
-                        placeholder="Day"
-                        type="text"
-                        inputMode="numeric"
-                        pattern="[0-9]*"
-                        value={day}
-                        onChange={(e) => handleChange('day', e.target.value.replace(/\D/g, ''))}
-                    />
-                </div>
+            <div>
+                <DateInput value={value} onChange={onChange} />
                 <Button variant="secondary" className="gap-2 mt-4" onClick={handleSetToToday}>
                     <Calendar size={17} strokeWidth={1.5} />
                     <span className="leading-none">Set to Today</span>

--- a/src/components/react/EditCitationFormComponents.tsx
+++ b/src/components/react/EditCitationFormComponents.tsx
@@ -443,51 +443,88 @@ function deriveDateParts(value: CSLDate | undefined): { year: string; month: str
 
 /**
  * Shared year/month/day input grid for PublicationDate and AccessDate.
- * Year/month/day are derived from `value`; every edit emits via `onChange`
- * with a fresh CSLDate (or undefined if no year is set).
+ *
+ * Local state for year/month/day is the source of truth for what's IN the
+ * inputs. `value` is only seeded on mount and updated externally via the
+ * imperative `setToToday` (exposed through `showSetToday`). The reason for
+ * the local-state shape: buildCslDate emits `undefined` whenever year is
+ * unset, so a fully value-derived implementation silently drops partial
+ * entry (typed day without year, picked month without year) and cascades
+ * year-clear into wiping month/day too.
  */
-const DateInput = ({ value, onChange }: { value: CSLDate | undefined; onChange: (v: CSLDate | undefined) => void }) => {
-    const { year, month, day } = useMemo(() => deriveDateParts(value), [value]);
+const DateInput = ({ value, onChange, showSetToday }: {
+    value: CSLDate | undefined;
+    onChange: (v: CSLDate | undefined) => void;
+    showSetToday?: boolean;
+}) => {
+    const initial = useMemo(() => deriveDateParts(value), []);
+    const [year, setYear] = useState(initial.year);
+    const [month, setMonth] = useState(initial.month);
+    const [day, setDay] = useState(initial.day);
 
-    const handleChange = (field: 'year' | 'month' | 'day', newValue: string) => {
-        let yearStr = year;
-        let monthStr = month;
-        let dayStr = day;
-        if (field === 'year') yearStr = validateYear(newValue);
-        else if (field === 'month') monthStr = newValue;
-        else if (field === 'day') dayStr = validateDay(newValue);
+    const emit = (y: string, m: string, d: string) => {
+        onChange(buildCslDate(parseInt(y) || 0, parseInt(m) || 0, parseInt(d) || 0));
+    };
 
-        const yearVal = parseInt(yearStr) || 0;
-        const monthVal = parseInt(monthStr) || 0;
-        const dayVal = parseInt(dayStr) || 0;
-        onChange(buildCslDate(yearVal, monthVal, dayVal));
+    const handleYear = (raw: string) => {
+        const v = validateYear(raw);
+        setYear(v);
+        emit(v, month, day);
+    };
+    const handleMonth = (raw: string) => {
+        setMonth(raw);
+        emit(year, raw, day);
+    };
+    const handleDay = (raw: string) => {
+        const v = validateDay(raw);
+        setDay(v);
+        emit(year, month, v);
+    };
+
+    const handleSetToToday = () => {
+        const today = new Date();
+        const y = String(today.getFullYear());
+        const m = String(today.getMonth() + 1);
+        const d = String(today.getDate());
+        setYear(y);
+        setMonth(m);
+        setDay(d);
+        emit(y, m, d);
     };
 
     return (
-        <div className="grid grid-cols-[minmax(0,3.5rem)_minmax(0,1fr)_minmax(0,3.5rem)] items-center gap-2 sm:gap-4">
-            <Input
-                placeholder="Year"
-                type="text"
-                inputMode="numeric"
-                pattern="[0-9]*"
-                value={year}
-                onChange={(e) => handleChange('year', e.target.value.replace(/\D/g, ''))}
-            />
-            <SimpleDropdown
-                options={months}
-                value={month ? months[parseInt(month) - 1] : undefined}
-                onChange={(option) => handleChange('month', option.value)}
-                placeholder="Month"
-                className="min-w-0"
-            />
-            <Input
-                placeholder="Day"
-                type="text"
-                inputMode="numeric"
-                pattern="[0-9]*"
-                value={day}
-                onChange={(e) => handleChange('day', e.target.value.replace(/\D/g, ''))}
-            />
+        <div>
+            <div className="grid grid-cols-[minmax(0,3.5rem)_minmax(0,1fr)_minmax(0,3.5rem)] items-center gap-2 sm:gap-4">
+                <Input
+                    placeholder="Year"
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    value={year}
+                    onChange={(e) => handleYear(e.target.value.replace(/\D/g, ''))}
+                />
+                <SimpleDropdown
+                    options={months}
+                    value={month ? months[parseInt(month) - 1] : undefined}
+                    onChange={(option) => handleMonth(option.value)}
+                    placeholder="Month"
+                    className="min-w-0"
+                />
+                <Input
+                    placeholder="Day"
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]*"
+                    value={day}
+                    onChange={(e) => handleDay(e.target.value.replace(/\D/g, ''))}
+                />
+            </div>
+            {showSetToday && (
+                <Button variant="secondary" className="gap-2 mt-4" onClick={handleSetToToday}>
+                    <Calendar size={17} strokeWidth={1.5} />
+                    <span className="leading-none">Set to Today</span>
+                </Button>
+            )}
         </div>
     );
 };
@@ -509,26 +546,13 @@ export const PublicationDate = ({ value, onChange, isRequired, isRecommended }: 
 /**
  * Access Date component — emits CSL-JSON `date-parts` shape.
  */
-export const AccessDate = ({ value, onChange, isRequired, isRecommended }: DateComponentProps) => {
-    const handleSetToToday = () => {
-        const today = new Date();
-        onChange(buildCslDate(today.getFullYear(), today.getMonth() + 1, today.getDate()));
-    };
-
-    return (
-        <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:gap-4">
-            <span className="flex flex-col leading-4 text-sm h-9 justify-center">
-                Access Date
-                {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
-                {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
-            </span>
-            <div>
-                <DateInput value={value} onChange={onChange} />
-                <Button variant="secondary" className="gap-2 mt-4" onClick={handleSetToToday}>
-                    <Calendar size={17} strokeWidth={1.5} />
-                    <span className="leading-none">Set to Today</span>
-                </Button>
-            </div>
-        </div>
-    );
-};
+export const AccessDate = ({ value, onChange, isRequired, isRecommended }: DateComponentProps) => (
+    <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:gap-4">
+        <span className="flex flex-col leading-4 text-sm h-9 justify-center">
+            Access Date
+            {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
+            {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
+        </span>
+        <DateInput value={value} onChange={onChange} showSetToday />
+    </div>
+);

--- a/src/lib/citations/useFormattedCitation.ts
+++ b/src/lib/citations/useFormattedCitation.ts
@@ -20,12 +20,26 @@ export function _resetCacheForTests() {
   inflight.clear();
 }
 
+// Stably sort object keys at every nesting level so two CSL items with
+// identical content but different insertion order produce the same string.
+// JSON.stringify's array-replacer would have been tempting here but is an
+// allow-list applied at every depth — it drops nested keys not in the
+// top-level list (author[].family, etc.), producing identical fingerprints
+// for distinct citations. Hence the recursive copy.
+function sortKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortKeysDeep);
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const k of Object.keys(value as Record<string, unknown>).sort()) {
+      out[k] = sortKeysDeep((value as Record<string, unknown>)[k]);
+    }
+    return out;
+  }
+  return value;
+}
+
 function cslFingerprint(csl: CSLItem): string {
-  // Sort top-level keys so two CSL items with identical content but different
-  // insertion order (e.g., after `{ ...prev, title }` respreads) produce the
-  // same fingerprint and hit the cache. Shallow sort is enough — CSL nested
-  // values are arrays/strings/numbers, all of which serialize order-stably.
-  return JSON.stringify(csl, Object.keys(csl).sort());
+  return JSON.stringify(sortKeysDeep(csl));
 }
 
 export function useFormattedCitation(source: Args, style: SupportedStyle): State {

--- a/src/lib/citations/useFormattedCitation.ts
+++ b/src/lib/citations/useFormattedCitation.ts
@@ -21,11 +21,11 @@ export function _resetCacheForTests() {
 }
 
 function cslFingerprint(csl: CSLItem): string {
-  // Stable JSON serialization. CSL-JSON's authors/dates are arrays — JSON.stringify
-  // preserves order, so the same logical citation produces the same fingerprint.
-  // This is needed so edits to a source's csl invalidate the cached render
-  // (otherwise the hook would return stale pre-edit output for an unchanged uuid).
-  return JSON.stringify(csl);
+  // Sort top-level keys so two CSL items with identical content but different
+  // insertion order (e.g., after `{ ...prev, title }` respreads) produce the
+  // same fingerprint and hit the cache. Shallow sort is enough — CSL nested
+  // values are arrays/strings/numbers, all of which serialize order-stably.
+  return JSON.stringify(csl, Object.keys(csl).sort());
 }
 
 export function useFormattedCitation(source: Args, style: SupportedStyle): State {

--- a/src/lib/references/useReferences.ts
+++ b/src/lib/references/useReferences.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { loadSources, saveSources, type StoredSource } from './storage';
 import type { CSLItem, SupportedStyle } from '../citations/csl-types';
 
@@ -32,6 +32,12 @@ export function useReferences(): UseReferencesReturn {
   const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
   const [citationFormat, setCitationFormatState] = useState<SupportedStyle>('mla-9');
 
+  // Mirror sources into a ref so callbacks with stable identities (e.g.
+  // selectAll, captured before an in-flight fetch resolves) still read the
+  // latest list, not the snapshot from the render that created the closure.
+  const sourcesRef = useRef(sources);
+  useEffect(() => { sourcesRef.current = sources; }, [sources]);
+
   const setSources = useCallback((next: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => {
     setSourcesState((prev) => {
       const computed = typeof next === 'function' ? (next as any)(prev) : next;
@@ -54,8 +60,8 @@ export function useReferences(): UseReferencesReturn {
   }, []);
 
   const selectAll = useCallback((checked: boolean) => {
-    setSelected(checked ? new Set(sources.map((s) => s.uuid)) : new Set());
-  }, [sources]);
+    setSelected(checked ? new Set(sourcesRef.current.map((s) => s.uuid)) : new Set());
+  }, []);
 
   const handleDelete = useCallback(() => {
     setSources((prev) => prev.filter((s) => !selected.has(s.uuid)));

--- a/tests/client/EditCitationFormComponents.test.tsx
+++ b/tests/client/EditCitationFormComponents.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import { PublicationDate, AccessDate } from '../../src/components/react/EditCitationFormComponents';
+
+// DateInput renders Year input, Month dropdown (a button, not <input>), Day input.
+// `container.querySelectorAll('input[type="text"]')` is [year, day] in that order.
+function findDateInputs(container: HTMLElement): { year: HTMLInputElement; day: HTMLInputElement } {
+  const inputs = container.querySelectorAll('input[type="text"]') as NodeListOf<HTMLInputElement>;
+  expect(inputs.length).toBe(2);
+  return { year: inputs[0], day: inputs[1] };
+}
+
+describe('DateInput partial-entry behavior', () => {
+  // Regression: an earlier refactor derived year/month/day from `value` via
+  // useMemo. Since buildCslDate returns undefined unless year > 0, picking
+  // a month or typing a day with year still empty produced value=undefined
+  // → derived back to '' → input snapped back to empty, silently dropping
+  // user input. Local state inside DateInput is the source of truth for
+  // typed-but-incomplete entry; `value` reflects only complete-enough state.
+
+  it('preserves a typed day value when year is still empty', () => {
+    const onChange = vi.fn();
+    const { container } = render(<PublicationDate value={undefined} onChange={onChange} />);
+    const { day } = findDateInputs(container);
+    fireEvent.change(day, { target: { value: '15' } });
+    expect(day.value).toBe('15');
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('preserves day when the user clears the year', () => {
+    const initial = { 'date-parts': [[2020, 5, 15]] as [number, number, number][] };
+    const onChange = vi.fn();
+    const { container } = render(<PublicationDate value={initial as any} onChange={onChange} />);
+    const { year, day } = findDateInputs(container);
+    expect(day.value).toBe('15');
+
+    fireEvent.change(year, { target: { value: '' } });
+
+    expect(year.value).toBe('');
+    expect(day.value).toBe('15');
+    expect(onChange).toHaveBeenLastCalledWith(undefined);
+  });
+
+  it('AccessDate Set to Today fills all three fields and emits a CSL date', () => {
+    const onChange = vi.fn();
+    const { container } = render(<AccessDate value={undefined} onChange={onChange} />);
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes('Set to Today'),
+    ) as HTMLButtonElement | undefined;
+    expect(button).toBeTruthy();
+    fireEvent.click(button!);
+
+    const today = new Date();
+    const { year, day } = findDateInputs(container);
+    expect(year.value).toBe(String(today.getFullYear()));
+    expect(day.value).toBe(String(today.getDate()));
+    expect(onChange).toHaveBeenCalledWith({
+      'date-parts': [[today.getFullYear(), today.getMonth() + 1, today.getDate()]],
+    });
+  });
+});

--- a/tests/client/useFormattedCitation.test.ts
+++ b/tests/client/useFormattedCitation.test.ts
@@ -60,6 +60,34 @@ describe('useFormattedCitation', () => {
     expect(callCount).toBe(2);
   });
 
+  it('cache is insensitive to CSL key insertion order', async () => {
+    // Regression: cslFingerprint used JSON.stringify(csl) without sorting
+    // keys, so two CSL items with identical content but different insertion
+    // order produced different cache keys, causing cache misses when an
+    // edit-and-respread reordered fields.
+    let callCount = 0;
+    globalThis.fetch = vi.fn(async () => {
+      callCount += 1;
+      return new Response(JSON.stringify({
+        formatted: [{ text: 'ok' }],
+      }), { status: 200 });
+    }) as any;
+
+    const initial = { id: 'u1', type: 'webpage' as const, title: 'T', URL: 'https://x.com' };
+    const reordered = { URL: 'https://x.com', title: 'T', type: 'webpage' as const, id: 'u1' };
+
+    const { result, rerender } = renderHook(
+      ({ csl }) => useFormattedCitation({ uuid: 'u1', csl }, 'mla-9'),
+      { initialProps: { csl: initial } },
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(callCount).toBe(1);
+
+    rerender({ csl: reordered });
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(callCount).toBe(1);
+  });
+
   it('surfaces an error when /api/format returns non-200', async () => {
     globalThis.fetch = vi.fn(async () => new Response('boom', { status: 500 })) as any;
     const csl = { id: 'u2', type: 'webpage' as const, title: 'X' };

--- a/tests/client/useFormattedCitation.test.ts
+++ b/tests/client/useFormattedCitation.test.ts
@@ -60,6 +60,44 @@ describe('useFormattedCitation', () => {
     expect(callCount).toBe(2);
   });
 
+  it('cache distinguishes citations whose only difference is in a nested field', async () => {
+    // Regression: a first attempt at the fingerprint sort used
+    // `JSON.stringify(csl, Object.keys(csl).sort())`. The array-replacer
+    // form of JSON.stringify is an allow-list applied at every nesting
+    // level, so nested keys (author[].family, author[].given,
+    // issued.date-parts) were dropped from the fingerprint and edits
+    // to nested fields silently hit the stale cache.
+    let callCount = 0;
+    const responses = ['Smith citation', 'Jones citation'];
+    globalThis.fetch = vi.fn(async () => {
+      const body = JSON.stringify({ formatted: [{ text: responses[callCount] }] });
+      callCount += 1;
+      return new Response(body, { status: 200 });
+    }) as any;
+
+    const initial = {
+      id: 'u1', type: 'webpage' as const, title: 'T',
+      author: [{ family: 'Smith', given: 'John' }],
+    };
+    const edited = {
+      id: 'u1', type: 'webpage' as const, title: 'T',
+      author: [{ family: 'Jones', given: 'John' }],
+    };
+
+    const { result, rerender } = renderHook(
+      ({ csl }) => useFormattedCitation({ uuid: 'u1', csl }, 'mla-9'),
+      { initialProps: { csl: initial } },
+    );
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.formatted.map((r) => r.text).join('')).toBe('Smith citation');
+
+    rerender({ csl: edited });
+    await waitFor(() =>
+      expect(result.current.formatted.map((r) => r.text).join('')).toBe('Jones citation'),
+    );
+    expect(callCount).toBe(2);
+  });
+
   it('cache is insensitive to CSL key insertion order', async () => {
     // Regression: cslFingerprint used JSON.stringify(csl) without sorting
     // keys, so two CSL items with identical content but different insertion

--- a/tests/client/useReferences.test.ts
+++ b/tests/client/useReferences.test.ts
@@ -105,6 +105,27 @@ describe('useReferences', () => {
       expect(result.current.selectedCount).toBe(0);
     });
 
+    it('selectAll captured before sources arrive still selects the new sources', async () => {
+      // Regression: selectAll was useCallback([sources]) — a render that captured
+      // the callback before a fetch added new uuids would operate on the stale
+      // snapshot and miss the in-flight source. Now reads sources via a ref so
+      // the captured reference always sees the latest list.
+      localStorage.clear();
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.sourceCount).toBe(0));
+
+      const staleSelectAll = result.current.selectAll;
+      act(() => result.current.setSources([
+        { uuid: 'x', csl: { id: 'x', type: 'webpage', title: 'X' } },
+        { uuid: 'y', csl: { id: 'y', type: 'webpage', title: 'Y' } },
+      ]));
+
+      act(() => staleSelectAll(true));
+      expect(result.current.selectedCount).toBe(2);
+      expect(result.current.selected.has('x')).toBe(true);
+      expect(result.current.selected.has('y')).toBe(true);
+    });
+
     it('selection survives list reordering by uuid (not index)', async () => {
       const { result } = renderHook(() => useReferences());
       await waitFor(() => expect(result.current.sourceCount).toBe(3));

--- a/tests/extract/author-parse.test.ts
+++ b/tests/extract/author-parse.test.ts
@@ -40,6 +40,15 @@ describe('parseAuthorName', () => {
       family: 'Smith', given: 'Foundation House',
     });
   });
+  it('still flags orgs that end in a period (Foundation., Press., etc.)', () => {
+    // Regression: a first attempt anchored ORG_SUFFIXES with `\s*$`, which
+    // only allowed trailing whitespace. Org-suffix tokens without a built-in
+    // optional period (Foundation, Press, University, Institute, Society,
+    // Group, Company, Department, Office, Agency, Bureau, Commission) would
+    // no longer match if the source HTML had a trailing dot.
+    expect(parseAuthorName('Wikimedia Foundation.')).toEqual({ literal: 'Wikimedia Foundation.' });
+    expect(parseAuthorName('Stanford University.')).toEqual({ literal: 'Stanford University.' });
+  });
   it('passes through pre-structured input', () => {
     expect(parseAuthorName({ family: 'X', given: 'Y' })).toEqual({ family: 'X', given: 'Y' });
   });

--- a/tests/extract/author-parse.test.ts
+++ b/tests/extract/author-parse.test.ts
@@ -29,6 +29,17 @@ describe('parseAuthorName', () => {
     expect(parseAuthorName('Acme Corp.')).toEqual({ literal: 'Acme Corp.' });
     expect(parseAuthorName('Stanford University')).toEqual({ literal: 'Stanford University' });
   });
+  it('treats org-suffix tokens as org markers only at end of string', () => {
+    // Regression: ORG_SUFFIXES matched anywhere in the string, so a surname
+    // like "Co" in "Co, John" was wrongly flagged as an organization.
+    expect(parseAuthorName('Co, John')).toEqual({ family: 'Co', given: 'John' });
+    // And a token like "Foundation" appearing in the middle of a name
+    // (e.g., person whose middle name happens to be Foundation) should be
+    // parsed as a person, not flattened to a literal.
+    expect(parseAuthorName('Foundation House Smith')).toEqual({
+      family: 'Smith', given: 'Foundation House',
+    });
+  });
   it('passes through pre-structured input', () => {
     expect(parseAuthorName({ family: 'X', given: 'Y' })).toEqual({ family: 'X', given: 'Y' });
   });


### PR DESCRIPTION
## Summary

Bundles the loose-end items flagged across PRs #4-#7 review threads into one refactor-only PR. No user-facing feature work; this is correctness, cache, and code-quality cleanup.

- **ORG_SUFFIXES regex** in `functions/lib/extract/author-parse.ts` anchored to end-of-string with `[.\s]*$` so suffix-shaped tokens (Co, Inc., Foundation, etc.) only classify a name as a corporate author when they actually terminate it. Fixes "Co, John" → org, "Foundation House Smith" → org, while preserving "Wikimedia Foundation." → org.
- **`cslFingerprint`** in `src/lib/citations/useFormattedCitation.ts` now sorts object keys at every nesting level via `sortKeysDeep`, so identical CSL content with different insertion order hits the same `/api/format` cache key. (Caught a sub-bug during pre-merge review: my first pass used the array-replacer form of `JSON.stringify`, which is an allow-list applied at every depth and dropped nested keys; fixed in commit 2.)
- **`selectAll`** in `src/lib/references/useReferences.ts` reads `sources` via a ref so a captured (stale) callback reference still operates on the latest list. Relevant when the user clicks "select all" between mount and an in-flight citation fetch resolving.
- **Extracted `DateInput`** from duplicated `PublicationDate` / `AccessDate`; hoisted `validateYear`, `validateDay`, `deriveDateParts` to module scope. Local state inside `DateInput` is the source of truth for typed-but-incomplete entry (`value` only seeds on mount + via "Set to Today"), since `buildCslDate` returns `undefined` whenever year is unset.
- **Renamed** `Publsiher` → `Publisher` and dropped the alias at the import site.

## Pre-merge review

A fresh-context correctness review ran against the diff before this PR opened (per the workflow in global CLAUDE.md). Two findings addressed in-branch:

- **BLOCKING (finding 1)**: DateInput's value-derived implementation silently dropped partial entry (typed day before year, picked month before year) because `buildCslDate` collapses to `undefined` without a year. Fixed by restoring local state inside `DateInput` with `value` only seeding on mount; "Set to Today" lifted into `DateInput` via a `showSetToday` prop so AccessDate keeps the imperative path. Three regression tests added in `tests/client/EditCitationFormComponents.test.tsx`.
- **NON-BLOCKING (finding 2)**: the first anchor was `\s*$`, which stopped matching trailing-period orgs like "Wikimedia Foundation.". Anchor relaxed to `[.\s]*$`. Test added.

Non-blocking findings deferred (LOW confidence, no current code path):
- `sortKeysDeep` doesn't special-case `toJSON`-bearing objects (Date, URL). CSL-JSON encodes dates as plain objects, so unaffected today.
- `sortKeysDeep` is not cycle-safe. CSL-JSON is acyclic by spec.

## Test plan

- [x] `npx vitest run` — 35 files, 206 tests pass
- [x] `npx tsc --noEmit` — no new errors (pre-existing PagesFunction / citationStyles / fetch test issues unchanged)
- [ ] Preview deploy smoke: `/my-references`, edit a citation's date and author, confirm typed values persist; pick a month before typing a year and confirm the selection sticks