### PR TITLE
Cloudflare Analytics Engine: instrument /api/cite-* and /api/format

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -1,0 +1,162 @@
+# Analytics
+
+This project emits per-request events to **Cloudflare Analytics Engine** via the `ANALYTICS` binding. The writer in `functions/lib/analytics.ts` is a no-op when the binding is absent, so the code is deploy-safe before the binding is configured — instrumentation lights up the moment you add the binding and redeploy.
+
+## One-time Cloudflare setup
+
+1. Open the Cloudflare dashboard → **Workers & Pages** → **citation-generator** (the Pages project).
+2. **Settings** → **Functions** → **Analytics Engine Bindings** → **Add binding**.
+3. Variable name: `ANALYTICS`. Dataset name: `citation_generator_events` (or whatever you prefer — pick a name and stick with it; SQL queries below assume this name).
+4. Save. Trigger a deploy (or wait for the next push to `main`) so the new Functions env picks up the binding.
+5. The dataset is auto-created on first write. No separate "create dataset" step is needed — the first cited URL after the deploy will materialize it.
+
+After the next deploy, every `/api/cite-website`, `/api/cite-book`, `/api/cite-journal`, and `/api/format` request emits one event. Errors emit a separate `error` event with `endpoint` and `code` dimensions.
+
+> The code is intentionally not gated behind a wrangler.toml so that the existing Cloudflare Pages dashboard config (compatibility flags, secrets, etc.) keeps owning deploy settings unchanged. Adding a wrangler.toml would override that config and was avoided.
+
+## Querying
+
+Go to **Workers & Pages** → **Analytics Engine** in the sidebar to open the SQL query interface. Or hit the SQL API directly:
+
+```bash
+curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/analytics_engine/sql" \
+  -H "Authorization: Bearer $CF_TOKEN" \
+  --data "SELECT count() FROM citation_generator_events WHERE index1 = 'format'"
+```
+
+## Event schema (columns are positional)
+
+Analytics Engine stores columns positionally, not by name. The writer in `functions/lib/analytics.ts` puts the event name in `blob1` (and duplicates it into `index1` for fast filtering). Dimensions follow in insertion order; metrics live in the `doubleN` columns.
+
+| Event           | blob1            | blob2                  | blob3                 | blob4 | double1        | double2        | double3   |
+| --------------- | ---------------- | ---------------------- | --------------------- | ----- | -------------- | -------------- | --------- |
+| `cite_website`  | `"cite_website"` | signal_winner_title    | signal_winner_url     | host  | html_size_kb   | extraction_ms  | cache_hit |
+| `cite_book`     | `"cite_book"`    | source (openlibrary\|googlebooks) | —          | —     | latency_ms     | cache_hit      | —         |
+| `cite_journal`  | `"cite_journal"` | source (crossref\|openalex)       | —          | —     | latency_ms     | cache_hit      | —         |
+| `format`        | `"format"`       | style                  | —                     | —     | latency_ms     | —              | —         |
+| `error`         | `"error"`        | endpoint               | code                  | —     | count (always 1) | —            | —         |
+
+On a cache hit, `source` for cite_book / cite_journal is `''` (empty string) because we didn't talk to either upstream; the `cache_hit` metric is the source of truth for "this was a cache hit". **Per-source SQL slices should filter on the metric, not on `blob2`** — e.g. to count fresh OpenLibrary hits, write `WHERE index1 = 'cite_book' AND double2 = 0 AND blob2 = 'openlibrary'`, not `WHERE blob2 = 'openlibrary'` alone (that's already correct, but the omission of `double2 = 0` would silently exclude cache hits even though they came from "openlibrary" originally — usually the desired behavior, but be explicit). cite_website on a cache hit carries the cached signal-winner dimensions but `html_size_kb` and `extraction_ms` are both 0.
+
+## Sample queries
+
+### 1. Top styles by volume (last 7 days)
+
+```sql
+SELECT
+  blob2 AS style,
+  count() AS requests
+FROM citation_generator_events
+WHERE index1 = 'format'
+  AND timestamp >= NOW() - INTERVAL '7' DAY
+GROUP BY style
+ORDER BY requests DESC
+```
+
+### 2. p95 latency per endpoint (last 24h)
+
+cite_website is excluded from this query because its `double1` is `html_size_kb`, not latency — putting it in the same `quantile(double1)` would compare bytes to milliseconds. cite_website's `extraction_ms` is queried separately (query 2b).
+
+```sql
+SELECT
+  index1 AS endpoint,
+  quantileWeighted(0.95)(double1, _sample_interval) AS p95_ms,
+  quantileWeighted(0.50)(double1, _sample_interval) AS p50_ms,
+  count() AS samples
+FROM citation_generator_events
+WHERE index1 IN ('cite_book', 'cite_journal', 'format')
+  AND timestamp >= NOW() - INTERVAL '24' HOUR
+GROUP BY endpoint
+ORDER BY p95_ms DESC
+```
+
+### 2b. cite_website extraction-time percentiles
+
+```sql
+SELECT
+  quantileWeighted(0.95)(double2, _sample_interval) AS p95_extract_ms,
+  quantileWeighted(0.50)(double2, _sample_interval) AS p50_extract_ms,
+  avg(double1) AS avg_html_kb
+FROM citation_generator_events
+WHERE index1 = 'cite_website'
+  AND double3 = 0  -- fresh extractions only; cache hits don't run the pipeline
+  AND timestamp >= NOW() - INTERVAL '24' HOUR
+```
+
+### 3. Signal-winner distribution for cite_website title extraction
+
+```sql
+SELECT
+  blob2 AS title_winner,
+  count() AS hits
+FROM citation_generator_events
+WHERE index1 = 'cite_website'
+  AND double3 = 0  -- fresh extractions only; cache hits carry the cached winner and would skew the distribution
+  AND blob2 <> ''  -- exclude rows where no signal claimed the title (rare)
+  AND timestamp >= NOW() - INTERVAL '30' DAY
+GROUP BY title_winner
+ORDER BY hits DESC
+```
+
+Useful for answering "which extraction signal is doing the work?" — if `jsonld` wins 80% of requests, that's where to invest extraction effort.
+
+### 4. Cache hit rate per endpoint (last 7 days)
+
+```sql
+SELECT
+  index1 AS endpoint,
+  sum(if(double2 = 1, 1, 0)) AS hits,
+  count() AS total,
+  sum(if(double2 = 1, 1, 0)) / count() AS hit_rate
+FROM citation_generator_events
+WHERE index1 IN ('cite_book', 'cite_journal')
+  AND timestamp >= NOW() - INTERVAL '7' DAY
+GROUP BY endpoint
+```
+
+For `cite_website`, swap `double2` for `double3` (different metric ordering).
+
+### 5. Error rate over time, broken out by endpoint and code
+
+```sql
+SELECT
+  toStartOfInterval(timestamp, INTERVAL '1' HOUR) AS hour,
+  blob2 AS endpoint,
+  blob3 AS code,
+  sum(double1) AS errors
+FROM citation_generator_events
+WHERE index1 = 'error'
+  AND timestamp >= NOW() - INTERVAL '24' HOUR
+GROUP BY hour, endpoint, code
+ORDER BY hour DESC, errors DESC
+```
+
+A sudden spike in `cite_website / fetch_failed` likely means a site started returning 403/404; a spike in `cite_journal / not_found` may mean a Crossref outage.
+
+### 6. Hosts being cited most often (cite_website)
+
+```sql
+SELECT
+  blob4 AS host,
+  count() AS requests,
+  avg(double2) AS avg_extraction_ms
+FROM citation_generator_events
+WHERE index1 = 'cite_website'
+  AND blob4 <> ''
+  AND timestamp >= NOW() - INTERVAL '30' DAY
+GROUP BY host
+ORDER BY requests DESC
+LIMIT 20
+```
+
+Tells you which sites' extraction quality matters most — high-volume hosts with low signal-winner diversity are where regressions hurt.
+
+## Notes on cardinality and cost
+
+Analytics Engine charges per data point written (the writer emits one per request) and per byte stored. The schema above is deliberately low-cardinality:
+- `style` ∈ 7 values
+- `source` ∈ 4 strings total across endpoints
+- `signal_winner_*` ∈ 6 signal names
+- `host` is the only high-cardinality dimension; if you ever want to cap it, you can post-process the dimension into TLD-only before emission.
+
+The dataset has no PII — no IPs, no user agents, no URLs (only hostnames for `cite_website`). If that ever changes, redact at the writer (in `functions/lib/analytics.ts`) rather than at the query layer.

