### PR TITLE
Anchor text fixes: bottom CTA label, guides anchor, self-URL

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -226,7 +226,7 @@ const extraSchemas = [buildSoftwareApplication()];
                     Each citation style has its own specific rules for
                     formatting in-text citations and the bibliography or works
                     cited list. You can learn more about these styles in our <a
-                        href="/guides/">guides</a
+                        href="/guides">citation style guides</a
                     >.
                 </p>
 
@@ -306,7 +306,7 @@ const extraSchemas = [buildSoftwareApplication()];
                     Working with sources is an integral part of academic
                     writing. By understanding the principles of citation and
                     utilizing tools like
-                    <a href="https://mlagenerator.com">MLA Generator</a>, you
+                    <a href="/">MLA Generator</a>, you
                     can ensure that your work is ethical, credible, and
                     well-supported. Remember to cite your sources diligently and
                     accurately to contribute to a culture of academic integrity.
@@ -328,7 +328,7 @@ const extraSchemas = [buildSoftwareApplication()];
                 })
             }
             <a href="/my-references" class="button-primary">
-                <span>Citation Generator</span>
+                <span>View My References</span>
                 <ArrowUpRightIcon className="button-icon" />
             </a>
         </div>


### PR DESCRIPTION
## Summary
Three small anchor-text / link fixes called out during an internal-linking audit.

| Location | Before | After | Why |
|---|---|---|---|
| Homepage bottom CTA | "Citation Generator" → /my-references | "View My References" → /my-references | Label/destination mismatch. The old label sounded like it linked to the citation tool but actually navigated to the references page. |
| Homepage prose link | "guides" → /guides/ | "citation style guides" → /guides | Generic single-word anchor replaced with descriptive multi-word anchor (richer SEO signal). |
| Homepage closing paragraph | "MLA Generator" → https://mlagenerator.com | "MLA Generator" → / | Absolute self-URL relativized so the internal self-link is properly relative. |

## Test plan
- [x] `npm run build` clean
- [ ] After deploy, sanity check: bottom CTA shows "View My References" and goes to /my-references; mid-page "citation style guides" links to /guides; closing-paragraph "MLA Generator" link works as expected.