### PR TITLE
Fix logo aspect ratio (header + footer)

### DIFF
--- a/src/components/astro/Footer.astro
+++ b/src/components/astro/Footer.astro
@@ -73,7 +73,7 @@ import Logo from '../../../public/images/logo.svg';
     }
     footer img {
         text-align: left;
-        width: min-content;
+        width: auto;
         image-rendering: -webkit-optimize-contrast;
     }
     footer nav a {

--- a/src/components/astro/Header.astro
+++ b/src/components/astro/Header.astro
@@ -228,6 +228,7 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
   }
   .logo img {
     height: 100%;
+    width: auto;
     image-rendering: -webkit-optimize-contrast;
   }
   .sub-menu-trigger button {


### PR DESCRIPTION
## Summary
Logo image in both header and footer was rendering stretched/distorted because the CSS overrode `height` (28px header, 32px footer) but left the width controlled by the HTML \`width=\"213\"\` attribute, which acts as a presentational hint with no CSS override. The image rendered at 213×28 / 213×32 instead of preserving the SVG's 213×35 aspect ratio.

Fix: add \`width: auto\` to the CSS rules in both Header.astro and Footer.astro so the browser preserves the SVG's intrinsic aspect ratio.

## Test plan
- [x] \`npm run build\` clean
- [ ] After deploy, confirm logo renders at correct proportions on mlagenerator.com (cache may need a hard refresh)