### PR TITLE
Dashboard charts + test-traffic opt-out + cite_website fetch_ms

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -32,6 +32,25 @@ After the next deploy, every `/api/cite-website`, `/api/cite-book`, `/api/cite-j
 
 > The code is intentionally not gated behind a wrangler.toml so that the existing Cloudflare Pages dashboard config (compatibility flags, secrets, etc.) keeps owning deploy settings unchanged. Adding a wrangler.toml would override that config and was avoided.
 
+## Excluding test traffic from analytics
+
+Any request that includes **either** of these signals skips analytics emission entirely — no row is written to the dataset, so the dashboard and SQL queries don't need to filter test traffic out:
+
+- HTTP header **`X-Mla-Test: 1`** (works for GET and POST)
+- Query param **`?nocache=1`** (reuses the existing cache-bypass convention)
+
+Use either for smoke tests, CI scripts, or any one-off curl probes against the production endpoints. Example:
+
+```bash
+# Both of these are filtered from analytics
+curl 'https://mlagenerator.com/api/cite-website?url=https://en.wikipedia.org/wiki/Citation&nocache=1'
+curl 'https://mlagenerator.com/api/format' -X POST \
+  -H 'X-Mla-Test: 1' -H 'content-type: application/json' \
+  --data '{"csl":{"id":"u","type":"webpage","title":"smoke"},"style":"mla-9"}'
+```
+
+Real user traffic never carries either signal, so this filter is operator-only.
+
 ## Querying
 
 Go to **Workers & Pages** → **Analytics Engine** in the sidebar to open the SQL query interface. Or hit the SQL API directly:
@@ -46,13 +65,15 @@ curl "https://api.cloudflare.com/client/v4/accounts/{account_id}/analytics_engin
 
 Analytics Engine stores columns positionally, not by name. The writer in `functions/lib/analytics.ts` puts the event name in `blob1` (and duplicates it into `index1` for fast filtering). Dimensions follow in insertion order; metrics live in the `doubleN` columns.
 
-| Event           | blob1            | blob2                  | blob3                 | blob4 | double1        | double2        | double3   |
-| --------------- | ---------------- | ---------------------- | --------------------- | ----- | -------------- | -------------- | --------- |
-| `cite_website`  | `"cite_website"` | signal_winner_title    | signal_winner_url     | host  | html_size_kb   | extraction_ms  | cache_hit |
-| `cite_book`     | `"cite_book"`    | source (openlibrary\|googlebooks) | —          | —     | latency_ms     | cache_hit      | —         |
-| `cite_journal`  | `"cite_journal"` | source (crossref\|openalex)       | —          | —     | latency_ms     | cache_hit      | —         |
-| `format`        | `"format"`       | style                  | —                     | —     | latency_ms     | —              | —         |
-| `error`         | `"error"`        | endpoint               | code                  | —     | count (always 1) | —            | —         |
+| Event           | blob1            | blob2                  | blob3                 | blob4 | double1        | double2        | double3   | double4  |
+| --------------- | ---------------- | ---------------------- | --------------------- | ----- | -------------- | -------------- | --------- | -------- |
+| `cite_website`  | `"cite_website"` | signal_winner_title    | signal_winner_url     | host  | html_size_kb   | extraction_ms  | cache_hit | fetch_ms |
+| `cite_book`     | `"cite_book"`    | source (openlibrary\|googlebooks) | —          | —     | latency_ms     | cache_hit      | —         | —        |
+| `cite_journal`  | `"cite_journal"` | source (crossref\|openalex)       | —          | —     | latency_ms     | cache_hit      | —         | —        |
+| `format`        | `"format"`       | style                  | —                     | —     | latency_ms     | —              | —         | —        |
+| `error`         | `"error"`        | endpoint               | code                  | —     | count (always 1) | —            | —         | —        |
+
+The `fetch_ms` column on `cite_website` was added 2026-05-27 — older rows have null/empty for that column. It separates network fetch time from extraction time so you can tell whether a slow citation was upstream (`fetch_ms` high) or our pipeline (`extraction_ms` high).
 
 On a cache hit, `source` for cite_book / cite_journal is `''` (empty string) because we didn't talk to either upstream; the `cache_hit` metric is the source of truth for "this was a cache hit". **Per-source SQL slices should filter on the metric, not on `blob2`** — e.g. to count fresh OpenLibrary hits, write `WHERE index1 = 'cite_book' AND double2 = 0 AND blob2 = 'openlibrary'`, not `WHERE blob2 = 'openlibrary'` alone (that's already correct, but the omission of `double2 = 0` would silently exclude cache hits even though they came from "openlibrary" originally — usually the desired behavior, but be explicit). cite_website on a cache hit carries the cached signal-winner dimensions but `html_size_kb` and `extraction_ms` are both 0.
 

--- a/functions/api/cite-book/index.ts
+++ b/functions/api/cite-book/index.ts
@@ -1,10 +1,12 @@
 import { handleCiteBook } from './handler';
 import { defaultCacheStore } from '../../lib/cache';
 import type { AnalyticsBinding } from '../../lib/analytics';
+import { isTestRequest } from '../../lib/test-context';
 
 interface Env { API_KEY?: string; ANALYTICS?: AnalyticsBinding }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   const url = new URL(context.request.url);
-  return handleCiteBook(url, defaultCacheStore(), context.env.API_KEY, context.env.ANALYTICS);
+  const analytics = isTestRequest(context.request) ? undefined : context.env.ANALYTICS;
+  return handleCiteBook(url, defaultCacheStore(), context.env.API_KEY, analytics);
 };

--- a/functions/api/cite-journal/index.ts
+++ b/functions/api/cite-journal/index.ts
@@ -1,10 +1,12 @@
 import { handleCiteJournal } from './handler';
 import { defaultCacheStore } from '../../lib/cache';
 import type { AnalyticsBinding } from '../../lib/analytics';
+import { isTestRequest } from '../../lib/test-context';
 
 interface Env { ANALYTICS?: AnalyticsBinding }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   const url = new URL(context.request.url);
-  return handleCiteJournal(url, defaultCacheStore(), context.env.ANALYTICS);
+  const analytics = isTestRequest(context.request) ? undefined : context.env.ANALYTICS;
+  return handleCiteJournal(url, defaultCacheStore(), analytics);
 };

--- a/functions/api/cite-website/handler.ts
+++ b/functions/api/cite-website/handler.ts
@@ -44,7 +44,7 @@ export async function handleCiteWebsite(
           signal_winner_url: body._signals?.URL ?? '',
           host,
         },
-        { html_size_kb: 0, extraction_ms: 0, cache_hit: 1 },
+        { html_size_kb: 0, extraction_ms: 0, cache_hit: 1, fetch_ms: 0 },
       );
       return jsonResponse(body);
     }
@@ -52,6 +52,7 @@ export async function handleCiteWebsite(
 
   let html: string;
   let finalUrl: string;
+  const fetchStart = Date.now();
   try {
     ({ html, finalUrl } = await fetchHtml(target));
   } catch (err) {
@@ -62,6 +63,7 @@ export async function handleCiteWebsite(
     writeEvent(analytics, 'error', { endpoint: 'cite_website', code: 'internal' }, { count: 1 });
     return errorResponse(500, 'internal', String((err as Error).message), false);
   }
+  const fetchMs = Date.now() - fetchStart;
 
   const extractStart = Date.now();
   const { csl, signals } = runExtractionPipeline(html, finalUrl);
@@ -90,6 +92,7 @@ export async function handleCiteWebsite(
       html_size_kb: Math.round(html.length / 1024),
       extraction_ms: extractionMs,
       cache_hit: 0,
+      fetch_ms: fetchMs,
     },
   );
 

--- a/functions/api/cite-website/index.ts
+++ b/functions/api/cite-website/index.ts
@@ -1,10 +1,14 @@
 import { handleCiteWebsite } from './handler';
 import { defaultCacheStore } from '../../lib/cache';
 import type { AnalyticsBinding } from '../../lib/analytics';
+import { isTestRequest } from '../../lib/test-context';
 
 interface Env { ANALYTICS?: AnalyticsBinding }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   const url = new URL(context.request.url);
-  return handleCiteWebsite(url, defaultCacheStore(), context.env.ANALYTICS);
+  // Test traffic (X-Mla-Test:1 or ?nocache=1) gets undefined binding so no
+  // data point lands in the dataset. Production dashboard stays clean.
+  const analytics = isTestRequest(context.request) ? undefined : context.env.ANALYTICS;
+  return handleCiteWebsite(url, defaultCacheStore(), analytics);
 };

--- a/functions/api/format/index.ts
+++ b/functions/api/format/index.ts
@@ -3,6 +3,7 @@ import { registerStyle, registerLocale } from '../../lib/format/citeproc';
 import { decode as decodeStyle, NAMES as STYLE_NAMES } from '../../lib/format/styles';
 import { decode as decodeLocale } from '../../lib/format/locales';
 import type { AnalyticsBinding } from '../../lib/analytics';
+import { isTestRequest } from '../../lib/test-context';
 
 interface Env { ANALYTICS?: AnalyticsBinding }
 
@@ -18,5 +19,6 @@ function ensureRegistered() {
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   ensureRegistered();
-  return handleFormat(context.request, context.env.ANALYTICS);
+  const analytics = isTestRequest(context.request) ? undefined : context.env.ANALYTICS;
+  return handleFormat(context.request, analytics);
 };

--- a/functions/lib/test-context.ts
+++ b/functions/lib/test-context.ts
@@ -1,0 +1,26 @@
+/**
+ * Detect whether an incoming API request is opting out of analytics
+ * emission. Two signals, either is sufficient:
+ *
+ *   - Header `X-Mla-Test: 1` — works for any method (incl. POST /api/format)
+ *   - Query `?nocache=1`     — reuses the existing cache-bypass convention
+ *
+ * Handlers consult this once at the request boundary and pass `undefined`
+ * for the analytics binding when it returns true. The writeEvent function
+ * then no-ops as it does for any other absent binding — there's no
+ * separate "test event" stored in the dataset; the row simply doesn't
+ * exist.
+ *
+ * This is a filter on emission, not a flag on the row. We want test
+ * traffic to be truly absent from dashboards, not just hidden behind a
+ * WHERE clause.
+ */
+export function isTestRequest(req: Request): boolean {
+  if (req.headers.get('x-mla-test') === '1') return true;
+  try {
+    if (new URL(req.url).searchParams.get('nocache') === '1') return true;
+  } catch {
+    /* malformed URL — treat as non-test */
+  }
+  return false;
+}

--- a/src/lib/admin/queries.ts
+++ b/src/lib/admin/queries.ts
@@ -1,7 +1,7 @@
 /**
  * Named dashboard queries. Each carries its SQL plus enough metadata
- * (title, description, column ordering) for the page to render a
- * consistent panel without per-query branching in the template.
+ * (title, description, column ordering, render hint) for the page to
+ * render a consistent panel without per-query branching in the template.
  *
  * Dataset name is parameterized so the user can override via
  * ANALYTICS_DATASET env var. SQL is `FORMAT JSON`-suffixed so the
@@ -9,28 +9,42 @@
  * parse.
  */
 
+export type RenderKind = 'tiles' | 'sparkline' | 'table';
+
 export interface QueryDef {
   key: string;
   title: string;
   description: string;
-  columns: Array<{ key: string; label: string; align?: 'left' | 'right' }>;
+  render: RenderKind;
+  /** Column metadata for table-render panels. */
+  columns?: Array<{
+    key: string;
+    label: string;
+    align?: 'left' | 'right';
+    /** If true, the column draws an inline bar proportional to the row max. */
+    bar?: boolean;
+  }>;
+  /** Tiles use a `label` column for the event/label and `count` for the value. */
+  tilesLabelKey?: string;
+  tilesValueKey?: string;
+  /** Sparklines use one row per bucket; `bucketKey` for the x label, `valueKey` for height. */
+  sparklineBucketKey?: string;
+  sparklineValueKey?: string;
+  sparklineWindowLabel?: string;
   sql: string;
 }
 
 export function buildQueries(dataset: string): QueryDef[] {
-  // Use `FORMAT JSON` for structured envelope; no trailing semicolon
-  // because the AE SQL endpoint rejects them in some response paths.
   const J = 'FORMAT JSON';
 
   return [
     {
       key: 'headline',
-      title: 'Headline counts (last 24h)',
+      title: 'Activity (last 24h)',
       description: 'Event volume by type. Sanity check that the binding is live.',
-      columns: [
-        { key: 'event', label: 'Event' },
-        { key: 'events', label: 'Count', align: 'right' },
-      ],
+      render: 'tiles',
+      tilesLabelKey: 'event',
+      tilesValueKey: 'events',
       sql: `
         SELECT
           index1 AS event,
