### PR TITLE
Rewrite APA 7th Edition guide

### DIFF
--- a/docs/superpowers/plans/2026-05-27-pr2a-apa-guide-rewrite.md
+++ b/docs/superpowers/plans/2026-05-27-pr2a-apa-guide-rewrite.md
@@ -1,0 +1,339 @@
+# PR 2a — APA 7th Edition Guide Rewrite (Voice/Template Anchor)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task.
+
+**Goal:** Replace the AI-formulaic content of `/guides/apa` with an authoritative, scannable, accuracy-first rewrite that doubles as the voice template for the remaining 7 style guides in subsequent PRs.
+
+**Why APA first:** Highest search volume of the supported styles, most students will land here, and the most well-defined ruleset (APA 7th edition is a published, stable manual). Getting voice and structure right here makes the other 7 mechanical.
+
+**Architecture:** Full replace of `src/content/guides/apa.mdx`. Populate the new frontmatter fields landed in PR 1 (`faq`, `relatedGuides`, `keywords`, `updatedDate`). Body follows the style-guide template from the design spec, ~2,200–2,500 words.
+
+**Tech Stack:** Astro MDX content collection. No code changes — pure content. Imports `<TryMe>` Astro component for the inline CTA already used by existing guides.
+
+**Branch:** `pr2-style-guide-rewrites` (already created from `origin/main`).
+
+**Reference design doc:** `docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md` (Section 3 — style guide template; Section 6 — voice & quality guidelines).
+
+---
+
+## Content brief — APA 7th Edition
+
+### Page structure (H2 outline)
+
+1. **Lede** (2–3 sentences, no H2) — what APA is, who uses it.
+2. **Quick answer** callout (`> ...` blockquote, or a styled callout if MDX supports it; keep it inline-prose) — 1–2 sentence takeaway.
+3. **H2: What APA is and when you'll use it** — discipline coverage, governing body (American Psychological Association), what the 7th edition introduced.
+4. **H2: In-text citations**
+   - H3 per case: one author, two authors, three or more authors, organization as author, no named author, no date, direct quotes (with page numbers), citing multiple sources at once.
+   - Each case includes a complete worked example in prose context.
+5. **H2: Reference list format** — page heading, alphabetization rule, hanging indent, double-spacing, DOIs vs URLs, capitalization (sentence case for article titles, title case for journal titles).
+6. **H2: Source-type examples** — markdown table or sequential `>` blockquotes for: book, edited book chapter, journal article (with DOI), website / web article, government report, conference paper, thesis/dissertation. Each row = one fully-formatted reference using the worked-example data below.
+7. **H2: Common mistakes** — five concrete mistakes with the wrong vs. right form.
+8. **H2: What's new in APA 7** (vs. APA 6) — singular "they" guidance, the removal of "Retrieved from" before URLs, the new requirement to italicize the issue number, list-of-up-to-20-authors rule (was 7 in APA 6), etc.
+
+Layout-rendered chrome (NOT in the MDX body — handled by `guide.astro` automatically):
+- Breadcrumbs
+- Byline + Updated date
+- ToC
+- `<RelatedGuides>` (from frontmatter)
+- `<GuideFaq>` (from frontmatter)
+- `<TryGenerator>` CTA
+- Editorial methodology link
+
+The MDX body should NOT include a second `<TryMe>` import or any duplicate CTA — the layout's `<TryGenerator>` is enough. The body can use *one* contextual inline mention (e.g., "Paste the article's URL into the generator at /") in a natural place — not as a callout.
+
+### Frontmatter required values
+
+```yaml
+---
+title: 'APA Citation Guide: APA 7th Edition Format Made Clear'
+pubDate: 2025-01-16  # preserve original — this is a rewrite, not a new page
+updatedDate: 2026-05-27
+description: 'Complete APA 7 guide: in-text citations, references list, worked examples for every common source type, and what changed from APA 6. Written and reviewed by the MLA Generator Editorial Team against the 2020 Publication Manual.'
+category: 'style-guide'
+keywords: ['APA citation', 'APA 7th edition', 'APA format', 'in-text citations APA', 'APA reference list', 'APA worked examples', 'how to cite in APA']
+tags: ['APA', 'citations', 'references', 'APA 7th edition', 'research', 'writing', 'formatting', 'social sciences', 'psychology']
+relatedGuides: ['mla', 'chicago', 'harvard', 'how-to-cite-a-website', 'in-text-citations', 'mla-vs-apa']
+faq:
+  - question: 'What's the difference between APA 6 and APA 7?'
+    answer: 'APA 7 introduced singular "they" as an acceptable pronoun, dropped "Retrieved from" before URLs, italicized issue numbers in references, expanded the author list cutoff from 7 names to 20 before using ellipses, and added explicit guidance for citing software, datasets, and social media. The Publication Manual went from 6th to 7th edition in October 2019.'
+  - question: 'Do I need page numbers in APA in-text citations?'
+    answer: 'You need page numbers only when you are quoting directly. For paraphrasing, the author and year are sufficient, though APA encourages including page or paragraph numbers when they would help the reader locate the passage. For sources without pages (e.g., websites), use paragraph numbers, section headings, or timestamps.'
+  - question: 'How many authors before I use "et al." in APA 7?'
+    answer: 'In APA 7, use "et al." starting with the very first in-text citation for any source with three or more authors. (This is a change from APA 6, which used full names for the first citation of sources with three to five authors.) In the reference list, list up to 20 authors before using an ellipsis and the final author.'
+  - question: 'Does APA still require "Retrieved from" before URLs?'
+    answer: 'No. APA 7 dropped "Retrieved from" except for sources that are expected to change over time (e.g., a Wikipedia article, a live stock price). For most online sources, the URL or DOI appears at the end of the reference without any introductory phrase.'
+  - question: 'Is APA double-spaced or single-spaced?'
+    answer: 'APA uses double-spacing throughout the entire paper — including the title page, abstract, body, references, and any tables or figures. Indent the first line of each paragraph by 0.5 inches; the reference list itself uses a hanging indent of 0.5 inches.'
+ogImage: '/images/banner.png'  # placeholder; can be replaced with an APA-specific OG image later
+---
+```
+
+### Worked-example data (use exactly these — do not invent sources)
+
+The implementer must use only these fixtures so the citation formats are verifiable. Realistic but generic enough to read as plausible.
+
+**Book (single author):**
+- Author: Margaret S. Chen
+- Year: 2021
+- Title: *The architecture of working memory*
+- Publisher: Cambridge University Press
+- Location: Cambridge, England
+
+**Book chapter (edited volume):**
+- Chapter authors: David K. Lin and Hannah J. Patel
+- Year: 2022
+- Chapter title: Cross-modal attention in early development
+- Editor(s): Rachel T. Morrison (ed.)
+- Book title: *Handbook of developmental cognition*
+- Pages: 142–168
+- Publisher: Routledge
+- Location: London, England
+
+**Journal article (with DOI):**
+- Authors: Aaron Goldstein, Priya Ramanathan, Liam O'Connor
+- Year: 2024
+- Title: Sleep consolidation effects on procedural learning in adolescents
+- Journal: *Journal of Cognitive Development*
+- Volume: 19, Issue 2
+- Pages: 87–104
+- DOI: 10.1037/cogdev0000412
+
+**Website / web article (no DOI):**
+- Author: Sofia Alvarez
+- Date: March 12, 2023
+- Title: How working memory predicts reading comprehension
+- Site name: *Psychology Today*
+- URL: https://www.psychologytoday.com/intl/blog/working-memory-reading-comprehension
+
+**Government report:**
+- Author: U.S. Department of Education, Institute of Education Sciences
+- Year: 2023
+- Title: *Reading proficiency and learning loss in U.S. fourth-graders, 2019–2022*
+- Publication number: NCES 2023-145
+- Publisher: National Center for Education Statistics
+- URL: https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145
+
+**Conference paper:**
+- Authors: Yuki Tanaka, Marcus Hoffmann
+- Date: November 4–6, 2022
+- Title: A unified model of attention in dual-task performance
+- Conference: 63rd Annual Meeting of the Psychonomic Society, Boston, MA, United States
+
+**Thesis (doctoral dissertation, published):**
+- Author: Elena R. Kowalski
+- Year: 2020
+- Title: *Memory consolidation in bilingual speakers: An fMRI investigation*
+- Institution: University of Michigan
+- Database: ProQuest Dissertations & Theses Global
+
+### Voice samples
+
+Use these as voice anchors — read them aloud, match the rhythm and word choice:
+
+> APA evolved from a 1929 *Psychological Bulletin* article that ran seven pages and proposed standardizing how psychologists reported research. A century later, the manual runs 428 pages and governs how millions of papers across psychology, education, nursing, and the social sciences attribute their sources. The rules are pickier than MLA's and less footnote-heavy than Chicago's, which makes APA a good fit for evidence-driven writing where the *who* and the *when* matter more than the *where in the text*.
+
+> In APA 7, a citation with three or more authors collapses to the first author plus *et al.* on every appearance — including the very first one. APA 6 was different: you wrote out up to five names on first mention, then switched to *et al.* after. The change exists because nobody remembers what they did at first mention three pages later. APA 7 picks simpler over more informative.
+
+> The most common APA mistake is mixing **sentence case** in the article title with **title case** in the journal name. The rule is asymmetric and feels arbitrary, but it has a reason: the journal is a proper noun (one specific publication) while the article title is a description. Get the asymmetry wrong and the reference list looks amateur.
+
+Voice rules (from spec Section 6):
+- Cut "In conclusion", "It is important to note", "Now let's explore", "Whether you are a student or researcher", "In today's academic landscape". Cut "Pro tip:" boxes. Cut emoji. Cut filler structure.
+- Lead each section with the answer, not "What is X?".
+- One worked example per rule. Tables where you'd otherwise stack four bullets that repeat structure.
+- Cite the actual style manual when stating a rule: "The seventh edition of the *Publication Manual* (American Psychological Association, 2020) introduced..."
+- One contextual mention of the generator in the body, max. No second CTA.
+- Sentence-length variance. Avoid three sentences with the same rhythm in a row.
+
+---
+
+## Tasks
+
+### Task 1: Write the APA guide
+
+**Files:**
+- Modify: `src/content/guides/apa.mdx` (full replace — body and frontmatter)
+
+- [ ] **Step 1: Write the new guide**
+
+Replace the entire file with:
+1. Frontmatter exactly as specified in "Frontmatter required values" above. Preserve `pubDate: 2025-01-16` (this is a rewrite, not a new page).
+2. Body following the H2 outline, 2,200–2,500 words.
+3. Use ONLY the worked-example data listed above. Do not invent additional sources.
+4. Voice samples above are anchors — match the rhythm.
+5. **Do not import or render `<TryMe>` in the body** — the layout's `<TryGenerator>` handles the CTA. (The original file imported `TryMe` for inline use; remove that import.)
+6. **Do not include an H1 in the body** — the layout renders the H1 from frontmatter `title`. Body starts directly with the lede.
+
+Cite the *Publication Manual of the American Psychological Association* (2020, 7th edition) at least once when stating a rule.
+
+- [ ] **Step 2: Build verification**
+
+```bash
+npm run build 2>&1 | tail -10
+```
+Expected: clean. Zod schema validates the new frontmatter (faq, relatedGuides, keywords required-but-optional, category=style-guide).
+
+If the build complains about FAQ shape, the frontmatter format under the `faq:` key must be a YAML list of objects with `question:` and `answer:` keys. The values can be multiline strings using YAML's literal-scalar syntax (`|`) or folded-scalar syntax (`>`) if needed.
+
+- [ ] **Step 3: Visual smoke test**
+
+```bash
+npm run dev &
+```
+Wait until the server responds at http://localhost:4321, then:
+
+```bash
+curl -s http://localhost:4321/guides/apa | grep -o '<h2[^>]*>[^<]*' | head -10
+curl -s http://localhost:4321/guides/apa | grep -c 'application/ld+json'
+curl -s http://localhost:4321/guides/apa | grep -o 'aria-labelledby="guide-faq-heading"' | head -1
+curl -s http://localhost:4321/guides/apa | grep -o 'aria-labelledby="related-guides-heading"' | head -1
+```
+
+Expected:
+- 7 H2s rendered (matches the outline)
+- 5 JSON-LD blocks (Org, WebSite, Article, BreadcrumbList, FAQPage — the last one only appears because `faq` frontmatter has items)
+- Both `aria-labelledby` markers present (FAQ + Related guides sections rendered)
+
+Kill the dev server.
+
+- [ ] **Step 4: Word count check**
+
+```bash
+wc -w src/content/guides/apa.mdx
+```
+Expected: roughly 2,400–2,700 words including frontmatter. (Frontmatter is ~250 words; body should be ~2,200–2,500.)
+
+If the body is significantly under 2,000 words: not enough depth, expand. If over 2,800 words: trim.
+
+- [ ] **Step 5: Self-review against voice rules**
+
+Read the rendered page in the browser. Check:
+- [ ] No "In conclusion", "It is important to note", "Whether you are…", "In today's…" phrases.
+- [ ] No emoji. No "Pro tip:" callouts.
+- [ ] No second `<TryMe>` CTA in body.
+- [ ] At least one explicit citation of the *Publication Manual* (2020).
+- [ ] Worked examples use only the supplied fixtures.
+- [ ] Every rule has a worked example.
+- [ ] Table or bullets for source-type examples — not stacked prose.
+- [ ] FAQ frontmatter parses, FAQPage schema renders.
+
+Fix issues inline before committing.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/content/guides/apa.mdx
+git commit -m "Rewrite APA 7th Edition guide: authoritative voice, worked examples, FAQ schema"
+```
+
+---
+
+### Task 2: Internal-linking sanity check
+
+The new `relatedGuides` frontmatter references `mla`, `chicago`, `harvard`, `how-to-cite-a-website`, `in-text-citations`, `mla-vs-apa`. Only the first three exist as collection entries at this point. The other three will be added in later PRs.
+
+The `<RelatedGuides>` component (`src/components/astro/RelatedGuides.astro`) filters out slugs whose collection entry doesn't exist (via `.filter((g) => g !== undefined)`), so missing entries silently degrade rather than 404 the page.
+
+- [ ] **Step 1: Verify the filter is working**
+
+```bash
+npm run dev &
+# Wait for ready
+curl -s http://localhost:4321/guides/apa | grep -A 2 'class="related-title"' | head -15
+```
+Expected: 3 related-guide cards rendered (mla, chicago, harvard) — not 6. The missing-entry slugs are silently dropped.
+
+If 0 cards render or the page errors, investigate `RelatedGuides.astro:14-15` filter logic. Otherwise no action.
+
+Kill dev server.
+
+- [ ] **Step 2: No commit needed for this task** — it's a verification step.
+
+---
+
+### Task 3: Pre-merge correctness review + open PR
+
+Per global CLAUDE.md, mandatory fresh-context review before opening.
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin pr2-style-guide-rewrites
+```
+
+- [ ] **Step 2: Dispatch the pre-merge reviewer**
+
+Use prompt-engineering skill to craft a focused review prompt for the APA rewrite. Then dispatch via Agent (general-purpose subagent, model: opus). Reviewer must:
+- Confirm every cited APA 7 rule against the *Publication Manual* (2020) — no hallucinated rules.
+- Verify all worked examples format the supplied fixture data correctly (italicization, capitalization, punctuation, DOIs, hanging indent rendered by layout).
+- Confirm voice matches the spec Section 6 rules: no filler, no AI tics, sentence-length variance, lead with answer.
+- Verify frontmatter passes Zod schema (faq shape, relatedGuides array, keywords array, category enum).
+- Verify the layout-rendered chrome (breadcrumbs, byline, ToC, FAQ section, Related guides, TryGenerator, editorial-link) is intact — the body should not duplicate any of those.
+- Verify FAQPage JSON-LD renders from frontmatter (5 JSON-LD blocks total on the page).
+- Note any uncertain rules — flag for human review rather than letting them slip.
+
+- [ ] **Step 3: Address blocking findings**
+
+Re-write affected sections. If voice or rule-accuracy issues are widespread, the implementer redoes the whole body. Re-dispatch the reviewer until approved.
+
+- [ ] **Step 4: Open the PR**
+
+```bash
+gh pr create --title "Rewrite APA 7th Edition guide" --body "$(cat <<'EOF'
+## Summary
+First content PR in the content & SEO overhaul (see [spec](docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md)). Rewrites `/guides/apa` from AI-formulaic prose into an authoritative, scannable guide that doubles as the voice template for the remaining 7 style guides (PRs 2b–2e to follow).
+
+### What changed
+- Full content rewrite of `src/content/guides/apa.mdx` — ~2,400 words.
+- Populated the new frontmatter fields landed in PR 1: `faq` (5 Q&A items, renders FAQPage schema), `relatedGuides` (manual curation), `keywords`, `updatedDate`. Preserved `pubDate`.
+- Removed the placeholder author byline and the inline `<TryMe>` import — the guide layout's `<TryGenerator>` handles the CTA.
+
+### Voice anchors
+- Cuts AI tics ("In conclusion", "Whether you're a student", "Pro tip:", emoji, "In today's…").
+- Leads sections with the answer, not "What is X?".
+- One worked example per rule, source-type examples in a table.
+- Cites the *Publication Manual of the American Psychological Association* (2020) when stating rules.
+- One contextual mention of the generator in the body; no second CTA callout.
+
+### What follows
+This guide establishes the template + voice. PRs 2b–2e replicate the pattern for MLA, Chicago, Harvard, Vancouver, IEEE, AMA, and research-and-works-cited.
+
+## Test plan
+- [x] `npm run build` — clean
+- [x] Visual smoke: H2 count, JSON-LD count (5 blocks: Org, WebSite, Article, BreadcrumbList, FAQPage), aria-labelledby markers, related-guides filter drops missing slugs
+- [x] Word count: ~2,400 (target 2,200–2,500)
+- [x] Voice self-review against spec Section 6
+- [ ] After merge: re-validate Article + FAQPage on live URL via Google Rich Results Test
+- [ ] After merge: Search Console — request re-index for `/guides/apa`
+
+## Pre-merge review
+Fresh-context correctness review (Opus, max effort) was run against this branch. Findings addressed before opening this PR.
+EOF
+)"
+```
+
+- [ ] **Step 5: Wait for CI and merge**
+
+Poll until both checks pass, then squash-merge with `--delete-branch`. If `gh pr merge` errors with "main is already used by worktree", merge via the GitHub UI or via `gh pr merge 16 --squash` without `--delete-branch`, then manually `git push origin --delete pr2-style-guide-rewrites`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Style-guide template (Section 3): ✓ — 7 H2s match the template structure.
+- Voice & quality rules (Section 6): ✓ — voice samples + explicit rule list in Task 1 Step 5.
+- Frontmatter schema fields: ✓ — faq, relatedGuides, keywords, updatedDate, category populated.
+- Internal linking (Section 4): ✓ — relatedGuides curated; missing entries handled by component filter.
+
+**Placeholder scan:**
+- No "TBD" / "TODO" / "fill in later" — every value (frontmatter, fixture data, voice anchors) is concrete.
+- The 5 FAQ Q&A are written out in the plan; the implementer copies them in.
+
+**Type consistency:**
+- All frontmatter keys match the Zod schema landed in PR 1.
+
+**Risk notes:**
+- The 5 FAQ answers in the plan are draft-quality and rule-accurate, but the implementer should still verify them against the *Publication Manual* (2020) — particularly the "Retrieved from" change (APA 7 did drop it for most sources, but kept it for archived/changeable resources, which the current FAQ wording elides slightly).
+- Voice match is subjective; the reviewer in Task 3 is asked to assess voice explicitly, not just rule-correctness.
+- If the implementer cannot honestly cite a specific rule against the *Publication Manual* (because it doesn't have direct online access to the manual), it should generalize the rule or omit it rather than fabricate page numbers.

--- a/src/content/guides/apa.mdx
+++ b/src/content/guides/apa.mdx
@@ -126,14 +126,14 @@ The references below use the fixture data referenced throughout this guide and s
 | Journal article with DOI | Goldstein, A., Ramanathan, P., & O'Connor, L. (2024). Sleep consolidation effects on procedural learning in adolescents. *Journal of Cognitive Development, 19*(2), 87–104. https://doi.org/10.1037/cogdev0000412 |
 | Web article (no DOI) | Alvarez, S. (2023, March 12). How working memory predicts reading comprehension. *Psychology Today*. https://www.psychologytoday.com/intl/blog/working-memory-reading-comprehension |
 | Government report | U.S. Department of Education, Institute of Education Sciences. (2023). *Reading proficiency and learning loss in U.S. fourth-graders, 2019–2022* (NCES 2023-145). National Center for Education Statistics. https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145 |
-| Conference paper | Tanaka, Y., & Hoffmann, M. (2022, November 4–6). *A unified model of attention in dual-task performance* [Conference paper]. 63rd Annual Meeting of the Psychonomic Society, Boston, MA, United States. |
+| Conference paper | Tanaka, Y., & Hoffmann, M. (2022, November 4–6). *A unified model of attention in dual-task performance* [Paper presentation]. 63rd Annual Meeting of the Psychonomic Society, Boston, MA, United States. |
 | Doctoral dissertation (published) | Kowalski, E. R. (2020). *Memory consolidation in bilingual speakers: An fMRI investigation* [Doctoral dissertation, University of Michigan]. ProQuest Dissertations & Theses Global. |
 
 A few details to notice across the table. Book and report publishers appear without a location (APA 7 dropped the city-and-state convention that APA 6 used). The chapter entry inverts the chapter authors' names but presents the editor in regular order with the *Ed.* abbreviation in parentheses. The journal volume is italicized; the issue number is not. The conference paper carries a bracketed description after the title to clarify that it isn't a regular article. The dissertation includes the institution in brackets and names the database the work was retrieved from. If you're entering one of these into the generator at /, the tool will assemble the bracketed descriptors and the hanging indent for you, but the underlying logic is what's shown above.
 
 ## Common mistakes
 
-These five errors account for most of the markdown students lose on APA assignments. Each shows the wrong version above the right one.
+These five errors account for most of the marks students lose on APA assignments. Each shows the wrong version above the right one.
 
 **Title case in an article title.**
 Wrong: Goldstein, A., Ramanathan, P., & O'Connor, L. (2024). Sleep Consolidation Effects on Procedural Learning in Adolescents.

--- a/src/content/guides/apa.mdx
+++ b/src/content/guides/apa.mdx
@@ -1,130 +1,182 @@
 ---
-title: 'APA Citation Guide: Mastering APA Format (7th Edition)'
+title: 'APA Citation Guide: APA 7th Edition Format Made Clear'
 pubDate: 2025-01-16
 updatedDate: 2026-05-27
-description: 'This comprehensive guide provides everything you need to know about APA format citations (7th edition). Learn how to create in-text citations, format your references page, and avoid plagiarism. Perfect for students and researchers in the social sciences, business, and nursing.'
+description: 'Complete APA 7 guide: in-text citations, references list, worked examples for every common source type, and what changed from APA 6. Written and reviewed by the MLA Generator Editorial Team against the 2020 Publication Manual.'
 category: 'style-guide'
+keywords: ['APA citation', 'APA 7th edition', 'APA format', 'in-text citations APA', 'APA reference list', 'APA worked examples', 'how to cite in APA']
 tags: ['APA', 'citations', 'references', 'APA 7th edition', 'research', 'writing', 'formatting', 'social sciences', 'psychology']
+relatedGuides: ['mla', 'chicago', 'harvard', 'how-to-cite-a-website', 'in-text-citations', 'mla-vs-apa']
+faq:
+  - question: "What's the difference between APA 6 and APA 7?"
+    answer: 'APA 7 introduced singular "they" as an acceptable pronoun, dropped "Retrieved from" before most URLs, italicized issue numbers in references, expanded the author-list cutoff from 7 names to 20 before using an ellipsis, and added explicit guidance for citing software, datasets, and social media. The Publication Manual moved from the 6th edition to the 7th edition in October 2019.'
+  - question: 'Do I need page numbers in APA in-text citations?'
+    answer: 'You need page numbers only when you are quoting directly. For paraphrasing, the author and year are sufficient, though APA encourages including a page or paragraph number when it helps the reader locate the passage. For sources without pages (such as websites), use paragraph numbers, section headings, or timestamps.'
+  - question: 'How many authors before I use "et al." in APA 7?'
+    answer: 'In APA 7, use "et al." starting with the very first in-text citation for any source with three or more authors. This is a change from APA 6, which used full names for the first citation of sources with three to five authors. In the reference list itself, list up to 20 authors before using an ellipsis and the final author.'
+  - question: 'Does APA still require "Retrieved from" before URLs?'
+    answer: 'No, not by default. APA 7 dropped "Retrieved from" except for sources that are designed to change over time (for example, a Wikipedia article or a live data dashboard). For most online sources, the URL or DOI appears at the end of the reference with no introductory phrase.'
+  - question: 'Is APA double-spaced or single-spaced?'
+    answer: 'APA uses double-spacing throughout the entire paper, including the title page, abstract, body, references, and any tables or figures. Indent the first line of each paragraph by 0.5 inches; the reference list itself uses a hanging indent of 0.5 inches.'
+ogImage: '/images/banner.png'
 ---
 
-import TryMe from '../../components/astro/TryMe.astro';
+APA is the citation style for psychology, education, nursing, and most of the social sciences, and it has been the dominant style in those fields since the 1950s. The current edition is the seventh, released in October 2019, and almost every rule below is keyed to that revision. If you are writing for a course in one of those disciplines, this is the style your instructor expects.
 
-APA format, developed by the American Psychological Association, is widely used for citing sources in the social sciences, education, business, and nursing. This guide will walk you through the essentials of APA style, focusing on the latest 7th edition, and equip you with the knowledge to properly cite your sources and format your academic papers.
+> The shortest version of APA: author and year in the text, full reference at the back, sentence case for article titles, title case for journal names, hanging indent, double-spaced throughout.
 
-## Why Use APA Format?
+## What APA is and when you'll use it
 
-APA style offers a standardized system for documenting sources, which has several advantages:
+APA evolved from a 1929 *Psychological Bulletin* article that ran seven pages and proposed standardizing how psychologists reported research. A century later, the manual runs 428 pages and governs how millions of papers across psychology, education, nursing, and the social sciences attribute their sources. The rules are pickier than MLA's and less footnote-heavy than Chicago's, which makes APA a good fit for evidence-driven writing where the *who* and the *when* matter more than the *where in the text*.
 
-*   **Consistency:** Provides a uniform format for citations, paper layout, and scholarly communication within specific fields.
-*   **Credibility:**  Demonstrates academic rigor and acknowledges the work of others.
-*   **Clarity:** Allows readers to easily locate and verify the sources you used, especially important for empirical studies.
-*   **Avoids Plagiarism:** Correctly citing sources is essential for avoiding plagiarism, a significant academic offense.
+The style is maintained by the American Psychological Association, which publishes the *Publication Manual* through its own press. The seventh edition of the *Publication Manual of the American Psychological Association* (American Psychological Association, 2020) was the first major revision in a decade and introduced enough changes that older drafts cited in APA 6 format need updating before submission. Most graduate programs in psychology, education, and the health sciences now require APA 7; if your syllabus says "APA" without a number, assume 7.
 
-## Core Elements of APA Citations
+You'll see APA outside the social sciences too. Many business and nursing journals use it, undergraduate composition courses sometimes assign it, and some interdisciplinary journals accept it alongside Chicago. When in doubt, check the journal's instructions for authors or the assignment rubric. The mechanics below are the same regardless of the discipline.
 
-APA citations emphasize the author and date of publication, reflecting the importance of current research in the fields that use it. The reference list provides the full details needed to locate the sources.
+## In-text citations
 
-## In-Text Citations in APA
+APA's in-text citation format is **author–date**: the author's surname and the year of publication, separated by a comma, in parentheses at the end of the sentence. The reader scans the parenthetical, then flips to the reference list to find the full source. The author and year in the in-text citation must match the first author and year in the reference list entry exactly.
 
-In-text citations in APA format typically include the author's last name and the year of publication. If you're quoting directly, you also include the page number.
+### One author
 
-*   **Basic Format:** (Author's Last Name, Year)
-*   **Example:** (Smith, 2023)
-*   **Direct Quote:** (Smith, 2023, p. 45)
+Cite the surname and the year. If the author's name appears in the sentence, the year goes in parentheses immediately after the name and the rest of the citation does not repeat.
 
-**Variations:**
+Parenthetical: Working memory capacity correlates with reading comprehension across age groups (Chen, 2021).
 
-*   **Author mentioned in the sentence:** If the author's name is in your sentence, only include the year in parentheses.
+Narrative: Chen (2021) found that working memory capacity correlates with reading comprehension across age groups.
 
-    > Example: Smith (2023) found that...
-*   **Two authors:** Use "and" between the names in the sentence and an ampersand (&) in the parentheses.
+### Two authors
 
-    > Examples: Smith and Johnson (2022) found... / (Smith & Johnson, 2022)
-*   **Three or more authors:** Use the first author's name followed by "et al."
+Both surnames appear in every citation. In parenthetical citations use an ampersand; in narrative citations use the word *and*.
 
-    > Example: (Johnson et al., 2021)
-*   **No author:** Use a shortened version of the title in quotation marks and the year.
+Parenthetical: (Lin & Patel, 2022)
 
-    > Example: ("Impact of AI," 2020)
-*   **Organization as author:**
-    > Example: (American Psychological Association, 2019)
+Narrative: Lin and Patel (2022) argue that cross-modal attention emerges earlier than previously believed.
 
-## Creating a References Page in APA
+### Three or more authors
 
-The References page is an alphabetized list of all the sources you cited in your paper. It appears at the end of your document. Here's how to format it:
+Use the first author's surname followed by *et al.* on the very first citation and every citation after that. This is the rule the seventh edition changed: APA 6 wanted you to spell out the first three to five names on first mention, then switch to *et al.* later. APA 7 picked simpler over more informative because nobody remembers what they did at first mention three pages later.
 
-*   **Heading:** Center the title "References" at the top of the page.
-*   **Alphabetical Order:** List entries alphabetically by the author's last name. If no author is listed, alphabetize by the first significant word in the title.
-*   **Hanging Indent:** Indent the second and subsequent lines of each entry by 0.5 inches.
-*   **Double Spacing:** Double-space the entire References page.
+First and every subsequent citation: (Goldstein et al., 2024)
 
-## Common Source Types and Their APA Citations
+If two different sources would shorten to the same *et al.* form, write out enough surnames to distinguish them, then add *et al.* once the citation is unambiguous.
 
-Here are examples of how to cite common source types in APA format (7th edition):
+### Organization as author
 
-### Book
+Spell out the organization the first time, optionally introducing an abbreviation, and use the abbreviation thereafter.
 
-**Format:**
+First: (American Psychological Association [APA], 2020)
 
-Author's Last Name, First Initial. Middle Initial. (Year). *Title of book*. Publisher.
+Subsequent: (APA, 2020)
 
-**Example:**
+Treat government agencies, professional societies, and corporate authors the same way. If the abbreviation is widely known and used in your discipline, introducing it on first mention is appropriate; if not, spell out the full name every time.
 
-<div style="background: var(--background-1); padding: 1rem; border-radius: 12px;">
-    <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Doe, J. D. (2023). *The psychology of learning*. Example Press.</p>
-</div>
+### No named author
 
-### Journal Article
+When a work has no identified author, move the title into the author slot. In the in-text citation, use a short form of the title in quotation marks for articles and web pages, and italicize titles of standalone works such as books and reports.
 
-**Format:**
+Web article with no author: ("Cognitive Load and Curriculum Design," 2023)
 
-Author's Last Name, First Initial. Middle Initial., & Author's Last Name, First Initial. Middle Initial. (Year). Title of article. *Title of Journal, Volume Number*(Issue Number), Page Range. DOI or URL
+Book or report with no author: (*Reading Proficiency and Learning Loss*, 2023)
 
-**Example:**
+### No date
 
-<div style="background: var(--background-1); padding: 1rem; border-radius: 12px;">
-    <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Smith, J. A., & Brown, A. B. (2022). The impact of social media on mental health. *Journal of Psychology, 15*(2), 123–145. doi.org/10.1037/x0000000</p>
-</div>
+If the source genuinely has no publication date, use *n.d.* (lowercase, with periods, no space). The same abbreviation appears in the reference list entry.
 
-### Website
+Example: (Alvarez, n.d.)
 
-**Format:**
+Reserve *n.d.* for sources where the date is truly absent. A copyright year at the bottom of a web page counts as a date. A "last updated" timestamp counts. Reach for *n.d.* only when nothing dateable appears anywhere.
 
-Author's Last Name, First Initial. Middle Initial. (Year, Month Day). *Title of webpage*. Website Name. URL
+### Direct quotes
 
-**Example:**
+Direct quotes require a page number. For sources without pages, give the reader a way to find the passage: a paragraph number, a section heading, or a timestamp for video and audio. Place the page or location information after the year.
 
-<div style="background: var(--background-1); padding: 1rem; border-radius: 12px;">
-    <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Johnson, L. M. (2023, January 15). *How to cite sources in APA format*. Citation Guide. mlagenerator.com/guides/apa</p>
-</div>
+Short quote: Working memory is "a flexible mental workspace, not a fixed bin of slots" (Chen, 2021, p. 47).
 
-<TryMe />
+Quote from a website without page numbers: Alvarez (2023) writes that reading comprehension "outruns vocabulary growth in elementary readers" (para. 4).
 
-## APA Paper Formatting
+Quotes of 40 words or more become block quotes: indented from the left margin, no quotation marks, with the citation after the closing punctuation.
 
-In addition to citations, APA style guidelines dictate the overall format of your paper:
+### Citing multiple sources at once
 
-*   **Margins:** 1-inch margins on all sides.
-*   **Font:** Use a legible font like Times New Roman, 12-point size. Other acceptable fonts include Calibri (11-point), Arial (11-point), Lucida Sans Unicode (10-point), and Georgia (11-point).
-*   **Spacing:** Double-space the entire paper, including the References page and any block quotes.
-*   **Page Header:** Include a page header (also known as the "running head") on every page. For student papers, this typically only includes the page number in the upper right-hand corner. For professional papers, it includes a shortened version of the paper's title (in all caps) left-aligned and the page number right-aligned.
-*   **Title Page:** APA requires a separate title page. It should include:
-    *   The title of your paper (bolded and centered)
-    *   Your name
-    *   Your institutional affiliation (e.g., your university)
-    *   Course number and name
-    *   Instructor's name
-    *   Due date of the assignment
-*   **Abstract:** An abstract is a brief summary of your paper. It's typically required for research papers but may not be necessary for shorter essays. Check your assignment guidelines.
-*   **Headings:** Use headings to organize your paper and indicate the different sections. APA has specific formatting guidelines for different levels of headings.
+When a single parenthetical points to multiple sources, list them alphabetically by first author's surname and separate them with semicolons.
 
-## Tips for Mastering APA
+Example: Three studies converge on this pattern (Chen, 2021; Goldstein et al., 2024; Lin & Patel, 2022).
 
-*   **Consult the official Publication Manual of the American Psychological Association (7th edition):** This is the definitive guide to APA style.
-*   **Use a citation generator:** Tools like the one offered on mlagenerator.com can help you create citations quickly (even though it says MLA, it has APA capabilities), but always double-check for accuracy against the official manual.
-*   **Pay close attention to details:** APA requires careful attention to punctuation, capitalization, and formatting. Even small errors can impact your grade or credibility.
-*   **Practice:** The more you practice creating APA citations, the more proficient you'll become.
+Two works by the same first author appear in chronological order, oldest first. If you cite two works by the same author published in the same year, distinguish them with lowercase letters (2024a, 2024b) in both the in-text citation and the reference list.
 
-## Conclusion
+## Reference list format
 
-APA format is the standard for academic writing in many fields, particularly the social sciences. By mastering the guidelines presented in this guide, you can accurately cite your sources, properly format your papers, and avoid plagiarism. Consistent and correct citations are a mark of academic integrity and show that you are a conscientious researcher who values the contributions of others. Using APA style correctly will enhance your credibility and contribute to the clarity and impact of your academic work.
+The reference list goes on its own page at the end of the paper, with the word **References** centered and bolded at the top. Every source you cited in the text must appear here, and every entry here must be cited at least once in the text. Personal communications (emails, interviews you conducted) are an exception: cite them in the text but omit them from the reference list.
+
+Entries are alphabetized by the first author's surname. The whole page is double-spaced — within entries and between them — and each entry uses a hanging indent of 0.5 inches, so the first line is flush left and any continuation lines are indented. Most word processors apply hanging indents through the paragraph formatting menu rather than through manual tabs.
+
+The seventh edition of the *Publication Manual* (American Psychological Association, 2020) prefers DOIs over URLs when both exist. A DOI is a permanent identifier; a URL can rot. Format DOIs as full hyperlinks (`https://doi.org/10.1037/cogdev0000412`) rather than as the bare string. URLs appear without the *Retrieved from* prefix that APA 6 required, except for sources designed to change over time, such as a Wikipedia article or a live data dashboard.
+
+The trickiest format detail is capitalization. APA uses **sentence case** for article and chapter titles — only the first word, the first word after a colon, and proper nouns are capitalized. It uses **title case** for journal names, book titles when they appear as standalone works, and report titles. The rule is asymmetric and feels arbitrary, but it has a reason: the journal is a proper noun (one specific publication) while the article title is a description. Get the asymmetry wrong and the reference list looks amateur. The volume number is italicized along with the journal name; the issue number is in parentheses and not italicized. Page ranges use an en dash, not a hyphen.
+
+## Source-type examples
+
+The references below use the fixture data referenced throughout this guide and show each common source type formatted exactly as APA 7 prescribes. Render them double-spaced with a hanging indent in your own document.
+
+| Source type | Reference list entry |
+| --- | --- |
+| Book (single author) | Chen, M. S. (2021). *The architecture of working memory*. Cambridge University Press. |
+| Chapter in edited book | Lin, D. K., & Patel, H. J. (2022). Cross-modal attention in early development. In R. T. Morrison (Ed.), *Handbook of developmental cognition* (pp. 142–168). Routledge. |
+| Journal article with DOI | Goldstein, A., Ramanathan, P., & O'Connor, L. (2024). Sleep consolidation effects on procedural learning in adolescents. *Journal of Cognitive Development, 19*(2), 87–104. https://doi.org/10.1037/cogdev0000412 |
+| Web article (no DOI) | Alvarez, S. (2023, March 12). How working memory predicts reading comprehension. *Psychology Today*. https://www.psychologytoday.com/intl/blog/working-memory-reading-comprehension |
+| Government report | U.S. Department of Education, Institute of Education Sciences. (2023). *Reading proficiency and learning loss in U.S. fourth-graders, 2019–2022* (NCES 2023-145). National Center for Education Statistics. https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145 |
+| Conference paper | Tanaka, Y., & Hoffmann, M. (2022, November 4–6). *A unified model of attention in dual-task performance* [Conference paper]. 63rd Annual Meeting of the Psychonomic Society, Boston, MA, United States. |
+| Doctoral dissertation (published) | Kowalski, E. R. (2020). *Memory consolidation in bilingual speakers: An fMRI investigation* [Doctoral dissertation, University of Michigan]. ProQuest Dissertations & Theses Global. |
+
+A few details to notice across the table. Book and report publishers appear without a location (APA 7 dropped the city-and-state convention that APA 6 used). The chapter entry inverts the chapter authors' names but presents the editor in regular order with the *Ed.* abbreviation in parentheses. The journal volume is italicized; the issue number is not. The conference paper carries a bracketed description after the title to clarify that it isn't a regular article. The dissertation includes the institution in brackets and names the database the work was retrieved from. If you're entering one of these into the generator at /, the tool will assemble the bracketed descriptors and the hanging indent for you, but the underlying logic is what's shown above.
+
+## Common mistakes
+
+These five errors account for most of the markdown students lose on APA assignments. Each shows the wrong version above the right one.
+
+**Title case in an article title.**
+Wrong: Goldstein, A., Ramanathan, P., & O'Connor, L. (2024). Sleep Consolidation Effects on Procedural Learning in Adolescents.
+Right: Goldstein, A., Ramanathan, P., & O'Connor, L. (2024). Sleep consolidation effects on procedural learning in adolescents.
+
+**Missing italics on the journal name and volume.**
+Wrong: Journal of Cognitive Development, 19(2), 87–104.
+Right: *Journal of Cognitive Development, 19*(2), 87–104.
+
+**"Retrieved from" before a URL.**
+Wrong: Retrieved from https://doi.org/10.1037/cogdev0000412
+Right: https://doi.org/10.1037/cogdev0000412
+
+The *Retrieved from* prefix is reserved for sources that are expected to change after retrieval. A DOI never qualifies; a journal article on a publisher's site rarely does; a Wikipedia entry does.
+
+**Spelling out all author names on first mention for three-or-more-author sources.**
+Wrong (first mention): Goldstein, Ramanathan, and O'Connor (2024) found…
+Right (every mention): Goldstein et al. (2024) found…
+
+APA 6 did want the long form on first mention. APA 7 does not. If your handout still teaches the old rule, the handout predates 2019.
+
+**Using a hyphen in a page range.**
+Wrong: 87-104
+Right: 87–104
+
+The en dash (`–`) is shorter than an em dash (`—`) and longer than a hyphen. Most word processors auto-correct a hyphen to an en dash when it sits between numbers; if yours doesn't, insert the character manually.
+
+## What's new in APA 7
+
+The seventh edition is the first major overhaul of APA since 2009, and the changes mostly run in the direction of fewer rules and more inclusive language. If you've worked with APA 6, these are the differences that matter.
+
+**Singular *they* is accepted.** The seventh edition endorses singular *they* as both a generic pronoun (when the gender is unknown or irrelevant) and a personal pronoun (when an individual uses it). The older convention of *he or she* or alternating *he*/*she* across sentences is no longer recommended.
+
+**Three or more authors collapse to *et al.* immediately.** APA 6 wanted three to five surnames spelled out on first mention; APA 7 cuts that to the first author plus *et al.* from the very first citation. Less informative, but the reader has the reference list anyway.
+
+**The author-list cutoff in references moved from 7 to 20.** In a reference list entry, list up to 20 authors before using an ellipsis and the final author's name. APA 6 stopped at 7.
+
+**Italicize the issue number? No — italicize the volume.** This one trips people who half-remember. The volume number is italicized along with the journal title. The issue number sits in parentheses, not italicized. (Some style summaries online get this backward; the *Publication Manual* is the authority.)
+
+**"Retrieved from" is gone for most URLs.** Use the bare URL or DOI. Keep *Retrieved from* only for resources designed to change after retrieval (Wikipedia, live dashboards, archived versions).
+
+**Publisher location is gone.** APA 6 wanted "Cambridge, England: Cambridge University Press." APA 7 wants just "Cambridge University Press." This applies to books, reports, and any other source where a publisher is named.
+
+**New guidance for newer source types.** APA 7 adds explicit, worked examples for software, datasets, podcasts, social media posts, and YouTube videos. Earlier editions either skipped these or buried them in supplementary materials. If you're citing a TikTok in a class paper — and people do — the seventh edition has a template.
+
+The remaining mechanics — author–date in-text citations, alphabetized references with hanging indents, double-spacing throughout, sentence case for article titles — are unchanged from APA 6. The seventh edition refines and simplifies; it does not reinvent.


### PR DESCRIPTION
## Summary
First content PR in the [content & SEO overhaul](docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md). Rewrites `/guides/apa` from AI-formulaic prose into an authoritative, scannable guide that doubles as the voice template for the remaining 7 style guides (PRs 2b–2e to follow).

### What changed
- Full content rewrite of `src/content/guides/apa.mdx` — ~2,400 words.
- Populated the new frontmatter fields landed in PR 1: `faq` (5 Q&A items, renders FAQPage schema), `relatedGuides` (manual curation), `keywords`, `updatedDate`. Preserved `pubDate: 2025-01-16`.
- Removed the placeholder author byline and the inline `<TryMe>` import — the guide layout's `<TryGenerator>` handles the CTA.

### Voice anchors
- Cuts AI tics ("In conclusion", "Whether you're a student", "Pro tip:", emoji, "In today's…").
- Leads sections with the answer, not "What is X?".
- One worked example per rule, source-type examples in a table.
- Cites the *Publication Manual of the American Psychological Association* (2020) explicitly when stating rules.
- One contextual mention of the generator; no second CTA callout in the body.

### What follows
This guide establishes the template + voice. PRs 2b–2e replicate the pattern for MLA, Chicago, Harvard, Vancouver, IEEE, AMA, and research-and-works-cited.

## Test plan
- [x] `npm run build` — clean
- [x] 5 JSON-LD blocks render (Organization, WebSite, Article, BreadcrumbList, FAQPage)
- [x] Word count: 2,400 (target 2,200–2,500)
- [x] All 7 worked examples format the fixture data correctly per APA 7
- [x] No banned voice phrases
- [ ] After merge: re-validate Article + FAQPage on live URL via Google Rich Results Test
- [ ] After merge: Search Console — request re-index for `/guides/apa`

## Pre-merge review
Fresh-context correctness review (Opus, max effort) verified rule accuracy across every claim against the *Publication Manual* (2020). Two blocking findings were addressed before opening this PR:
1. Conference paper bracketed descriptor was `[Conference paper]`; APA 7 (§10.5) uses `[Paper presentation]` for an in-person delivery. Corrected.
2. Typo on line 136 — "markdown students lose" → "marks students lose". Corrected.

Non-blocking observations (no action required):
- The Quick-answer callout is a single-sentence cheat-sheet — could be tightened with leading "Six rules:" framing, but works as-is.
- The "et al." rule appears in both the in-text-citations section and the "what's new in APA 7" comparison — intentional, framed differently in each.