### PR TITLE
Rewrite MLA 9th Edition guide

### DIFF
--- a/docs/superpowers/plans/2026-05-27-pr2b-mla-guide-rewrite.md
+++ b/docs/superpowers/plans/2026-05-27-pr2b-mla-guide-rewrite.md
@@ -1,0 +1,241 @@
+# PR 2b — MLA 9th Edition Guide Rewrite
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Rewrite `/guides/mla` to match the voice/structure template established by [PR 2a's APA guide](./2026-05-27-pr2a-apa-guide-rewrite.md). Authoritative voice, ~2,200–2,500 words, real worked examples, FAQ schema.
+
+**Template reference:** The APA plan at `2026-05-27-pr2a-apa-guide-rewrite.md` documents the full template (structure, voice rules, frontmatter requirements, fixture-data conventions). This plan ONLY documents MLA-specific differences from that template — the implementer should read both files.
+
+**Architecture:** Full replace of `src/content/guides/mla.mdx`. Body and frontmatter only — no code changes.
+
+**Branch:** `pr2b-mla-guide-rewrite` (already created from `origin/main`).
+
+---
+
+## MLA-specific content brief
+
+### Page structure (H2 outline)
+
+Same skeleton as APA, MLA-specific section names:
+
+1. (No H2) Lede — 2–3 sentences.
+2. (No H2) Quick-answer callout — `> ...` blockquote, one or two sentences capturing the essential takeaway.
+3. **H2: What MLA is and when you'll use it** — disciplines (literature, humanities, languages), governing body (Modern Language Association), the 9th edition's date (April 2021) and what changed at a high level.
+4. **H2: In-text citations** — with H3 subsections:
+   - One author
+   - Two authors
+   - Three or more authors
+   - Organization as author
+   - No named author
+   - Multiple works by the same author
+   - Direct quotes (block quote threshold = 4 lines for prose, 3+ for poetry)
+   - Citing multiple sources at once
+   - Sources without page numbers (use paragraph numbers, timestamps, etc.)
+5. **H2: Works Cited page format** — page title ("Works Cited"), alphabetization, hanging indent, double-spacing, the *core elements* approach (Author, Title of source, Title of container, Other contributors, Version, Number, Publisher, Publication date, Location).
+6. **H2: Source-type examples** — table with one row per fixture source type. Use the MLA-specific fixture data below.
+7. **H2: Common mistakes** — five concrete wrong/right pairs.
+8. **H2: What's new in MLA 9** — vs. MLA 8: clarified the *core elements* approach, added more guidance on annotated bibliographies + inclusive language, expanded examples for digital sources (DOIs preferred), gave explicit treatment for in-class lectures, social media, and emerging genres.
+
+### Frontmatter required values
+
+```yaml
+---
+title: 'MLA Citation Guide: MLA 9th Edition Format Made Clear'
+pubDate: <preserve whatever pubDate is in the current file>
+updatedDate: 2026-05-27
+description: 'Complete MLA 9 guide: in-text citations, Works Cited page, the core elements approach, and worked examples for every common source type. Written and reviewed by the MLA Generator Editorial Team against the 2021 MLA Handbook.'
+category: 'style-guide'
+keywords: ['MLA citation', 'MLA 9th edition', 'MLA format', 'in-text citations MLA', 'works cited page', 'MLA worked examples', 'how to cite in MLA', 'MLA core elements']
+tags: ['MLA', 'citations', 'works cited', 'MLA 9th edition', 'literature', 'humanities', 'writing', 'formatting']
+relatedGuides: ['apa', 'chicago', 'harvard', 'how-to-cite-a-website', 'works-cited-vs-bibliography', 'mla-vs-apa']
+faq:
+  - question: 'What changed between MLA 8 and MLA 9?'
+    answer: 'MLA 9 clarified and expanded the *core elements* approach that MLA 8 introduced, added detailed guidance on annotated bibliographies, inclusive language, and the formatting of new digital and emerging source types. MLA 9 also expanded the worked-example library — particularly for online sources, social media, and academic genres MLA 8 hadn''t addressed explicitly. The MLA Handbook moved from the 8th edition to the 9th edition in April 2021.'
+  - question: 'Do MLA in-text citations include the year of publication?'
+    answer: 'No. MLA in-text citations use the author''s surname and a page number ("Smith 42"), not the year. The year appears in the Works Cited entry but not in the body of the paper. This is the most visible difference between MLA and APA — if your professor asks for "Author Year" inside parentheses, they want APA, not MLA.'
+  - question: 'What is the "core elements" approach in MLA 9?'
+    answer: 'Rather than offering a separate template for every source type, MLA 9 asks you to assemble each Works Cited entry from nine core elements, in order: Author. Title of source. Title of container, Other contributors, Version, Number, Publisher, Publication date, Location. Each element ends with the punctuation shown. If an element doesn''t apply to your source, you skip it. The approach works for any source — print, digital, hybrid, or emerging genre — without needing a new template every time.'
+  - question: 'When do I use a block quote in MLA?'
+    answer: 'Prose quotations of more than four lines become block quotes — indented half an inch from the left margin, with no quotation marks, double-spaced like the rest of the paper. For poetry, three or more lines of verse become a block quote. Place the in-text citation after the closing punctuation of the block quote, with no period following the parenthetical citation.'
+  - question: 'Do I include the URL in MLA Works Cited entries?'
+    answer: 'Yes — include URLs (without the "https://" prefix and the protocol-leading "www.") for online sources. MLA 9 prefers DOIs when they exist (formatted as full URLs like "https://doi.org/10.xxxx/..."), but a plain URL is acceptable when no DOI is available. Add an access date for sources that may change after retrieval (live web pages, social media); access dates are optional but recommended for any source that lacks a stable publication date.'
+ogImage: '/images/banner.png'
+---
+```
+
+**Note:** Read the current `src/content/guides/mla.mdx` to find the original `pubDate` value (don't change it — this is a rewrite, not a new page).
+
+### Worked-example data — use ONLY these fixtures
+
+To keep voice consistent across guides and make formatting verifiable, every guide uses the same source fixtures but formatted in the style-appropriate way. Reuse these from the APA guide.
+
+**Book (single author):**
+- Author: Margaret S. Chen
+- Year: 2021
+- Title: The Architecture of Working Memory
+- Publisher: Cambridge University Press
+
+**Book chapter (edited volume):**
+- Chapter authors: David K. Lin and Hannah J. Patel
+- Year: 2022
+- Chapter title: Cross-Modal Attention in Early Development
+- Editor: Rachel T. Morrison
+- Book title: Handbook of Developmental Cognition
+- Pages: 142–168
+- Publisher: Routledge
+
+**Journal article (with DOI):**
+- Authors: Aaron Goldstein, Priya Ramanathan, Liam O'Connor
+- Year: 2024
+- Title: Sleep Consolidation Effects on Procedural Learning in Adolescents
+- Journal: Journal of Cognitive Development
+- Volume: 19, Issue 2
+- Pages: 87–104
+- DOI: 10.1037/cogdev0000412
+
+**Website / web article (no DOI):**
+- Author: Sofia Alvarez
+- Date: 12 Mar. 2023
+- Title: How Working Memory Predicts Reading Comprehension
+- Site name: Psychology Today
+- URL: https://www.psychologytoday.com/intl/blog/working-memory-reading-comprehension
+- Access date (where appropriate): 20 May 2026
+
+**Government report:**
+- Author: United States Department of Education, Institute of Education Sciences
+- Year: 2023
+- Title: Reading Proficiency and Learning Loss in U.S. Fourth-Graders, 2019–2022
+- Publication number: NCES 2023-145
+- Publisher: National Center for Education Statistics
+- URL: https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145
+
+**Conference paper (in proceedings):**
+- Authors: Yuki Tanaka, Marcus Hoffmann
+- Year: 2022
+- Title: A Unified Model of Attention in Dual-Task Performance
+- Conference proceedings title: Proceedings of the 63rd Annual Meeting of the Psychonomic Society
+- Conference dates: 4–6 November 2022
+- Pages: 412–419
+
+**Thesis (doctoral dissertation):**
+- Author: Elena R. Kowalski
+- Year: 2020
+- Title: Memory Consolidation in Bilingual Speakers: An fMRI Investigation
+- Institution: University of Michigan
+- Type: PhD dissertation
+
+Note: MLA uses title case for ALL titles (article, journal, book — all title case). This differs from APA's sentence/title case asymmetry.
+
+### Voice rules
+
+Identical to PR 2a. See the design spec Section 6 and the PR 2a plan's voice samples for the rhythm. The MLA-specific equivalent of the APA voice samples could be:
+
+> MLA was the dominant style of the American humanities classroom for sixty years before it absorbed the rest of the modern languages and named itself after them. The Modern Language Association published the first MLA Style Sheet in 1951. The current edition is the ninth, released April 2021, and the underlying logic has shifted in a meaningful way since the eighth: instead of cataloguing rules per source type, MLA 9 hands you nine *core elements* and asks you to assemble each entry from those.
+
+> Author. Title of source. Title of container, Other contributors, Version, Number, Publisher, Publication date, Location. Read the punctuation marks at the end of each element as carefully as the words — the period after Author and Title of source is mandatory; the commas after Title of container through Publication date are mandatory; the period after Location is mandatory. The pattern looks fussy until you realize it's the same pattern for a book, a journal article, a tweet, and a video game. MLA built one shape and asked you to fold each source into it.
+
+> MLA's most common mistake is forgetting the second container. A journal article in JSTOR sits inside two containers: the journal that originally published it (container 1) and the database that holds the digitized version (container 2). The Works Cited entry names both. Drop container 2 and you've half-cited the source.
+
+### Style-specific rules to highlight
+
+- In-text format: `(Author Page)` — no comma, no year, no `p.` abbreviation. Example: `(Chen 47)`.
+- For sources without pages, omit page numbers; use paragraph numbers (`par. 4`), timestamps for video (`02:14:55`), or section headings only when the source is divided into named sections.
+- Works Cited capitalization: title case for everything.
+- Block quote threshold: more than 4 lines of prose (NOT 4 lines, MORE than 4); for poetry, 3+ lines of verse.
+- Containers: a single Works Cited entry can have one container (a book) or two containers (a journal article in a database).
+- DOIs preferred over URLs when both exist. URLs are written without `https://` in some style guides but MLA 9 specifically accepts the full URL including protocol. Confirm against the 9th edition's §5.93.
+- The Works Cited page heading is "Works Cited" (centered, not bolded — different from APA's bold "References").
+- Author element: surname first for the first author only. Subsequent authors in normal order. For 3+ authors, use first author's surname-then-given-name followed by `et al.`.
+
+---
+
+## Tasks
+
+### Task 1: Write the MLA guide
+
+**File:** `src/content/guides/mla.mdx` (full replace)
+
+- [ ] **Step 1: Read the PR 2a APA plan + the existing mla.mdx**
+
+Read both files to understand the template + the preserved `pubDate`.
+
+- [ ] **Step 2: Write the guide**
+
+Match the structure, voice, and quality bar of the APA guide. Use ONLY the MLA-specific fixture data above. Cite the *MLA Handbook* (Modern Language Association, 2021, 9th edition) explicitly when stating a rule.
+
+Do NOT include an H1 in the body. Do NOT import or render `<TryMe>`. One contextual mention of the generator at `/` in natural prose is the maximum.
+
+- [ ] **Step 3: Build + smoke test**
+
+```bash
+npm run build 2>&1 | tail -10
+npm run dev &
+# wait for ready
+curl -s http://localhost:4321/guides/mla | grep -o '<h2[^>]*>[^<]*' | head -10
+curl -s http://localhost:4321/guides/mla | grep -c 'application/ld+json'
+curl -s http://localhost:4321/guides/mla | grep -o '"@type":"Question"' | wc -l
+wc -w src/content/guides/mla.mdx
+```
+
+Expected: 6 body H2s, 5 JSON-LD blocks, 5 Question entries, ~2,400 body words.
+
+Kill dev server.
+
+- [ ] **Step 4: Self-review against voice rules**
+
+Same rules as the APA guide. Specifically check for:
+- No "In conclusion", "It is important to note", "Whether you're", "In today's", "Pro tip:", emoji.
+- No second `<TryMe>` CTA in body.
+- At least one explicit citation of the *MLA Handbook* (Modern Language Association, 2021).
+- Worked examples use only the supplied fixtures.
+- Author element formatting matches MLA 9 (surname first for first author only, normal order for subsequent).
+
+Fix issues inline.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/content/guides/mla.mdx
+git commit -m "Rewrite MLA 9th Edition guide: core elements approach, worked examples, FAQ schema"
+```
+
+---
+
+### Task 2: Pre-merge correctness review + open PR
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin pr2b-mla-guide-rewrite
+```
+
+- [ ] **Step 2: Dispatch the pre-merge reviewer**
+
+Use an Opus subagent for a fresh-context correctness review. Focus areas:
+- Every cited MLA 9 rule must be verifiable against the *MLA Handbook* (2021). Specifically: the 9 core elements, the (Author Page) format, container concept, block-quote thresholds (4+ lines prose, 3+ lines poetry), works-cited page heading, capitalization (title case throughout), URL/DOI handling.
+- All worked examples use the supplied fixture data verbatim and format correctly per MLA 9.
+- Voice matches the spec Section 6 rules — no AI tics, no filler.
+- Frontmatter: faq, relatedGuides, keywords, updatedDate populated; pubDate preserved; category='style-guide'.
+- 5 JSON-LD blocks render (Organization, WebSite, Article, BreadcrumbList, FAQPage).
+- Word count 2,200–2,500 body.
+
+- [ ] **Step 3: Address blocking findings**
+
+Implement fixes inline. Re-dispatch reviewer if substantial.
+
+- [ ] **Step 4: Open PR + wait + merge**
+
+```bash
+gh pr create --title "Rewrite MLA 9th Edition guide" --body "<see PR 2a body for template; adapt for MLA>"
+```
+
+Then poll CI, squash-merge with `--delete-branch`, push delete the remote branch via `git push origin --delete pr2b-mla-guide-rewrite` if `gh pr merge --delete-branch` errors with the worktree issue.
+
+---
+
+## Self-Review
+
+Same coverage checks as PR 2a: spec coverage, placeholder scan, type consistency. Risk notes:
+- The MLA fixtures use title case (different from APA's sentence case for article titles). Cross-reference the worked examples — they must NOT carry over the APA sentence-case rendering from when the implementer wrote the previous guide.
+- MLA 9 (April 2021) is the current edition; do not cite MLA 8 rules as if they were current.
+- The "containers" concept is the heart of MLA 9 — verify the implementer explains it clearly, not as an afterthought.

--- a/src/content/guides/mla.mdx
+++ b/src/content/guides/mla.mdx
@@ -17,7 +17,7 @@ faq:
   - question: 'When do I use a block quote in MLA?'
     answer: 'Prose quotations that run more than four lines in your paper become block quotes — indented half an inch from the left margin, with no quotation marks, double-spaced like the rest of the paper. For poetry, three or more lines of verse become a block quote. Place the parenthetical citation after the closing punctuation of the block quote, with no period following the parenthetical.'
   - question: 'Do I include the URL in MLA Works Cited entries?'
-    answer: 'Yes. Include URLs for online sources, and prefer DOIs (formatted as full links such as "https://doi.org/10.1037/cogdev0000412") when both exist. MLA 9 accepts the full URL including the "https://" protocol. Add an access date for sources without a stable publication date — live web pages, social media posts, and frequently revised reference articles. Access dates are optional but recommended whenever the source could change after you read it.'
+    answer: 'Yes. Include URLs for online sources, and prefer DOIs (formatted as full links such as "https://doi.org/10.1037/cogdev0000412") when both exist. MLA 9 strips the "http://" or "https://" prefix from URLs in the Works Cited entry; DOIs are the exception — they keep the "https://doi.org/" prefix because the prefix is part of the identifier. Add an access date for sources without a stable publication date — live web pages, social media posts, and frequently revised reference articles. Access dates are optional but recommended whenever the source could change after you read it.'
 ogImage: '/images/banner.png'
 ---
 
@@ -57,7 +57,7 @@ Narrative: Lin and Patel argue that cross-modal attention appears earlier than d
 
 ### Three or more authors
 
-Use the first author's surname followed by *et al.* (roman, not italicized in MLA) on every citation, including the first. There is no "spell them all out the first time" phase the way some older style guides require.
+Use the first author's surname followed by et al. (set in roman in MLA — no italics) on every citation, including the first. There is no "spell them all out the first time" phase the way some older style guides require.
 
 Every citation: (Goldstein et al. 88)
 
@@ -67,7 +67,7 @@ If the source is by Goldstein, Ramanathan, and O'Connor, the in-text citation is
 
 Treat a corporate or government author like a personal one. Use the full organization name on first mention; if the name is long, introduce a short form and use it thereafter.
 
-First: (United States Department of Education, Institute of Education Sciences 12)
+First: (United States, Department of Education, Institute of Education Sciences 12)
 
 Subsequent: (Inst. of Education Sciences 12)
 
@@ -135,7 +135,7 @@ Read the punctuation marks at the end of each element as carefully as the words.
 
 The container concept is the part that catches people off guard. A *container* is the larger work that holds the thing you're citing. A book is its own container (the entry has one). A journal article sits inside the journal (container 1) and, if you accessed it through a database, also inside the database (container 2). Drop container 2 from a database-retrieved article and you've half-cited the source.
 
-For the author element, invert the first author's name (surname first); present subsequent authors in normal order. For three or more authors, name only the first and add *et al.* For online sources, the *MLA Handbook* (Modern Language Association, 2021) accepts the full URL including the `https://` protocol; use a DOI in place of a URL whenever a DOI exists. Add an access date for sources without a stable publication date — live web pages, social media posts, frequently updated reference articles — by appending `Accessed 20 May 2026.` after the URL. Access dates are optional but recommended whenever the source could change after you read it.
+For the author element, invert the first author's name (surname first); present subsequent authors in normal order. For three or more authors, name only the first and add et al. For online sources, the *MLA Handbook* (Modern Language Association, 2021) strips the `http://` or `https://` prefix from URLs in the Works Cited entry. DOIs are the exception — they keep the `https://doi.org/` prefix because the prefix is part of the canonical identifier. Use a DOI in place of a URL whenever a DOI exists. Add an access date for sources without a stable publication date — live web pages, social media posts, frequently updated reference articles — by appending `Accessed 20 May 2026.` after the URL. Access dates are optional but recommended whenever the source could change after you read it.
 
 Capitalization is title case across the board: article titles, book titles, journal titles, container titles. This is the cleanest difference from APA, which mixes sentence case and title case across the same reference. In MLA you only need to remember one rule.
 
@@ -153,7 +153,7 @@ The entries below use the fixture sources referenced throughout this guide and s
 | Conference paper (in proceedings) | Tanaka, Yuki, and Marcus Hoffmann. "A Unified Model of Attention in Dual-Task Performance." *Proceedings of the 63rd Annual Meeting of the Psychonomic Society*, 4–6 Nov. 2022, pp. 412–419. |
 | Doctoral dissertation | Kowalski, Elena R. *Memory Consolidation in Bilingual Speakers: An fMRI Investigation*. 2020. University of Michigan, PhD dissertation. |
 
-A few details to notice. Book and journal titles are italicized; article and chapter titles take quotation marks. The journal entry collapses three authors to `Goldstein, et al.` on the Works Cited page just as it does in the in-text citation — MLA 9 applies the rule to both. The edited-volume chapter names the editor in normal order with `edited by`, not the parenthetical `(Ed.)` APA uses. The website entry includes an access date because the page is on a live publication; the journal article doesn't because its publication date is fixed. The government report inverts the corporate author so the larger entity comes first, making the entry sortable under *U*. If you're entering one of these into the generator at /, the tool will assemble the punctuation, italics, and hanging indent for you, but the underlying logic is what's shown above.
+A few details to notice. Book and journal titles are italicized; article and chapter titles take quotation marks. The journal entry collapses three authors to `Goldstein, Aaron, et al.` on the Works Cited page — the first author inverted as surname-then-given-name, followed by `et al.` — just as the in-text citation uses `Goldstein et al.` MLA 9 applies the rule to both. The edited-volume chapter names the editor in normal order with `edited by`, not the parenthetical `(Ed.)` APA uses. The website entry includes an access date because the page is on a live publication; the journal article doesn't because its publication date is fixed. The government report inverts the corporate author so the larger entity comes first, making the entry sortable under *U*. If you're entering one of these into the generator at /, the tool will assemble the punctuation, italics, and hanging indent for you, but the underlying logic is what's shown above.
 
 ## Common mistakes
 
@@ -203,6 +203,6 @@ The ninth edition is a refinement of the eighth, not a reinvention. The eighth e
 
 **Explicit treatment of in-class materials.** A guest lecture, a class discussion, a slide deck, a handout — MLA 9 has a worked example for each. Earlier editions treated these as personal communications and offered little detail.
 
-**DOIs preferred over URLs.** MLA 8 accepted either; MLA 9 makes the preference explicit. When both exist, use the DOI. When only a URL exists, include it with the `https://` protocol.
+**DOIs preferred over URLs.** MLA 8 accepted either; MLA 9 makes the preference explicit. When both exist, use the DOI. When only a URL exists, strip the `http://` or `https://` prefix — the MLA 9 convention is to omit the protocol on plain URLs but keep `https://doi.org/` on DOIs.
 
 The remaining mechanics — author–page in-text citations, the nine core elements in fixed order, alphabetized Works Cited entries with hanging indents, double-spacing, title case throughout — are unchanged from MLA 8. The ninth edition deepens and clarifies; it does not rebuild.

--- a/src/content/guides/mla.mdx
+++ b/src/content/guides/mla.mdx
@@ -1,28 +1,125 @@
 ---
-title: 'MLA Citation Guide: Mastering MLA Format (9th Edition)'
+title: 'MLA Citation Guide: MLA 9th Edition Format Made Clear'
 pubDate: 2025-01-04
 updatedDate: 2026-05-27
-description: 'This comprehensive guide provides everything you need to know about MLA format citations (9th edition). Learn how to create in-text citations, format your Works Cited page, and avoid plagiarism. Perfect for students and researchers in the humanities.'
+description: 'Complete MLA 9 guide: in-text citations, Works Cited page, the core elements approach, and worked examples for every common source type. Written and reviewed by the MLA Generator Editorial Team against the 2021 MLA Handbook.'
 category: 'style-guide'
-tags: ['MLA', 'citations', 'Works Cited', 'MLA 9th edition', 'research', 'writing', 'formatting']
+keywords: ['MLA citation', 'MLA 9th edition', 'MLA format', 'in-text citations MLA', 'works cited page', 'MLA worked examples', 'how to cite in MLA', 'MLA core elements']
+tags: ['MLA', 'citations', 'works cited', 'MLA 9th edition', 'literature', 'humanities', 'writing', 'formatting']
+relatedGuides: ['apa', 'chicago', 'harvard', 'how-to-cite-a-website', 'works-cited-vs-bibliography', 'mla-vs-apa']
+faq:
+  - question: 'What changed between MLA 8 and MLA 9?'
+    answer: 'MLA 9 clarified and expanded the core elements approach that MLA 8 introduced, added detailed guidance on annotated bibliographies and inclusive language, and broadened the worked-example library for digital and emerging source types. The MLA Handbook moved from the 8th edition to the 9th edition in April 2021. The core mechanics — author–page in-text citations, the nine core elements, the Works Cited page — carry over from MLA 8; what is new is the level of detail and the range of examples.'
+  - question: 'Do MLA in-text citations include the year of publication?'
+    answer: 'No. MLA in-text citations use the author''s surname and a page number — for example, "(Chen 47)" — not the year. The year appears in the Works Cited entry but not inside the parenthetical citation in the body. This is the most visible difference between MLA and APA: if your instructor asks for "Author Year" inside parentheses, they want APA, not MLA.'
+  - question: 'What is the "core elements" approach in MLA 9?'
+    answer: 'Rather than offering a separate template for every source type, MLA 9 asks you to assemble each Works Cited entry from nine core elements, in this fixed order: Author. Title of source. Title of container, Other contributors, Version, Number, Publisher, Publication date, Location. Each element ends with the punctuation shown above. If an element does not apply to your source, you skip it. The approach works for a book, a journal article, a film, a tweet, or a video game without needing a new template per medium.'
+  - question: 'When do I use a block quote in MLA?'
+    answer: 'Prose quotations that run more than four lines in your paper become block quotes — indented half an inch from the left margin, with no quotation marks, double-spaced like the rest of the paper. For poetry, three or more lines of verse become a block quote. Place the parenthetical citation after the closing punctuation of the block quote, with no period following the parenthetical.'
+  - question: 'Do I include the URL in MLA Works Cited entries?'
+    answer: 'Yes. Include URLs for online sources, and prefer DOIs (formatted as full links such as "https://doi.org/10.1037/cogdev0000412") when both exist. MLA 9 accepts the full URL including the "https://" protocol. Add an access date for sources without a stable publication date — live web pages, social media posts, and frequently revised reference articles. Access dates are optional but recommended whenever the source could change after you read it.'
+ogImage: '/images/banner.png'
 ---
 
-import TryMe from '../../components/astro/TryMe.astro';
+MLA is the citation style of literature, languages, and the rest of the modern humanities. The current edition is the ninth, released April 2021, and almost every rule below is keyed to that revision. If your humanities course asks for "MLA," this is the style your instructor expects.
 
-MLA format, developed by the Modern Language Association, is the go-to citation style for papers in literature, language, and other humanities disciplines. This guide will walk you through the essentials of MLA style, focusing on the latest 9th edition, and equip you with the knowledge to properly cite your sources and format your academic papers.
+> The shortest version of MLA: author and page in the text, full entry on the Works Cited page, title case throughout, nine core elements in a fixed order, hanging indent, double-spaced.
 
-## Why Use MLA Format?
+## What MLA is and when you'll use it
 
-MLA style provides a standardized system for documenting sources, which offers several benefits:
+MLA was the dominant style of the American humanities classroom for sixty years before it absorbed the rest of the modern languages and named itself after them. The Modern Language Association published the first MLA Style Sheet in 1951; the current edition is the ninth, released April 2021. The underlying logic shifted at the eighth edition and was refined in the ninth: instead of cataloguing rules per source type, MLA hands you nine *core elements* and asks you to assemble each entry from those. The result is a single shape that fits a book, a journal article, a film, a tweet, or a podcast.
 
-*   **Consistency:** Ensures a uniform format for citations and paper layout.
-*   **Credibility:** Demonstrates academic rigor and acknowledges the work of others.
-*   **Clarity:** Allows readers to easily locate and verify the sources you used.
-*   **Avoids Plagiarism:** Properly citing sources is crucial for avoiding plagiarism, a serious academic offense.
+The *MLA Handbook* (Modern Language Association, 2021) is the authoritative reference, and most of what you'll find online is a summary of it. Where this guide states a rule, the rule comes from the ninth edition.
 
-## Core Elements of MLA Citations
+You'll be asked for MLA in literature, foreign-language, comparative literature, classics, film, and most humanities composition courses. Some media and cultural studies programs use it too. If your assignment rubric says "MLA" without a number, assume the ninth edition — anything older has been out of date since spring 2021.
 
-MLA citations, whether in-text or on the Works Cited page, revolve around a set of core elements:
+## In-text citations
+
+MLA's in-text citation is **author–page**: the author's surname and the page number where the cited material appears, with no comma between them and no abbreviation in front of the page. The reader scans the parenthetical, then turns to the Works Cited page for the full entry. The surname in the parenthetical must match the first surname in the Works Cited entry exactly.
+
+### One author
+
+Cite the surname and the page. If the author's name appears in the sentence, only the page number goes in the parenthetical.
+
+Parenthetical: Working memory operates less like a storage bin and more like a workspace (Chen 47).
+
+Narrative: Chen argues that working memory operates less like a storage bin and more like a workspace (47).
+
+No year, no comma, no *p.* The format is `(Surname Page)` and that is the whole template.
+
+### Two authors
+
+Both surnames appear in every citation, joined by *and* — not an ampersand. Order matches the Works Cited entry.
+
+Parenthetical: (Lin and Patel 155)
+
+Narrative: Lin and Patel argue that cross-modal attention appears earlier than developmental psychology has typically allowed (155).
+
+### Three or more authors
+
+Use the first author's surname followed by *et al.* (roman, not italicized in MLA) on every citation, including the first. There is no "spell them all out the first time" phase the way some older style guides require.
+
+Every citation: (Goldstein et al. 88)
+
+If the source is by Goldstein, Ramanathan, and O'Connor, the in-text citation is `(Goldstein et al. 88)` from the first appearance forward. The full author list appears only in the Works Cited entry.
+
+### Organization as author
+
+Treat a corporate or government author like a personal one. Use the full organization name on first mention; if the name is long, introduce a short form and use it thereafter.
+
+First: (United States Department of Education, Institute of Education Sciences 12)
+
+Subsequent: (Inst. of Education Sciences 12)
+
+A widely known acronym can be used from the start; an obscure one needs the full form on first mention.
+
+### No named author
+
+When a work has no identified author, the title moves into the author slot. Use a shortened form of the title in the parenthetical, italicized for standalone works (books, films, reports) and in quotation marks for shorter pieces (articles, chapters, web pages).
+
+Web article with no author: ("Cognitive Load" par. 6)
+
+Book or report with no author: (*Reading Proficiency and Learning Loss* 14)
+
+### Multiple works by the same author
+
+When your Works Cited page lists more than one work by the same author, the in-text citation needs a short title to point the reader to the right entry. Place a comma between the surname and the short title, and the page number after the title with no comma.
+
+Example: (Chen, *Architecture* 47) vs. (Chen, "Workspace" 12)
+
+The short title matches the first significant word or words of the full title in the Works Cited entry.
+
+### Direct quotes
+
+Direct quotations use the same `(Author Page)` parenthetical you'd use for paraphrase — MLA does not require a separate format for quotes. Place the citation after the closing quotation mark and before the sentence's terminal punctuation.
+
+Short quote: Working memory is "a flexible mental workspace, not a fixed bin of slots" (Chen 47).
+
+Prose quotations that run **more than four lines** in your paper become block quotes: indented half an inch from the left margin, no quotation marks, double-spaced like the rest of the paper. The parenthetical follows the closing punctuation of the block, with no period after the parenthetical. For poetry, the threshold is three or more lines of verse. A prose quotation of exactly four lines is not a block quote — the cutoff is "more than four," and the *MLA Handbook* (Modern Language Association, 2021) is explicit about that.
+
+### Citing multiple sources at once
+
+When a single parenthetical points to multiple sources, separate them with semicolons. Order them as the sense of the passage requires — there is no fixed alphabetical rule the way APA insists on.
+
+Example: Three studies converge on the pattern (Chen 47; Goldstein et al. 88; Lin and Patel 155).
+
+### Sources without page numbers
+
+Web pages, videos, and most digital-only sources don't have pages. Cite them anyway: use a paragraph number with *par.* if the source numbers its paragraphs, a timestamp for video or audio (`02:14:55`), or a named section heading. If none is available, the parenthetical is just the surname.
+
+With paragraph numbers: Alvarez argues that comprehension "outruns vocabulary growth" in elementary readers (par. 4).
+
+With no available locator: (Alvarez)
+
+Do not invent a page number by counting paragraphs or screens. MLA 9 prefers an honest omission to a fabricated locator.
+
+## Works Cited page format
+
+The Works Cited page goes on its own page at the end of the paper, with the words **Works Cited** centered at the top — not bolded, not underlined, just centered in the same font as the rest of the paper. This is a small but visible difference from APA's bold "References." Every source cited in the body appears here, and every entry here is cited at least once in the body.
+
+Entries are alphabetized by the first author's surname (or, for a source with no named author, by the first significant word of the title — ignoring *A*, *An*, *The*). The page is double-spaced throughout, and each entry uses a hanging indent of half an inch.
+
+The heart of MLA 9 is the *core elements* approach. Rather than memorize a separate template for every kind of source you might cite, you assemble each Works Cited entry from these nine elements, in this order:
 
 1. **Author.**
 2. **Title of source.**
@@ -34,95 +131,78 @@ MLA citations, whether in-text or on the Works Cited page, revolve around a set 
 8. **Publication date,**
 9. **Location.**
 
-Not all elements will be present in every source. The goal is to include the relevant elements in the specified order to help readers identify and locate the source.
+Read the punctuation marks at the end of each element as carefully as the words. The period after **Author** and **Title of source** is mandatory; the commas after **Title of container** through **Publication date** are mandatory; the period after **Location** closes the entry. If an element doesn't apply to your source — most sources skip several — leave it out and continue with the punctuation of the next element that does apply.
 
-## In-Text Citations in MLA
+The container concept is the part that catches people off guard. A *container* is the larger work that holds the thing you're citing. A book is its own container (the entry has one). A journal article sits inside the journal (container 1) and, if you accessed it through a database, also inside the database (container 2). Drop container 2 from a database-retrieved article and you've half-cited the source.
 
-In-text citations briefly identify the source within the body of your paper and point readers to the full citation on the Works Cited page. MLA uses a simple author-page number system:
+For the author element, invert the first author's name (surname first); present subsequent authors in normal order. For three or more authors, name only the first and add *et al.* For online sources, the *MLA Handbook* (Modern Language Association, 2021) accepts the full URL including the `https://` protocol; use a DOI in place of a URL whenever a DOI exists. Add an access date for sources without a stable publication date — live web pages, social media posts, frequently updated reference articles — by appending `Accessed 20 May 2026.` after the URL. Access dates are optional but recommended whenever the source could change after you read it.
 
-*   **Basic Format:** (Author's Last Name Page Number)
-*   **Example:** (Smith 23)
+Capitalization is title case across the board: article titles, book titles, journal titles, container titles. This is the cleanest difference from APA, which mixes sentence case and title case across the same reference. In MLA you only need to remember one rule.
 
-**Variations:**
+## Source-type examples
 
-*   **Author mentioned in the sentence:** If you mention the author's name in your sentence, only include the page number in the parentheses.
+The entries below use the fixture sources referenced throughout this guide and show each common source type formatted exactly as MLA 9 prescribes. Render them double-spaced with a half-inch hanging indent in your own document.
 
-    > Example: Smith argues that the novel is a critique of social norms (23).
-*   **No known author:** Use a shortened version of the title in quotation marks.
+| Source type | Works Cited entry |
+| --- | --- |
+| Book (single author) | Chen, Margaret S. *The Architecture of Working Memory*. Cambridge University Press, 2021. |
+| Chapter in edited book | Lin, David K., and Hannah J. Patel. "Cross-Modal Attention in Early Development." *Handbook of Developmental Cognition*, edited by Rachel T. Morrison, Routledge, 2022, pp. 142–168. |
+| Journal article with DOI | Goldstein, Aaron, et al. "Sleep Consolidation Effects on Procedural Learning in Adolescents." *Journal of Cognitive Development*, vol. 19, no. 2, 2024, pp. 87–104. https://doi.org/10.1037/cogdev0000412. |
+| Web article (no DOI) | Alvarez, Sofia. "How Working Memory Predicts Reading Comprehension." *Psychology Today*, 12 Mar. 2023, www.psychologytoday.com/intl/blog/working-memory-reading-comprehension. Accessed 20 May 2026. |
+| Government report | United States, Department of Education, Institute of Education Sciences. *Reading Proficiency and Learning Loss in U.S. Fourth-Graders, 2019–2022*. National Center for Education Statistics, 2023. NCES 2023-145, nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145. |
+| Conference paper (in proceedings) | Tanaka, Yuki, and Marcus Hoffmann. "A Unified Model of Attention in Dual-Task Performance." *Proceedings of the 63rd Annual Meeting of the Psychonomic Society*, 4–6 Nov. 2022, pp. 412–419. |
+| Doctoral dissertation | Kowalski, Elena R. *Memory Consolidation in Bilingual Speakers: An fMRI Investigation*. 2020. University of Michigan, PhD dissertation. |
 
-    > Example: ("Impact of Technology" 42)
-*   **Multiple works by the same author:** Include a shortened title to distinguish between the works.
+A few details to notice. Book and journal titles are italicized; article and chapter titles take quotation marks. The journal entry collapses three authors to `Goldstein, et al.` on the Works Cited page just as it does in the in-text citation — MLA 9 applies the rule to both. The edited-volume chapter names the editor in normal order with `edited by`, not the parenthetical `(Ed.)` APA uses. The website entry includes an access date because the page is on a live publication; the journal article doesn't because its publication date is fixed. The government report inverts the corporate author so the larger entity comes first, making the entry sortable under *U*. If you're entering one of these into the generator at /, the tool will assemble the punctuation, italics, and hanging indent for you, but the underlying logic is what's shown above.
 
-    > Example: (Smith, "Modernism" 15)
+## Common mistakes
 
-## Creating a Works Cited Page in MLA
+These five errors account for most of the marks students lose on MLA assignments. Each shows the wrong version above the right one.
 
-The Works Cited page is an alphabetized list of all the sources you cited in your paper. It appears at the end of your document. Here's how to format it:
+**Comma between the author and the page number.**
+Wrong: (Chen, 47)
+Right: (Chen 47)
 
-*   **Heading:** Center the title "Works Cited" at the top of the page.
-*   **Alphabetical Order:** List entries alphabetically by the author's last name. If no author is listed, alphabetize by the first significant word in the title.
-*   **Hanging Indent:** Indent the second and subsequent lines of each entry by 0.5 inches.
-*   **Double Spacing:** Double-space the entire Works Cited page.
+MLA's parenthetical has no internal comma. The comma is APA's convention; if you've taken classes in both styles, the muscle memory will fight you.
 
-## Common Source Types and Their MLA Citations
+**Including the year in the parenthetical.**
+Wrong: (Chen 2021, 47)
+Right: (Chen 47)
 
-Here are examples of how to cite common source types in MLA format:
+The year lives in the Works Cited entry, not in the parenthetical. Author–page is the whole signature.
 
-### Book
+**Forgetting the second container for a database-retrieved article.**
+Wrong: ... *Journal of Cognitive Development*, vol. 19, no. 2, 2024, pp. 87–104.
+Right: ... *Journal of Cognitive Development*, vol. 19, no. 2, 2024, pp. 87–104. *JSTOR*, https://doi.org/10.1037/cogdev0000412.
 
-**Format:**
+If you accessed the article through a database, name the database as container 2 and italicize it; the DOI or URL goes after. When the DOI is the only access point — for instance, an open-access article retrieved directly from the publisher — container 2 may be omitted.
 
-Author's Last Name, First Name. *Title of Book*. Publisher, Publication Date.
+**Using sentence case for the article title.**
+Wrong: "Sleep consolidation effects on procedural learning in adolescents."
+Right: "Sleep Consolidation Effects on Procedural Learning in Adolescents."
 
-**Example:**
+MLA uses title case everywhere. Sentence case is APA's habit, not MLA's.
 
-<div style="background: var(--background-1); padding: 1rem; border-radius: 12px;">
-    <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Doe, John. *The Art of Writing*. Example Press, 2023.</p>
-</div>
+**Block-quoting a four-line passage.**
+Wrong: Indenting a four-line prose quotation as a block.
+Right: Treat anything four lines or shorter as a run-in quotation with quotation marks; block-quote only what runs more than four lines.
 
-### Journal Article
+The threshold is *more than four*, not *four or more*. A five-line quotation belongs in a block; a four-line quotation belongs in your paragraph.
 
-**Format:**
+## What's new in MLA 9
 
-Author's Last Name, First Name. "Title of Article." *Title of Journal*, volume number, issue number, Publication Date, page range. *Database Name* (if applicable), DOI or URL.
+The ninth edition is a refinement of the eighth, not a reinvention. The eighth edition (2016) introduced the core elements approach; the ninth (2021) tightened the rules, expanded the worked-example library, and added several new sections. If you've worked with MLA 8, these are the differences that matter.
 
-**Example:**
+**Core elements approach, clarified.** MLA 9 walks through edge cases and ambiguous source types in much more depth. The order and the punctuation didn't change.
 
-<div style="background: var(--background-1); padding: 1rem; border-radius: 12px;">
-    <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Smith, Jane. "The Future of Technology." *Journal of Innovation*, vol. 10, no. 2, 2022, pp. 45-60. *JSTOR*, doi:10.1234/xyz.</p>
-</div>
+**Annotated bibliography guidance.** MLA 9 adds explicit formatting rules for annotated bibliographies — placement of the annotation under the Works Cited entry, indentation, expected length. Earlier editions left those details to instructors.
 
-### Website
+**Inclusive language section.** The ninth edition adds a chapter on inclusive language, covering gender-neutral pronouns, identity-first vs. person-first language, and references to race and ethnicity. The chapter is descriptive rather than prescriptive, but it gives writers a vocabulary for choices earlier editions didn't address.
 
-**Format:**
+**More worked examples for digital and emerging sources.** Tweets, video games, YouTube videos, podcasts, web comics, and other born-digital genres all get explicit worked examples. MLA 8 mostly told you to apply the core elements yourself; MLA 9 shows you.
 
-Author's Last Name, First Name (if available). "Title of Web Page." *Title of Website*, Publication Date (if available), URL.
+**Explicit treatment of in-class materials.** A guest lecture, a class discussion, a slide deck, a handout — MLA 9 has a worked example for each. Earlier editions treated these as personal communications and offered little detail.
 
-**Example:**
+**DOIs preferred over URLs.** MLA 8 accepted either; MLA 9 makes the preference explicit. When both exist, use the DOI. When only a URL exists, include it with the `https://` protocol.
 
-<div style="background: var(--background-1); padding: 1rem; border-radius: 12px;">
-    <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Brown, Alice. "Understanding MLA Format." *Citation Guide*, 15 Jan. 2023, mlagenerator.com/guides/mla.</p>
-</div>
-
-<TryMe />
-
-## MLA Paper Formatting
-
-In addition to citations, MLA style dictates the overall format of your paper:
-
-*   **Margins:** 1-inch margins on all sides.
-*   **Font:** Use a legible font like Times New Roman, 12-point size.
-*   **Spacing:** Double-space the entire paper, including the Works Cited page.
-*   **Header:** Include a header in the upper right-hand corner of each page with your last name and the page number.
-*   **Title Page:** MLA typically does not require a separate title page. Instead, include your name, your instructor's name, the course name, and the date in the upper left-hand corner of the first page, double-spaced. Below this, center the title of your paper.
-
-## Tips for Mastering MLA
-
-*   **Consult the official MLA Handbook (9th edition):** This is the definitive guide to MLA style.
-*   **Use a citation generator:** Tools like [MLA Generator](https://mlagenerator.com) can help you create citations quickly, but always double-check the results. _Note the SEO-centric link placement here_
-*   **Pay attention to details:** MLA requires careful attention to punctuation, capitalization, and formatting.
-*   **Practice:** The more you practice creating MLA citations, the more comfortable you'll become with the format.
-
-## Conclusion
-
-MLA format is essential for students and researchers in the humanities. By mastering the principles outlined in this guide, you'll be well-equipped to cite your sources accurately, format your papers correctly, and avoid plagiarism. Remember that consistent and accurate citations are a hallmark of strong academic writing. They demonstrate your credibility as a researcher and your respect for the intellectual contributions of others.
+The remaining mechanics — author–page in-text citations, the nine core elements in fixed order, alphabetized Works Cited entries with hanging indents, double-spacing, title case throughout — are unchanged from MLA 8. The ninth edition deepens and clarifies; it does not rebuild.


### PR DESCRIPTION
## Summary
Second content PR in the [content & SEO overhaul](docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md). Rewrites `/guides/mla` to match the voice/structure template established by the [APA guide rewrite (PR #16)](https://github.com/matt-connors/citation-generator/pull/16).

### What changed
- Full content rewrite of `src/content/guides/mla.mdx` — ~2,500 words.
- Populated frontmatter: `faq` (5 Q&A items, FAQPage schema), `relatedGuides`, `keywords`, `updatedDate`. Preserved `pubDate: 2025-01-04`.
- 6 body H2s + 9 H3 subsections under "In-text citations" per the plan.
- Authoritative voice keyed to the *MLA Handbook* (Modern Language Association, 2021, 9th edition) — explicit citations to the manual when stating rules.
- 7 worked examples in the source-type table, formatted from a fixed fixture set (reused across the style guides).
- Coverage of the *core elements* approach, container concept (incl. two-container handling), `(Author Page)` in-text format, block-quote thresholds (4+ lines prose, 3+ lines poetry), URL/DOI handling, title-case-throughout difference from APA.

### What follows
PRs 2c–2e will replicate this pattern for Chicago, Harvard, Vancouver, IEEE, AMA, and the research-and-works-cited meta page.

## Test plan
- [x] `npm run build` — clean
- [x] 5 JSON-LD blocks render (Organization, WebSite, Article, BreadcrumbList, FAQPage)
- [x] 6 body H2s + 9 H3 subsections + ToC anchors match rendered ids
- [x] Word count: 2,499 (target 2,200–2,500)
- [x] All 7 worked examples format the fixture data correctly per MLA 9
- [x] No banned voice phrases
- [ ] After merge: re-validate Article + FAQPage on live URL via Google Rich Results Test

## Pre-merge review
Fresh-context correctness review (Opus, max effort) caught one blocking finding plus three polish notes — all addressed before opening this PR:
1. **Blocking — URL protocol inconsistency.** Three places in the body claimed MLA 9 accepts URLs *with* the `https://` protocol, but the table examples (correctly) strip the protocol. MLA 9 §5.93 directs writers to omit the `http://` or `https://` prefix from URLs (DOIs are the exception — they keep `https://doi.org/`). Rewrote the three body claims to match §5.93 and the table.
2. *et al.* was italicized in the very sentence describing it as roman. Fixed.
3. Government-author in-text example was missing the comma after "United States" — the Works Cited entry uses the comma per MLA convention. Fixed.
4. Narrative gloss said the journal entry collapses to `Goldstein, et al.` but the table actually shows `Goldstein, Aaron, et al.` (inverted first author + et al.). Tightened the gloss to match.

Non-blocking observations (no action required) — see review on the implementer agent's transcript.