@@ -43,12 +57,32 @@ export function buildQueries(dataset: string): QueryDef[] {
       `,
     },
     {
+      key: 'events_per_hour',
+      title: 'Events per hour (last 24h)',
+      description: 'All event types, bucketed hourly.',
+      render: 'sparkline',
+      sparklineBucketKey: 'hour',
+      sparklineValueKey: 'events',
+      sparklineWindowLabel: '24h',
+      sql: `
+        SELECT
+          toStartOfInterval(timestamp, INTERVAL '1' HOUR) AS hour,
+          count() AS events
+        FROM ${dataset}
+        WHERE timestamp >= NOW() - INTERVAL '24' HOUR
+        GROUP BY hour
+        ORDER BY hour ASC
+        ${J}
+      `,
+    },
+    {
       key: 'top_styles',
       title: 'Top citation styles (last 7d)',
       description: 'Which CSL styles users actually format with.',
+      render: 'table',
       columns: [
         { key: 'style', label: 'Style' },
-        { key: 'requests', label: 'Requests', align: 'right' },
+        { key: 'requests', label: 'Requests', align: 'right', bar: true },
       ],
       sql: `
         SELECT
@@ -66,10 +100,11 @@ export function buildQueries(dataset: string): QueryDef[] {
       key: 'latency_p95',
       title: 'p95 latency by endpoint (last 24h)',
       description: 'cite_website excluded — its double1 is html_size_kb, not latency.',
+      render: 'table',
       columns: [
         { key: 'endpoint', label: 'Endpoint' },
         { key: 'p50_ms', label: 'p50 ms', align: 'right' },
-        { key: 'p95_ms', label: 'p95 ms', align: 'right' },
+        { key: 'p95_ms', label: 'p95 ms', align: 'right', bar: true },
         { key: 'samples', label: 'Samples', align: 'right' },
       ],
       sql: `
@@ -88,23 +123,41 @@ export function buildQueries(dataset: string): QueryDef[] {
     },
     {
       key: 'cite_website_extract',
-      title: 'cite_website extraction time (last 24h, fresh only)',
-      description: 'Cache hits skipped (double3 = 0). double2 = extraction_ms.',
+      title: 'cite_website timing (last 24h, fresh only)',
+      description: 'Now splits fetch (double4) from extraction (double2). Cache hits skipped.',
+      render: 'table',
       columns: [
-        { key: 'p50_extract_ms', label: 'p50 extract ms', align: 'right' },
-        { key: 'p95_extract_ms', label: 'p95 extract ms', align: 'right' },
-        { key: 'avg_html_kb', label: 'Avg HTML KB', align: 'right' },
+        { key: 'metric', label: 'Metric' },
+        { key: 'p50', label: 'p50', align: 'right' },
+        { key: 'p95', label: 'p95', align: 'right', bar: true },
         { key: 'samples', label: 'Samples', align: 'right' },
       ],
       sql: `
         SELECT
-          round(quantileWeighted(0.50)(double2, _sample_interval), 1) AS p50_extract_ms,
-          round(quantileWeighted(0.95)(double2, _sample_interval), 1) AS p95_extract_ms,
-          round(avg(double1), 1) AS avg_html_kb,
+          'extraction_ms' AS metric,
+          round(quantileWeighted(0.50)(double2, _sample_interval), 1) AS p50,
+          round(quantileWeighted(0.95)(double2, _sample_interval), 1) AS p95,
           count() AS samples
         FROM ${dataset}
-        WHERE index1 = 'cite_website'
-          AND double3 = 0
+        WHERE index1 = 'cite_website' AND double3 = 0
+          AND timestamp >= NOW() - INTERVAL '24' HOUR
+        UNION ALL
+        SELECT
+          'fetch_ms' AS metric,
+          round(quantileWeighted(0.50)(double4, _sample_interval), 1) AS p50,
+          round(quantileWeighted(0.95)(double4, _sample_interval), 1) AS p95,
+          count() AS samples
+        FROM ${dataset}
+        WHERE index1 = 'cite_website' AND double3 = 0
+          AND timestamp >= NOW() - INTERVAL '24' HOUR
+        UNION ALL
+        SELECT
+          'html_size_kb' AS metric,
+          round(quantileWeighted(0.50)(double1, _sample_interval), 1) AS p50,
+          round(quantileWeighted(0.95)(double1, _sample_interval), 1) AS p95,
+          count() AS samples
+        FROM ${dataset}
+        WHERE index1 = 'cite_website' AND double3 = 0
           AND timestamp >= NOW() - INTERVAL '24' HOUR
         ${J}
       `,
@@ -113,9 +166,10 @@ export function buildQueries(dataset: string): QueryDef[] {
       key: 'signal_winners',
       title: 'cite_website title signal winners (last 30d, fresh only)',
       description: 'Which extraction signal claimed the title. Empty rows excluded.',
+      render: 'table',
       columns: [
         { key: 'title_winner', label: 'Signal' },
-        { key: 'hits', label: 'Hits', align: 'right' },
+        { key: 'hits', label: 'Hits', align: 'right', bar: true },
       ],
       sql: `
         SELECT
@@ -135,11 +189,12 @@ export function buildQueries(dataset: string): QueryDef[] {
       key: 'cache_hit_rate',
       title: 'Cache hit rate by endpoint (last 7d)',
       description: 'double2 = cache_hit for cite_book/cite_journal.',
+      render: 'table',
       columns: [
         { key: 'endpoint', label: 'Endpoint' },
         { key: 'hits', label: 'Hits', align: 'right' },
         { key: 'total', label: 'Total', align: 'right' },
-        { key: 'hit_rate', label: 'Hit rate', align: 'right' },
+        { key: 'hit_rate', label: 'Hit rate', align: 'right', bar: true },
       ],
       sql: `
         SELECT
@@ -158,10 +213,11 @@ export function buildQueries(dataset: string): QueryDef[] {
       key: 'errors',
       title: 'Errors by endpoint + code (last 24h)',
       description: 'Spikes here usually mean an upstream went sideways.',
+      render: 'table',
       columns: [
         { key: 'endpoint', label: 'Endpoint' },
         { key: 'code', label: 'Code' },
-        { key: 'errors', label: 'Count', align: 'right' },
+        { key: 'errors', label: 'Count', align: 'right', bar: true },
       ],
       sql: `
         SELECT
@@ -180,15 +236,18 @@ export function buildQueries(dataset: string): QueryDef[] {
       key: 'top_hosts',
       title: 'Top hosts cited (last 30d, cite_website only)',
       description: 'High-volume hosts are where extraction regressions hurt most.',
+      render: 'table',
       columns: [
         { key: 'host', label: 'Host' },
-        { key: 'requests', label: 'Requests', align: 'right' },
+        { key: 'requests', label: 'Requests', align: 'right', bar: true },
+        { key: 'avg_fetch_ms', label: 'Avg fetch ms', align: 'right' },
         { key: 'avg_extraction_ms', label: 'Avg extract ms', align: 'right' },
       ],
       sql: `
         SELECT
           blob4 AS host,
           count() AS requests,
+          round(avg(double4), 1) AS avg_fetch_ms,
           round(avg(double2), 1) AS avg_extraction_ms
         FROM ${dataset}
         WHERE index1 = 'cite_website'

--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -22,12 +22,35 @@ const queries = dataset ? buildQueries(dataset) : [];
 
 interface PanelResult {
   def: QueryDef;
-  rows?: Array<Record<string, unknown>>;
+  rows: Array<Record<string, unknown>>;
   error?: string;
+  /** Precomputed per-column max for any column flagged `bar: true`. */
+  barMaxes: Record<string, number>;
 }
 
 let panels: PanelResult[] = [];
 let configError: string | null = null;
+
+function emptyPanel(def: QueryDef, error?: string): PanelResult {
+  return { def, rows: [], error, barMaxes: {} };
+}
+
+function maxOf(rows: Array<Record<string, unknown>>, key: string): number {
+  let m = 0;
+  for (const r of rows) {
+    const v = Number(r[key]);
+    if (Number.isFinite(v) && v > m) m = v;
+  }
+  return m;
+}
+
+function decorate(def: QueryDef, rows: Array<Record<string, unknown>>): PanelResult {
+  const barMaxes: Record<string, number> = {};
+  for (const c of def.columns ?? []) {
+    if (c.bar) barMaxes[c.key] = maxOf(rows, c.key);
+  }
+  return { def, rows, barMaxes };
+}
 
 if (datasetInvalid) {
   configError = `ANALYTICS_DATASET env var is invalid: ${JSON.stringify(rawDataset)}. `
@@ -36,19 +59,19 @@ if (datasetInvalid) {
 } else if (!accountId || !token) {
   configError = 'Server is missing CF_ACCOUNT_ID and/or CF_API_TOKEN secret(s). '
     + 'Set both in Cloudflare Pages → Settings → Environment variables (encrypt as secrets).';
-  panels = queries.map((def) => ({ def }));
+  panels = queries.map((def) => emptyPanel(def));
 } else {
   const client = makeSqlClient({ accountId, token });
   panels = await Promise.all(
     queries.map(async (def) => {
       try {
         const r = await client.query(def.sql);
-        return { def, rows: r.data as Array<Record<string, unknown>> };
+        return decorate(def, r.data as Array<Record<string, unknown>>);
       } catch (e) {
         const msg = e instanceof SqlError
           ? `${e.status}: ${e.message}`
           : (e as Error).message;
-        return { def, error: msg };
+        return emptyPanel(def, msg);
       }
     }),
   );
@@ -56,8 +79,36 @@ if (datasetInvalid) {
 
 function fmt(v: unknown): string {
   if (v === null || v === undefined) return '—';
-  if (typeof v === 'number') return Number.isInteger(v) ? String(v) : v.toFixed(2);
+  if (typeof v === 'number') return Number.isInteger(v) ? v.toLocaleString() : v.toFixed(2);
   return String(v);
+}
+
+function pctOf(value: unknown, max: number): number {
+  if (max <= 0) return 0;
+  const v = Number(value);
+  if (!Number.isFinite(v) || v <= 0) return 0;
+  return Math.min(100, (v / max) * 100);
+}
+
+// Build a sparkline SVG path from rows. Returns an empty string if no data.
+function sparklinePath(rows: Array<Record<string, unknown>>, valueKey: string, width: number, height: number, pad: number): { line: string; area: string; lastValue: number; max: number } {
+  if (!rows.length) return { line: '', area: '', lastValue: 0, max: 0 };
+  const vals = rows.map((r) => Number(r[valueKey]) || 0);
+  const max = Math.max(...vals, 1);
+  const w = width - 2 * pad;
+  const h = height - 2 * pad;
+  const step = vals.length > 1 ? w / (vals.length - 1) : 0;
+  const points = vals.map((v, i) => {
+    const x = pad + i * step;
+    const y = pad + h - (v / max) * h;
+    return [x, y] as const;
+  });
+  const line = points.map(([x, y], i) => `${i === 0 ? 'M' : 'L'} ${x.toFixed(1)} ${y.toFixed(1)}`).join(' ');
+  // Area = line plus a baseline closure
+  const last = points[points.length - 1];
+  const first = points[0];
+  const area = `${line} L ${last[0].toFixed(1)} ${(pad + h).toFixed(1)} L ${first[0].toFixed(1)} ${(pad + h).toFixed(1)} Z`;
+  return { line, area, lastValue: vals[vals.length - 1], max };
 }
 ---
 
@@ -76,6 +127,8 @@ function fmt(v: unknown): string {
       --ink: #e7e9ee;
       --muted: #8b93a7;
       --accent: #7aa2f7;
+      --accent-soft: rgba(122, 162, 247, 0.18);
+      --accent-bar: rgba(122, 162, 247, 0.35);
       --error: #f7768e;
       --row-alt: #1a1e2a;
     }
@@ -88,10 +141,10 @@ function fmt(v: unknown): string {
       padding: 32px 24px;
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
-    header { margin-bottom: 32px; }
-    header h1 { margin: 0 0 4px; font-size: 22px; font-weight: 600; letter-spacing: -0.01em; }
-    header .meta { color: var(--muted); font-size: 12px; }
-    header .meta code {
+    header.page { margin-bottom: 24px; }
+    header.page h1 { margin: 0 0 4px; font-size: 22px; font-weight: 600; letter-spacing: -0.01em; }
+    header.page .meta { color: var(--muted); font-size: 12px; }
+    header.page .meta code {
       background: var(--panel);
       padding: 2px 6px;
       border-radius: 4px;
@@ -105,9 +158,68 @@ function fmt(v: unknown): string {
       border-radius: 8px;
       margin-bottom: 24px;
     }
+
+    /* Tiles strip */
+    .tiles {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+      gap: 12px;
+      margin-bottom: 16px;
+    }
+    .tile {
+      background: var(--panel);
+      border: 1px solid var(--panel-border);
+      border-radius: 8px;
+      padding: 14px 16px;
+    }
+    .tile .label {
+      font-size: 11px;
+      color: var(--muted);
+      text-transform: lowercase;
+      letter-spacing: 0.02em;
+    }
+    .tile .value {
+      font-size: 24px;
+      font-weight: 600;
+      color: var(--accent);
+      font-variant-numeric: tabular-nums;
+      margin-top: 4px;
+    }
+
+    /* Sparkline panel */
+    .panel-wide {
+      background: var(--panel);
+      border: 1px solid var(--panel-border);
+      border-radius: 8px;
+      padding: 16px;
+      margin-bottom: 16px;
+    }
+    .panel-wide h2 {
+      margin: 0 0 4px;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--accent);
+    }
+    .panel-wide p.desc {
+      margin: 0 0 12px;
+      color: var(--muted);
+      font-size: 11px;
+    }
+    .spark { width: 100%; height: 96px; display: block; }
+    .spark .area { fill: var(--accent-soft); }
+    .spark .line { fill: none; stroke: var(--accent); stroke-width: 1.5; }
+    .spark-meta {
+      display: flex;
+      justify-content: space-between;
+      color: var(--muted);
+      font-size: 11px;
+      margin-top: 4px;
+    }
+
+    /* Grid of regular panels */
     .grid {
       display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(380px, 1fr));
+      grid-template-columns: repeat(auto-fit, minmax(420px, 1fr));
       gap: 16px;
     }
     section.panel {
@@ -128,11 +240,7 @@ function fmt(v: unknown): string {
       color: var(--muted);
       font-size: 11px;
     }
-    table {
-      width: 100%;
-      border-collapse: collapse;
-      font-size: 12px;
-    }
+    table { width: 100%; border-collapse: collapse; font-size: 12px; }
     th, td {
       padding: 6px 8px;
       text-align: left;
@@ -144,6 +252,28 @@ function fmt(v: unknown): string {
     th { color: var(--muted); font-weight: 500; }
     tr:nth-child(even) td { background: var(--row-alt); }
     td.r, th.r { text-align: right; font-variant-numeric: tabular-nums; }
+
+    /* Inline horizontal bar inside a value cell */
+    td.bar-cell {
+      position: relative;
+      text-align: right;
+      font-variant-numeric: tabular-nums;
+    }
+    td.bar-cell .bar-fill {
+      position: absolute;
+      top: 50%;
+      right: 8px;
+      transform: translateY(-50%);
+      height: 18px;
+      background: var(--accent-bar);
+      border-radius: 3px;
+      z-index: 0;
+    }
+    td.bar-cell .bar-value {
+      position: relative;
+      z-index: 1;
+    }
+
     .empty { color: var(--muted); font-style: italic; padding: 8px 0; }
     .err {
       color: var(--error);
@@ -160,12 +290,11 @@ function fmt(v: unknown): string {
       font-size: 11px;
       text-align: center;
     }
-    footer a { color: var(--accent); }
   </style>
 </head>
 <body>
   <div class="wrap">
-    <header>
+    <header class="page">
       <h1>Citation Generator · Analytics</h1>
       <div class="meta">
         Dataset <code>{dataset}</code> · {new Date().toISOString()}
@@ -176,20 +305,67 @@ function fmt(v: unknown): string {
       <div class="config-error">{configError}</div>
     )}
 
+    {/* Tiles + sparkline appear first, then the regular grid */}
+    {panels.filter((p) => p.def.render === 'tiles').map(({ def, rows, error }) => (
+      <section>
+        {error ? (
+          <div class="config-error">{def.title}: {error}</div>
+        ) : !rows || rows.length === 0 ? (
+          <div class="config-error">No data in window for {def.title}.</div>
+        ) : (
+          <div class="tiles">
+            {rows.map((row) => (
+              <div class="tile">
+                <div class="label">{fmt(row[def.tilesLabelKey!])}</div>
+                <div class="value">{fmt(row[def.tilesValueKey!])}</div>
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    ))}
+
+    {panels.filter((p) => p.def.render === 'sparkline').map(({ def, rows, error }) => {
+      const data = rows ?? [];
+      const path = sparklinePath(data, def.sparklineValueKey!, 800, 96, 6);
+      return (
+        <div class="panel-wide">
+          <h2>{def.title}</h2>
+          <p class="desc">{def.description}</p>
+          {error ? (
+            <div class="err">{error}</div>
+          ) : data.length === 0 ? (
+            <div class="empty">No data in window.</div>
+          ) : (
+            <>
+              <svg class="spark" viewBox="0 0 800 96" preserveAspectRatio="none">
+                <path class="area" d={path.area} />
+                <path class="line" d={path.line} />
+              </svg>
+              <div class="spark-meta">
+                <span>{data.length} buckets · {def.sparklineWindowLabel}</span>
+                <span>max {fmt(path.max)} / last {fmt(path.lastValue)}</span>
+              </div>
+            </>
+          )}
+        </div>
+      );
+    })}
+
     <div class="grid">
-      {panels.map(({ def, rows, error }) => (
+      {panels.filter((p) => p.def.render === 'table').map(({ def, rows, error, barMaxes }) => (
         <section class="panel">
           <h2>{def.title}</h2>
           <p class="desc">{def.description}</p>
           {error ? (
             <div class="err">{error}</div>
-          ) : !rows || rows.length === 0 ? (
+          ) : rows.length === 0 ? (
             <div class="empty">No data in window.</div>
           ) : (
             <table>
               <thead>
                 <tr>
-                  {def.columns.map((c) => (
+                  {def.columns?.map((c) => (
                     <th class={c.align === 'right' ? 'r' : ''}>{c.label}</th>
                   ))}
                 </tr>
@@ -197,10 +373,15 @@ function fmt(v: unknown): string {
               <tbody>
                 {rows.map((row) => (
                   <tr>
-                    {def.columns.map((c) => (
-                      <td class={c.align === 'right' ? 'r' : ''} title={fmt(row[c.key])}>
-                        {fmt(row[c.key])}
-                      </td>
+                    {def.columns?.map((c) => (
+                      c.bar ? (
+                        <td class="bar-cell">
+                          <span class="bar-fill" style={`width: ${pctOf(row[c.key], barMaxes[c.key] || 0).toFixed(1)}%`}></span>
+                          <span class="bar-value">{fmt(row[c.key])}</span>
+                        </td>
+                      ) : (
+                        <td class={c.align === 'right' ? 'r' : ''} title={fmt(row[c.key])}>{fmt(row[c.key])}</td>
+                      )
                     ))}
                   </tr>
                 ))}
@@ -212,8 +393,8 @@ function fmt(v: unknown): string {
     </div>
 
     <footer>
-      Rendered server-side at request time. Auth via HTTP basic. <br/>
-      No JS, no client-side data — close the tab to log out.
+      Server-rendered. Auth via HTTP basic. <br/>
+      Test traffic (X-Mla-Test:1 header or ?nocache=1 query) is filtered before emission.
     </footer>
   </div>
 </body>

--- a/tests/test-context.test.ts
+++ b/tests/test-context.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { isTestRequest } from '../functions/lib/test-context';
+
+describe('isTestRequest', () => {
+  it('returns true on X-Mla-Test: 1 header', () => {
+    const r = new Request('https://m.com/api/cite-website?url=https://x.com', {
+      headers: { 'x-mla-test': '1' },
+    });
+    expect(isTestRequest(r)).toBe(true);
+  });
+
+  it('header is case-insensitive (Fetch API normalizes header names)', () => {
+    const r = new Request('https://m.com/api/format', {
+      method: 'POST',
+      headers: { 'X-MLA-Test': '1', 'content-type': 'application/json' },
+      body: '{}',
+    });
+    expect(isTestRequest(r)).toBe(true);
+  });
+
+  it('returns true on ?nocache=1 query param', () => {
+    const r = new Request('https://m.com/api/cite-website?url=https://x.com&nocache=1');
+    expect(isTestRequest(r)).toBe(true);
+  });
+
+  it('returns false on a normal request', () => {
+    const r = new Request('https://m.com/api/cite-website?url=https://x.com');
+    expect(isTestRequest(r)).toBe(false);
+  });
+
+  it('returns false on X-Mla-Test set to a value other than "1"', () => {
+    const r = new Request('https://m.com/api/cite-website?url=https://x.com', {
+      headers: { 'x-mla-test': 'true' },
+    });
+    expect(isTestRequest(r)).toBe(false);
+  });
+
+  it('returns false on nocache=0', () => {
+    const r = new Request('https://m.com/api/cite-website?url=https://x.com&nocache=0');
+    expect(isTestRequest(r)).toBe(false);
+  });
+
+  it('header takes priority over query (either signal sufficient)', () => {
+    const r = new Request('https://m.com/api/cite-website?url=https://x.com', {
+      headers: { 'x-mla-test': '1' },
+    });
+    expect(isTestRequest(r)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Three small coupled changes per user request:

### 1. Test-traffic opt-out

Any request carrying **`X-Mla-Test: 1`** header OR **`?nocache=1`** query param now skips the analytics emission entirely — no row written to the dataset. Real user traffic never carries either signal, so this is operator-only.

Handlers consult \`isTestRequest()\` (new helper in \`functions/lib/test-context.ts\`) once at the index.ts entry point and pass \`undefined\` for the analytics binding on test traffic. The writeEvent function then no-ops as it does for any other absent binding.

Existing rows from prior smoke tests (the 100+ \`wikipedia.org / heuristic\` events) stay in the dataset and will age out as the 30-day window slides. Going forward, anyone using \`?nocache=1\` during development won't add noise.

### 2. \`fetch_ms\` metric on cite_website (double4)

Splits network fetch time from extraction time so we can finally tell whether a slow citation came from a slow upstream (e.g., Wikipedia took 8 seconds) or our extraction pipeline (e.g., heuristic signal walked a huge DOM). Older cite_website rows have null for \`double4\`; the new \`cite_website_extract\` query handles that fine.

### 3. Dashboard rewrite at \`/admin/analytics\`

- **Big-number tiles** for the headline 24h counts (one tile per event type)
- **New events-per-hour sparkline panel** — at-a-glance traffic shape over the last 24h
- **Inline horizontal bars** in top-N table columns (proportional to per-panel max) for quick visual comparison without reading numbers
- **cite_website timing** panel now shows p50/p95 for fetch_ms, extraction_ms, and html_size_kb side-by-side
- **Top hosts** panel now exposes avg fetch_ms alongside extraction_ms

All rendering is server-side SVG/CSS — still no client JS, still gated by basic auth, still no data leaves the user's browser other than what the SQL queries return.

## On "should we add new metrics"

My pragmatic take: **fetch_ms is the one with obvious immediate value.** Everything else (CSL field completeness, time-to-first-cite, session tracking, etc.) is "might be useful someday" — premature without a concrete "I wish I knew X" question driving it. The current 5 events × ~10 dimensions can answer 90% of operational questions. Easy to add more later when a question surfaces.

## Test plan

- [x] \`npx vitest run\` — 40 files, 253 tests pass (7 new \`isTestRequest\` cases)
- [x] \`npm run build\` — Astro builds the rewritten page cleanly
- [ ] Post-merge: hit \`/admin/analytics\` and confirm the tiles + sparkline render, bars show, fetch_ms column populates as new traffic arrives
- [ ] Post-merge: \`curl 'https://mlagenerator.com/api/cite-website?url=https://en.wikipedia.org/wiki/Citation&nocache=1'\` and confirm no new row lands (check the headline count doesn't tick up)