--- a/functions/api/cite-book/handler.ts
+++ b/functions/api/cite-book/handler.ts
@@ -3,6 +3,7 @@ import { fetchGoogleBooks } from '../../lib/book/googlebooks';
 import { normalizeOpenLibrary, normalizeGoogleBooks } from '../../lib/book/normalize';
 import { TTL } from '../../lib/cache';
 import type { ExtractEnvelope } from '../../lib/csl-types';
+import { writeEvent, type AnalyticsBinding } from '../../lib/analytics';
 
 const ISBN_RE = /^(97[89])?\d{9}[\dX]$/;
 
@@ -11,11 +12,23 @@ export interface MinCache {
   put(key: string, response: Response, maxAgeSeconds: number): Promise<void>;
 }
 
-export async function handleCiteBook(requestUrl: URL, cache: MinCache | null, apiKey?: string): Promise<Response> {
+export async function handleCiteBook(
+  requestUrl: URL,
+  cache: MinCache | null,
+  apiKey?: string,
+  analytics?: AnalyticsBinding,
+): Promise<Response> {
+  const start = Date.now();
   const raw = requestUrl.searchParams.get('isbn');
-  if (!raw) return errorResponse(400, 'invalid_isbn', 'Missing isbn parameter');
+  if (!raw) {
+    writeEvent(analytics, 'error', { endpoint: 'cite_book', code: 'invalid_isbn' }, { count: 1 });
+    return errorResponse(400, 'invalid_isbn', 'Missing isbn parameter');
+  }
   const isbn = raw.replace(/[-\s]/g, '');
-  if (!ISBN_RE.test(isbn)) return errorResponse(400, 'invalid_isbn', 'Invalid ISBN format');
+  if (!ISBN_RE.test(isbn)) {
+    writeEvent(analytics, 'error', { endpoint: 'cite_book', code: 'invalid_isbn' }, { count: 1 });
+    return errorResponse(400, 'invalid_isbn', 'Invalid ISBN format');
+  }
 
   const cacheKey = `https://cache.mlagenerator/book/${isbn}`;
   const bypassCache = requestUrl.searchParams.get('nocache') === '1';
@@ -24,10 +37,15 @@ export async function handleCiteBook(requestUrl: URL, cache: MinCache | null, ap
     if (hit) {
       const body = await hit.json() as ExtractEnvelope;
       body._cached = true;
+      writeEvent(analytics, 'cite_book',
+        { source: '' },
+        { latency_ms: Date.now() - start, cache_hit: 1 },
+      );
       return jsonResponse(body);
     }
   }
 
+  let source = 'openlibrary';
   const ol = await fetchOpenLibrary(isbn);
   let csl;
   if (ol && ol.title) {
@@ -35,13 +53,23 @@ export async function handleCiteBook(requestUrl: URL, cache: MinCache | null, ap
   } else {
     const gb = await fetchGoogleBooks(isbn, apiKey);
     if (!gb || !gb.title) {
+      writeEvent(analytics, 'error', { endpoint: 'cite_book', code: 'not_found' }, { count: 1 });
       return errorResponse(404, 'not_found', 'Book not found in OpenLibrary or Google Books');
     }
     csl = normalizeGoogleBooks(gb, isbn);
+    source = 'googlebooks';
   }
 
   const envelope: ExtractEnvelope = { uuid: isbn, type: 'book', csl, _cached: false };
   const response = jsonResponse(envelope);
+
+  // Emit before cache.put: a cache-write failure shouldn't shadow the
+  // success event for an otherwise-completed citation.
+  writeEvent(analytics, 'cite_book',
+    { source },
+    { latency_ms: Date.now() - start, cache_hit: 0 },
+  );
+
   if (cache && !bypassCache) {
     await cache.put(cacheKey, response.clone(), TTL.BOOK_OR_JOURNAL);
   }

--- a/functions/api/cite-book/index.ts
+++ b/functions/api/cite-book/index.ts
@@ -1,9 +1,10 @@
 import { handleCiteBook } from './handler';
 import { defaultCacheStore } from '../../lib/cache';
+import type { AnalyticsBinding } from '../../lib/analytics';
 
-interface Env { API_KEY?: string }
+interface Env { API_KEY?: string; ANALYTICS?: AnalyticsBinding }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   const url = new URL(context.request.url);
-  return handleCiteBook(url, defaultCacheStore(), context.env.API_KEY);
+  return handleCiteBook(url, defaultCacheStore(), context.env.API_KEY, context.env.ANALYTICS);
 };

--- a/functions/api/cite-journal/handler.ts
+++ b/functions/api/cite-journal/handler.ts
@@ -4,21 +4,36 @@ import { normalizeCrossref, normalizeOpenAlex } from '../../lib/journal/normaliz
 import { validateDoi } from '../../lib/journal/doi-detect';
 import { TTL } from '../../lib/cache';
 import type { ExtractEnvelope } from '../../lib/csl-types';
+import { writeEvent, type AnalyticsBinding } from '../../lib/analytics';
 
 export interface MinCache {
   get(key: string): Promise<Response | undefined>;
   put(key: string, response: Response, maxAgeSeconds: number): Promise<void>;
 }
 
-export async function handleCiteJournal(requestUrl: URL, cache: MinCache | null): Promise<Response> {
+export async function handleCiteJournal(
+  requestUrl: URL,
+  cache: MinCache | null,
+  analytics?: AnalyticsBinding,
+): Promise<Response> {
+  const start = Date.now();
   const rawDoi = requestUrl.searchParams.get('doi');
   const rawUrl = requestUrl.searchParams.get('url');
-  if (!rawDoi && !rawUrl) return errorResponse(400, 'invalid_doi', 'Missing doi or url parameter');
+  if (!rawDoi && !rawUrl) {
+    writeEvent(analytics, 'error', { endpoint: 'cite_journal', code: 'invalid_doi' }, { count: 1 });
+    return errorResponse(400, 'invalid_doi', 'Missing doi or url parameter');
+  }
 
   let doi: string | null = rawDoi ? validateDoi(rawDoi) : null;
-  if (!doi && rawDoi) return errorResponse(400, 'invalid_doi', 'Malformed DOI');
+  if (!doi && rawDoi) {
+    writeEvent(analytics, 'error', { endpoint: 'cite_journal', code: 'invalid_doi' }, { count: 1 });
+    return errorResponse(400, 'invalid_doi', 'Malformed DOI');
+  }
 
-  if (!doi) return errorResponse(400, 'invalid_doi', 'cite-journal currently requires a doi parameter; use cite-website for non-DOI articles');
+  if (!doi) {
+    writeEvent(analytics, 'error', { endpoint: 'cite_journal', code: 'invalid_doi' }, { count: 1 });
+    return errorResponse(400, 'invalid_doi', 'cite-journal currently requires a doi parameter; use cite-website for non-DOI articles');
+  }
 
   const cacheKey = `https://cache.mlagenerator/journal/${doi}`;
   const bypassCache = requestUrl.searchParams.get('nocache') === '1';
@@ -27,22 +42,39 @@ export async function handleCiteJournal(requestUrl: URL, cache: MinCache | null)
     if (hit) {
       const body = await hit.json() as ExtractEnvelope;
       body._cached = true;
+      writeEvent(analytics, 'cite_journal',
+        { source: '' },
+        { latency_ms: Date.now() - start, cache_hit: 1 },
+      );
       return jsonResponse(body);
     }
   }
 
+  let source = 'crossref';
   const cr = await fetchCrossref(doi);
   let csl;
   if (cr && cr.title?.length) {
     csl = normalizeCrossref(cr);
   } else {
     const oa = await fetchOpenAlex(doi);
-    if (!oa || !oa.title) return errorResponse(404, 'not_found', 'DOI not found in Crossref or OpenAlex');
+    if (!oa || !oa.title) {
+      writeEvent(analytics, 'error', { endpoint: 'cite_journal', code: 'not_found' }, { count: 1 });
+      return errorResponse(404, 'not_found', 'DOI not found in Crossref or OpenAlex');
+    }
     csl = normalizeOpenAlex(oa);
+    source = 'openalex';
   }
 
   const envelope: ExtractEnvelope = { uuid: doi, type: 'article-journal', csl, _cached: false };
   const response = jsonResponse(envelope);
+
+  // Emit before cache.put: a cache-write failure shouldn't shadow the
+  // success event for an otherwise-completed citation.
+  writeEvent(analytics, 'cite_journal',
+    { source },
+    { latency_ms: Date.now() - start, cache_hit: 0 },
+  );
+
   if (cache && !bypassCache) {
     await cache.put(cacheKey, response.clone(), TTL.BOOK_OR_JOURNAL);
   }

--- a/functions/api/cite-journal/index.ts
+++ b/functions/api/cite-journal/index.ts
@@ -1,7 +1,10 @@
 import { handleCiteJournal } from './handler';
 import { defaultCacheStore } from '../../lib/cache';
+import type { AnalyticsBinding } from '../../lib/analytics';
 
-export const onRequest: PagesFunction = async (context) => {
+interface Env { ANALYTICS?: AnalyticsBinding }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
   const url = new URL(context.request.url);
-  return handleCiteJournal(url, defaultCacheStore());
+  return handleCiteJournal(url, defaultCacheStore(), context.env.ANALYTICS);
 };

--- a/functions/api/cite-website/handler.ts
+++ b/functions/api/cite-website/handler.ts
@@ -3,23 +3,34 @@ import { fetchHtml, FetchError } from '../../lib/extract/fetch';
 import { normalizeUrl } from '../../lib/extract/url-normalize';
 import { TTL } from '../../lib/cache';
 import type { ExtractEnvelope } from '../../lib/csl-types';
+import { writeEvent, type AnalyticsBinding } from '../../lib/analytics';
 
 export interface MinCache {
   get(key: string): Promise<Response | undefined>;
   put(key: string, response: Response, maxAgeSeconds: number): Promise<void>;
 }
 
-export async function handleCiteWebsite(requestUrl: URL, cache: MinCache | null): Promise<Response> {
+export async function handleCiteWebsite(
+  requestUrl: URL,
+  cache: MinCache | null,
+  analytics?: AnalyticsBinding,
+): Promise<Response> {
   const raw = requestUrl.searchParams.get('url');
-  if (!raw) return errorResponse(400, 'invalid_url', 'Missing url parameter', false);
+  if (!raw) {
+    writeEvent(analytics, 'error', { endpoint: 'cite_website', code: 'invalid_url' }, { count: 1 });
+    return errorResponse(400, 'invalid_url', 'Missing url parameter', false);
+  }
 
   let target: string;
   try {
     const decoded = decodeURIComponent(raw);
     target = normalizeUrl(decoded.startsWith('http') ? decoded : `https://${decoded}`);
   } catch {
+    writeEvent(analytics, 'error', { endpoint: 'cite_website', code: 'invalid_url' }, { count: 1 });
     return errorResponse(400, 'invalid_url', 'Malformed URL', false);
   }
+
+  const host = hostOf(target);
 
   const bypassCache = requestUrl.searchParams.get('nocache') === '1';
   if (cache && !bypassCache) {
@@ -27,6 +38,14 @@ export async function handleCiteWebsite(requestUrl: URL, cache: MinCache | null)
     if (hit) {
       const body = await hit.json() as ExtractEnvelope;
       body._cached = true;
+      writeEvent(analytics, 'cite_website',
+        {
+          signal_winner_title: body._signals?.title ?? '',
+          signal_winner_url: body._signals?.URL ?? '',
+          host,
+        },
+        { html_size_kb: 0, extraction_ms: 0, cache_hit: 1 },
+      );
       return jsonResponse(body);
     }
   }
@@ -37,12 +56,17 @@ export async function handleCiteWebsite(requestUrl: URL, cache: MinCache | null)
     ({ html, finalUrl } = await fetchHtml(target));
   } catch (err) {
     if (err instanceof FetchError) {
+      writeEvent(analytics, 'error', { endpoint: 'cite_website', code: err.code }, { count: 1 });
       return errorResponse(400, err.code, err.message, err.retryable);
     }
+    writeEvent(analytics, 'error', { endpoint: 'cite_website', code: 'internal' }, { count: 1 });
     return errorResponse(500, 'internal', String((err as Error).message), false);
   }
 
+  const extractStart = Date.now();
   const { csl, signals } = runExtractionPipeline(html, finalUrl);
+  const extractionMs = Date.now() - extractStart;
+
   const envelope: ExtractEnvelope = {
     uuid: target,
     type: 'webpage',
@@ -51,10 +75,32 @@ export async function handleCiteWebsite(requestUrl: URL, cache: MinCache | null)
     _cached: false,
   };
   const response = jsonResponse(envelope);
+
+  // Emit before cache.put so a cache-write failure (network blip into the
+  // Cache API) doesn't swallow the analytics event for an otherwise-
+  // successful request — those slow-tail successes are precisely what the
+  // dashboard wants to see.
+  writeEvent(analytics, 'cite_website',
+    {
+      signal_winner_title: signals.title ?? '',
+      signal_winner_url: signals.URL ?? '',
+      host,
+    },
+    {
+      html_size_kb: Math.round(html.length / 1024),
+      extraction_ms: extractionMs,
+      cache_hit: 0,
+    },
+  );
+
   if (cache && !bypassCache) {
     await cache.put(target, response.clone(), TTL.WEBSITE);
   }
   return response;
+}
+
+function hostOf(url: string): string {
+  try { return new URL(url).hostname; } catch { return ''; }
 }
 
 function jsonResponse(body: unknown): Response {

--- a/functions/api/cite-website/index.ts
+++ b/functions/api/cite-website/index.ts
@@ -1,7 +1,10 @@
 import { handleCiteWebsite } from './handler';
 import { defaultCacheStore } from '../../lib/cache';
+import type { AnalyticsBinding } from '../../lib/analytics';
 
-export const onRequest: PagesFunction = async (context) => {
+interface Env { ANALYTICS?: AnalyticsBinding }
+
+export const onRequest: PagesFunction<Env> = async (context) => {
   const url = new URL(context.request.url);
-  return handleCiteWebsite(url, defaultCacheStore());
+  return handleCiteWebsite(url, defaultCacheStore(), context.env.ANALYTICS);
 };

--- a/functions/api/format/handler.ts
+++ b/functions/api/format/handler.ts
@@ -1,29 +1,40 @@
 import type { CSLItem, FormatRequest, FormatResponse, SupportedStyle } from '../../lib/csl-types';
 import { formatCitation } from '../../lib/format/citeproc';
+import { writeEvent, type AnalyticsBinding } from '../../lib/analytics';
 
 const SUPPORTED: SupportedStyle[] = ['mla-9', 'apa-7', 'chicago-18', 'ama-11', 'harvard', 'ieee', 'vancouver'];
 
-export async function handleFormat(req: Request): Promise<Response> {
+export async function handleFormat(req: Request, analytics?: AnalyticsBinding): Promise<Response> {
+  const start = Date.now();
   if (req.method !== 'POST') {
+    writeEvent(analytics, 'error', { endpoint: 'format', code: 'method_not_allowed' }, { count: 1 });
     return error(405, 'method_not_allowed', 'POST required');
   }
   let parsed: FormatRequest;
   try {
     parsed = await req.json() as FormatRequest;
   } catch {
+    writeEvent(analytics, 'error', { endpoint: 'format', code: 'bad_request' }, { count: 1 });
     return error(400, 'bad_request', 'Body must be JSON');
   }
   if (!parsed || !parsed.csl || typeof parsed.csl !== 'object') {
+    writeEvent(analytics, 'error', { endpoint: 'format', code: 'bad_request' }, { count: 1 });
     return error(400, 'bad_request', 'Missing csl');
   }
   if (!parsed.style || !SUPPORTED.includes(parsed.style)) {
+    writeEvent(analytics, 'error', { endpoint: 'format', code: 'bad_request' }, { count: 1 });
     return error(400, 'bad_request', `Unsupported style. Allowed: ${SUPPORTED.join(', ')}`);
   }
   try {
     const formatted = formatCitation(parsed.csl as CSLItem, parsed.style);
     const body: FormatResponse = { formatted };
+    writeEvent(analytics, 'format',
+      { style: parsed.style },
+      { latency_ms: Date.now() - start },
+    );
     return new Response(JSON.stringify(body), { headers: { 'content-type': 'application/json' } });
   } catch (e) {
+    writeEvent(analytics, 'error', { endpoint: 'format', code: 'internal' }, { count: 1 });
     return error(500, 'internal', `Format failed: ${(e as Error).message}`);
   }
 }

--- a/functions/api/format/index.ts
+++ b/functions/api/format/index.ts
@@ -2,6 +2,9 @@ import { handleFormat } from './handler';
 import { registerStyle, registerLocale } from '../../lib/format/citeproc';
 import { decode as decodeStyle, NAMES as STYLE_NAMES } from '../../lib/format/styles';
 import { decode as decodeLocale } from '../../lib/format/locales';
+import type { AnalyticsBinding } from '../../lib/analytics';
+
+interface Env { ANALYTICS?: AnalyticsBinding }
 
 let registered = false;
 function ensureRegistered() {
@@ -13,7 +16,7 @@ function ensureRegistered() {
   registered = true;
 }
 
-export const onRequest: PagesFunction = async (context) => {
+export const onRequest: PagesFunction<Env> = async (context) => {
   ensureRegistered();
-  return handleFormat(context.request);
+  return handleFormat(context.request, context.env.ANALYTICS);
 };

--- a/functions/lib/analytics.ts
+++ b/functions/lib/analytics.ts
@@ -1,0 +1,42 @@
+/**
+ * Cloudflare Analytics Engine dataset binding. Matches the runtime shape
+ * Workers/Pages expose; we re-declare instead of importing
+ * @cloudflare/workers-types because the rest of the project keeps that
+ * dependency out and inlines the few types it needs (see
+ * `PagesFunction` usage in functions/api/**\/index.ts).
+ */
+export interface AnalyticsBinding {
+  writeDataPoint(point: { blobs?: string[]; doubles?: number[]; indexes?: string[] }): void;
+}
+
+/**
+ * Emit one event to the Analytics Engine dataset, if the binding exists.
+ *
+ * Storage layout (Analytics Engine is positional, not keyed):
+ *   blobs[0]   = event name
+ *   blobs[1..] = dimension values in iteration order
+ *   doubles[0..] = metric values in iteration order
+ *   indexes[0] = event name (for fast WHERE filtering in SQL)
+ *
+ * Missing binding = no-op. Analytics is never load-bearing for citation
+ * correctness; the dataset can be deployed after the code if the
+ * Cloudflare dashboard hasn't been touched yet.
+ *
+ * IMPORTANT: dimension / metric ORDER is the storage column order. The
+ * dashboard SQL refers to columns positionally as blob2, blob3,
+ * double1, double2... Renaming the keys at the call site is harmless;
+ * reordering them is silently breaking. See docs/analytics.md for the
+ * column→meaning mapping that downstream queries depend on.
+ */
+export function writeEvent(
+  analytics: AnalyticsBinding | undefined,
+  event: string,
+  dimensions: Record<string, string>,
+  metrics: Record<string, number>,
+): void {
+  analytics?.writeDataPoint({
+    blobs: [event, ...Object.values(dimensions)],
+    doubles: Object.values(metrics),
+    indexes: [event],
+  });
+}

--- a/tests/analytics.test.ts
+++ b/tests/analytics.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { writeEvent } from '../functions/lib/analytics';
+
+describe('writeEvent', () => {
+  it('writes blobs, doubles, indexes in positional order', () => {
+    const writeDataPoint = vi.fn();
+    writeEvent(
+      { writeDataPoint },
+      'cite_website',
+      { signal_winner_title: 'jsonld', signal_winner_url: 'opengraph', host: 'example.com' },
+      { html_size_kb: 42, extraction_ms: 17, cache_hit: 0 },
+    );
+    expect(writeDataPoint).toHaveBeenCalledTimes(1);
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: ['cite_website', 'jsonld', 'opengraph', 'example.com'],
+      doubles: [42, 17, 0],
+      indexes: ['cite_website'],
+    });
+  });
+
+  it('is a no-op when the binding is undefined', () => {
+    // Pre-deploy and pre-dataset-creation: env.ANALYTICS is undefined.
+    // Handlers must keep working unchanged.
+    expect(() =>
+      writeEvent(undefined, 'cite_book', { source: 'openlibrary' }, { latency_ms: 100, cache_hit: 1 }),
+    ).not.toThrow();
+  });
+
+  it('preserves insertion order even when keys would not sort the same way', () => {
+    // Object property iteration in JS is insertion order for string keys.
+    // The writer relies on this to keep dimension column order stable.
+    const writeDataPoint = vi.fn();
+    writeEvent(
+      { writeDataPoint },
+      'err',
+      { z_last: 'zzz', a_first: 'aaa' },
+      { z_metric: 1, a_metric: 2 },
+    );
+    expect(writeDataPoint.mock.calls[0][0].blobs).toEqual(['err', 'zzz', 'aaa']);
+    expect(writeDataPoint.mock.calls[0][0].doubles).toEqual([1, 2]);
+  });
+
+  it('emits event name into both blobs[0] and indexes[0]', () => {
+    const writeDataPoint = vi.fn();
+    writeEvent({ writeDataPoint }, 'format', { style: 'mla-9' }, { latency_ms: 8 });
+    const point = writeDataPoint.mock.calls[0][0];
+    expect(point.blobs[0]).toBe('format');
+    expect(point.indexes[0]).toBe('format');
+  });
+
+  it('handles zero-dimension / zero-metric calls', () => {
+    const writeDataPoint = vi.fn();
+    writeEvent({ writeDataPoint }, 'noop', {}, {});
+    expect(writeDataPoint).toHaveBeenCalledWith({
+      blobs: ['noop'],
+      doubles: [],
+      indexes: ['noop'],
+    });
+  });
+});

--- a/tests/api/analytics-integration.test.ts
+++ b/tests/api/analytics-integration.test.ts
@@ -1,0 +1,245 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { handleCiteBook } from '../../functions/api/cite-book/handler';
+import { handleCiteJournal } from '../../functions/api/cite-journal/handler';
+import { handleCiteWebsite } from '../../functions/api/cite-website/handler';
+import { handleFormat } from '../../functions/api/format/handler';
+import { loadFixtureFile } from '../helpers/load-fixture';
+import { join } from 'node:path';
+
+const OL_FIX = join(__dirname, '../book/fixtures/openlibrary');
+const GB_FIX = join(__dirname, '../book/fixtures/googlebooks');
+
+function mockSequence(...responses: Response[]) {
+  let i = 0;
+  globalThis.fetch = vi.fn(async () => responses[i++]) as any;
+}
+
+function mockOnce(r: Response) {
+  globalThis.fetch = vi.fn(async () => r) as any;
+}
+
+interface CapturedPoint {
+  blobs?: string[];
+  doubles?: number[];
+  indexes?: string[];
+}
+
+function makeAnalytics() {
+  const writeDataPoint = vi.fn();
+  return { binding: { writeDataPoint }, writeDataPoint };
+}
+
+// Extract dimensions (everything in blobs after the event name) and metrics
+// (everything in doubles). The event name is in blobs[0] and indexes[0].
+function shapeOf(point: CapturedPoint) {
+  return {
+    event: point.blobs?.[0],
+    dimensions: (point.blobs ?? []).slice(1),
+    metrics: point.doubles ?? [],
+    index: point.indexes?.[0],
+  };
+}
+
+describe('analytics integration', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  describe('cite-book', () => {
+    it('emits cite_book with source=openlibrary on success', async () => {
+      const body = loadFixtureFile(OL_FIX, '9780553418811.json');
+      mockOnce(new Response(body, { status: 200, headers: { 'content-type': 'application/json' } }));
+      const { binding, writeDataPoint } = makeAnalytics();
+
+      const res = await handleCiteBook(
+        new URL('https://m.com/api/cite-book?isbn=9780553418811'),
+        null, undefined, binding,
+      );
+      expect(res.status).toBe(200);
+      expect(writeDataPoint).toHaveBeenCalledTimes(1);
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('cite_book');
+      expect(shape.index).toBe('cite_book');
+      expect(shape.dimensions).toEqual(['openlibrary']);
+      // metrics: [latency_ms, cache_hit]. Latency is wall-clock so just bounds-check.
+      expect(shape.metrics[0]).toBeGreaterThanOrEqual(0);
+      expect(shape.metrics[1]).toBe(0);
+    });
+
+    it('emits cite_book with source=googlebooks when OL is empty', async () => {
+      const empty = new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } });
+      const gb = loadFixtureFile(GB_FIX, '9780553418811.json');
+      mockSequence(empty, new Response(gb, { status: 200, headers: { 'content-type': 'application/json' } }));
+      const { binding, writeDataPoint } = makeAnalytics();
+
+      await handleCiteBook(
+        new URL('https://m.com/api/cite-book?isbn=9780553418811'),
+        null, undefined, binding,
+      );
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.dimensions[0]).toBe('googlebooks');
+    });
+
+    it('emits error event on 400 invalid_isbn', async () => {
+      const { binding, writeDataPoint } = makeAnalytics();
+      await handleCiteBook(new URL('https://m.com/api/cite-book'), null, undefined, binding);
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('error');
+      expect(shape.dimensions).toEqual(['cite_book', 'invalid_isbn']);
+      expect(shape.metrics).toEqual([1]);
+    });
+
+    it('emits error event on 404 not_found', async () => {
+      mockSequence(
+        new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }),
+        new Response(JSON.stringify({ totalItems: 0 }), { status: 200, headers: { 'content-type': 'application/json' } }),
+      );
+      const { binding, writeDataPoint } = makeAnalytics();
+      await handleCiteBook(
+        new URL('https://m.com/api/cite-book?isbn=9780553418811'),
+        null, undefined, binding,
+      );
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('error');
+      expect(shape.dimensions).toEqual(['cite_book', 'not_found']);
+    });
+  });
+
+  describe('cite-journal', () => {
+    it('emits error event on missing doi', async () => {
+      const { binding, writeDataPoint } = makeAnalytics();
+      await handleCiteJournal(new URL('https://m.com/api/cite-journal'), null, binding);
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('error');
+      expect(shape.dimensions).toEqual(['cite_journal', 'invalid_doi']);
+    });
+
+    it('emits error event on malformed doi', async () => {
+      const { binding, writeDataPoint } = makeAnalytics();
+      await handleCiteJournal(new URL('https://m.com/api/cite-journal?doi=garbage'), null, binding);
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('error');
+      expect(shape.dimensions).toEqual(['cite_journal', 'invalid_doi']);
+    });
+  });
+
+  describe('cite-website', () => {
+    const HTML = `<!DOCTYPE html><html><head>
+      <title>Test</title>
+      <script type="application/ld+json">${JSON.stringify({
+        '@type': 'NewsArticle', headline: 'Test', author: { givenName: 'A', familyName: 'B' },
+      })}</script>
+    </head></html>`;
+
+    it('emits cite_website on success with host + signal winners + sizes', async () => {
+      mockOnce(new Response(HTML, { status: 200, headers: { 'content-type': 'text/html' } }));
+      const { binding, writeDataPoint } = makeAnalytics();
+      await handleCiteWebsite(
+        new URL('https://m.com/api/cite-website?url=https://example.com/page'),
+        null, binding,
+      );
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('cite_website');
+      // [signal_winner_title, signal_winner_url, host]
+      expect(shape.dimensions[2]).toBe('example.com');
+      expect(shape.dimensions[0]).toBeTruthy(); // a signal name (jsonld, microdata, etc.)
+      // metrics: [html_size_kb, extraction_ms, cache_hit]
+      expect(shape.metrics[0]).toBeGreaterThanOrEqual(0);
+      expect(shape.metrics[1]).toBeGreaterThanOrEqual(0);
+      expect(shape.metrics[2]).toBe(0);
+    });
+
+    it('emits cite_website with cache_hit=1 when cache is warm', async () => {
+      mockOnce(new Response(HTML, { status: 200, headers: { 'content-type': 'text/html' } }));
+      const store = new Map<string, Response>();
+      const cache = {
+        async get(k: string) { return store.get(k)?.clone(); },
+        async put(k: string, r: Response) { store.set(k, r.clone()); },
+      };
+      const url = new URL('https://m.com/api/cite-website?url=https://example.com/page');
+      const { binding, writeDataPoint } = makeAnalytics();
+
+      await handleCiteWebsite(url, cache, binding);   // miss → populates cache
+      await handleCiteWebsite(url, cache, binding);   // hit
+      const hitPoint = shapeOf(writeDataPoint.mock.calls[1][0]);
+      expect(hitPoint.event).toBe('cite_website');
+      expect(hitPoint.metrics[2]).toBe(1);
+    });
+
+    it('emits error event on fetch_failed', async () => {
+      globalThis.fetch = vi.fn(async () => new Response('nope', { status: 404, headers: { 'content-type': 'text/html' } })) as any;
+      const { binding, writeDataPoint } = makeAnalytics();
+      await handleCiteWebsite(
+        new URL('https://m.com/api/cite-website?url=https://example.com/p'),
+        null, binding,
+      );
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('error');
+      expect(shape.dimensions[0]).toBe('cite_website');
+      expect(shape.dimensions[1]).toBe('fetch_failed');
+    });
+  });
+
+  describe('format', () => {
+    it('emits format with style + latency on success', async () => {
+      // Avoid hitting the real citeproc registration: simplest path is feeding
+      // it a tiny CSL and a registered style. The other format tests already
+      // exercise registration; here we just verify the analytics shape.
+      // If the style isn't registered yet (vitest process state), the handler
+      // returns 500 with code=internal, which is still a valid emission shape.
+      const { binding, writeDataPoint } = makeAnalytics();
+      const req = new Request('https://m.com/api/format', {
+        method: 'POST',
+        body: JSON.stringify({ csl: { id: 'u', type: 'webpage', title: 'T' }, style: 'mla-9' }),
+        headers: { 'content-type': 'application/json' },
+      });
+      const res = await handleFormat(req, binding);
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      // Either it succeeded (format event) or it errored without the style
+      // being registered (error event with code=internal). Both are valid
+      // from the perspective of "did the analytics fire correctly?"
+      if (res.status === 200) {
+        expect(shape.event).toBe('format');
+        expect(shape.dimensions).toEqual(['mla-9']);
+        expect(shape.metrics[0]).toBeGreaterThanOrEqual(0);
+      } else {
+        expect(shape.event).toBe('error');
+        expect(shape.dimensions[0]).toBe('format');
+      }
+    });
+
+    it('emits error event on bad JSON body', async () => {
+      const { binding, writeDataPoint } = makeAnalytics();
+      const req = new Request('https://m.com/api/format', {
+        method: 'POST',
+        body: 'not json',
+        headers: { 'content-type': 'application/json' },
+      });
+      await handleFormat(req, binding);
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('error');
+      expect(shape.dimensions).toEqual(['format', 'bad_request']);
+    });
+
+    it('emits error event on unsupported style', async () => {
+      const { binding, writeDataPoint } = makeAnalytics();
+      const req = new Request('https://m.com/api/format', {
+        method: 'POST',
+        body: JSON.stringify({ csl: { id: 'u', type: 'webpage' }, style: 'fake-style' }),
+        headers: { 'content-type': 'application/json' },
+      });
+      await handleFormat(req, binding);
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('error');
+      expect(shape.dimensions).toEqual(['format', 'bad_request']);
+    });
+
+    it('emits error event on non-POST', async () => {
+      const { binding, writeDataPoint } = makeAnalytics();
+      const req = new Request('https://m.com/api/format', { method: 'GET' });
+      await handleFormat(req, binding);
+      const shape = shapeOf(writeDataPoint.mock.calls[0][0]);
+      expect(shape.event).toBe('error');
+      expect(shape.dimensions).toEqual(['format', 'method_not_allowed']);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds per-request instrumentation to all four API endpoints, writing one event per request to a Cloudflare Analytics Engine dataset via an `env.ANALYTICS` binding. Optional chaining means the code is deploy-safe before the binding is configured — events start flowing the moment you add the binding in the Cloudflare dashboard and redeploy.

## What's emitted

| Event           | Dimensions                                        | Metrics                                                       |
|-----------------|---------------------------------------------------|---------------------------------------------------------------|
| `cite_website`  | signal_winner_title, signal_winner_url, host      | html_size_kb, extraction_ms, cache_hit                        |
| `cite_book`     | source (openlibrary\|googlebooks)                 | latency_ms, cache_hit                                         |
| `cite_journal`  | source (crossref\|openalex)                       | latency_ms, cache_hit                                         |
| `format`        | style                                             | latency_ms                                                    |
| `error`         | endpoint, code                                    | count (1)                                                     |

Writer module (`functions/lib/analytics.ts`) is positional — `Object.values()` extracts dims/metrics in insertion order, which JS guarantees for string keys. Event name is duplicated into `indexes[0]` so SQL `WHERE index1 = '...'` is fast.

## Deploy prerequisite (one-time, on your end)

Adding `wrangler.toml` was deliberately skipped — the project's current Pages deploy uses dashboard config (compatibility flags, secrets), and introducing wrangler.toml would override that config. The binding goes in via the dashboard instead:

1. Cloudflare dashboard → **Workers & Pages** → **citation-generator** → **Settings** → **Functions** → **Analytics Engine Bindings** → **Add binding**.
2. Variable name: `ANALYTICS`. Dataset name: `citation_generator_events` (or pick one — the sample SQL in `docs/analytics.md` assumes that name).
3. Save → the next deploy picks it up. The dataset auto-creates on first write; no separate step.

If the binding isn't added, the code still deploys and runs identically; `env.ANALYTICS` is just `undefined` and `writeDataPoint` is never called.

## Notes from pre-merge review

A fresh-context correctness review was run against the diff before this PR opened. Verdict: `READY_TO_OPEN_PR`. Four non-blocking findings worth applying were addressed in-branch:

- **Query 2 fix**: original query plotted cite_website's `double1` (which is `html_size_kb`, not latency) alongside other endpoints' latencies. Excluded cite_website from query 2; added a separate query 2b for its extraction-time percentiles.
- **Query 3 comment fix**: the cache-hit filter rationale was backwards (cached rows do carry the cached signal winner, so filtering `blob2 <> ''` doesn't exclude them as the comment claimed). Now filters on `double3 = 0` (cache_hit = 0) with a corrected comment.
- **writeEvent before cache.put**: in cite_website / cite_book / cite_journal, the analytics emission was moved above the `await cache.put` so a transient cache-write failure no longer silently drops the success event for an otherwise-completed request.
- **Doc clarification on source = '' for cache hits**: clearer SQL guidance about using `cache_hit` (double2/double3) as the source of truth rather than the empty `source` dimension.

Non-blockers explicitly deferred (LOW confidence, no current code path affected): `signal_winner_url` semantics (often empty because `pipeline.ts` always sets `URL` itself), `invalid_doi` lumping three sub-states (acceptable for now).

## Test plan

- [x] `npx vitest run` — 37 test files, 224 tests pass (5 new unit cases for the writer, 13 integration cases for handler instrumentation)
- [x] `npx tsc --noEmit` — no new errors (pre-existing PagesFunction / citationStyles / fetch test issues unchanged)
- [ ] Post-merge: add the dashboard binding per the steps above, redeploy, then `curl https://mlagenerator.com/api/format -X POST -d '{"csl":{"id":"u","type":"webpage","title":"T"},"style":"mla-9"}' -H 'content-type: application/json'` and confirm an event lands in the dashboard's SQL query view.

## Files

- `functions/lib/analytics.ts` (new)
- `functions/api/{cite-website,cite-book,cite-journal,format}/handler.ts` (instrumented)
- `functions/api/{cite-website,cite-book,cite-journal,format}/index.ts` (read `env.ANALYTICS`, thread to handler)
- `tests/analytics.test.ts` (new — writer unit tests)
- `tests/api/analytics-integration.test.ts` (new — handler integration tests)
- `docs/analytics.md` (new — setup + schema + 7 sample queries)