### PR TITLE
Header/Footer logo: declare width/height to fix page-load CLS

### DIFF
--- a/src/components/astro/Footer.astro
+++ b/src/components/astro/Footer.astro
@@ -6,7 +6,7 @@ import Logo from '../../../public/images/logo.svg';
 <footer>
     <figure>
         <a href={`${site}`} aria-label="MLA Generator">
-            <img src={Logo.src} alt="MLA Generator" />
+            <img src={Logo.src} alt="MLA Generator" width="213" height="35" />
         </a>
         <figcaption>
             MLA Generator is a free tool that creates citations, references, and

--- a/src/components/astro/Header.astro
+++ b/src/components/astro/Header.astro
@@ -15,7 +15,7 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
   <div class="logo">
     <a href={`${site}`} aria-label="MLA Generator">
       <!-- <p>MLA Generator</p> -->
-      <img src={Logo.src} alt="MLA Generator" title="MLA Generator" />
+      <img src={Logo.src} alt="MLA Generator" title="MLA Generator" width="213" height="35" />
     </a>
   </div>
   <ul id="menu-content">


### PR DESCRIPTION
## Summary

Adds explicit `width="213" height="35"` to the logo `<img>` tags in `Header.astro` and `Footer.astro`. The SVG's intrinsic dimensions are 213×35; the attributes let the browser reserve aspect-ratio-correct space before the asset arrives. CSS continues to set the rendered height (32px footer / 28px header) and computed width.

CDP layout-shift probe at the end of the prior session measured ~0.04 CLS on initial load of `/my-references`, attributed to the footer logo. The header logo has the same shape and is on every page, so it's fixed in the same diff.

## Deferred

This PR was originally scoped as "fixtures + CLS" per the Phase 1 plan, but the Google Books unauthenticated API quota is still exhausted on this IP (verified 2026-05-27 — same 429 as during the original vendoring run). Re-vendoring the five `tests/book/fixtures/googlebooks/*.json` files needs an API key. The README in that directory documents the recovery steps; carrying that forward into the next pass.

## Test plan

- [x] No tests touched; full suite still passes (`npx vitest run` — 34 files, 198 tests).
- [ ] Preview deploy smoke: re-run CDP CLS probe on `/my-references` and confirm the layout-shift attribution to the footer is gone.