### PR TITLE
Add Vancouver guide (NLM Citing Medicine 2nd edition)

### DIFF
--- a/src/content/guides/vancouver.mdx
+++ b/src/content/guides/vancouver.mdx
@@ -17,7 +17,7 @@ faq:
   - question: 'Where do I find a journal''s official Vancouver abbreviation?'
     answer: 'The NLM Catalog (https://www.ncbi.nlm.nih.gov/nlmcatalog/journals) is the canonical source. Search for the journal name and the "Title Abbreviation" field gives the NLM-standard short form. If the journal isn''t indexed by NLM, abbreviate using the same conventions (drop articles like "the" and "of"; abbreviate common words per ISO 4 / List of Title Word Abbreviations). When in doubt, use the full name — readers and editors find that less confusing than a guessed abbreviation.'
   - question: 'Do I include DOIs in Vancouver references?'
-    answer: 'Yes when one exists. NLM *Citing Medicine* recommends including the DOI for any journal article when available, formatted as the full URL: "https://doi.org/...". Add a colon and the DOI after the page range, with no space before. For online-only sources without a DOI, include the full URL with an "Available from:" prefix (note: NLM uses "Available from:" with a colon, not Cite Them Right''s "Available at:").'
+    answer: 'Yes when one exists. NLM *Citing Medicine* recommends including the DOI for any journal article when available. The engine renders it as `doi:10.1037/cogdev0000412` (lowercase prefix, no URL form, no `https://`) appended to the page range. For online-only sources without a DOI, include the full URL with an `Available from:` prefix instead. NLM uses `Available from:` (with a colon), distinct from MLA''s `Available at:` and Cite Them Right''s `Available at:`.'
 ogImage: '/images/banner.png'
 ---
 
@@ -53,7 +53,7 @@ Non-consecutive: Several reviews report the same effect (1,4,7).
 
 Mixed: A broader literature supports the finding (1–3,7,9–11).
 
-The engine sorts the numbers ascending and applies the collapse automatically. NLM *Citing Medicine* uses a comma with no following space inside the parenthetical, which is what this site's generator produces.
+NLM *Citing Medicine* uses a comma with no following space inside the parenthetical.
 
 ### Author-prominent narrative
 
@@ -79,7 +79,7 @@ The practical consequence is that reordering paragraphs during revision can requ
 
 ## Reference list format
 
-The reference list goes on its own page at the end of the manuscript with the heading **References** at the top — not italicized, not bolded, just the word "References" in the same font as the body. Some journals prefer "Bibliography" or no heading at all; check your target journal's instructions to authors. Every source cited in the body must appear here, and every entry here must be cited at least once.
+The reference list goes on its own page at the end of the manuscript with the heading **References** at the top — not italicized, not bolded, just the word "References" in the same font as the body. NLM uses "References"; the occasional journal may specify a different heading, so check your target journal's instructions to authors if in doubt. Every source cited in the body must appear here, and every entry here must be cited at least once.
 
 Entries are **numbered**, starting at 1, in the order they were first cited in the text. The number is followed by a period and a single space, then the entry. The page is single-spaced within and between entries in most submission formats. There is no hanging indent — Vancouver entries are flush left, or the citation number is set apart in its own column with the entry text aligned beside it. Either rendering is correct.
 
@@ -95,15 +95,15 @@ The entries below use the same fixture sources referenced throughout this guide 
 
 | Source type | Reference list entry |
 | --- | --- |
-| Book (single author) | Chen MS. The architecture of working memory. Cambridge (UK): Cambridge University Press; 2021. |
-| Chapter in edited book | Lin DK, Patel HJ. Cross-modal attention in early development. In: Morrison RT, editor. Handbook of developmental cognition. London: Routledge; 2022. p. 142–168. |
-| Journal article with DOI | Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. https://doi.org/10.1037/cogdev0000412. |
-| Web article | Alvarez S. How working memory predicts reading comprehension. Psychology Today. 2023 Mar 12 [cited 2026 May 20]. Available from: https://www.psychologytoday.com/intl/blog/working-memory-reading-comprehension. |
-| Government report | U.S. Department of Education, Institute of Education Sciences. Reading proficiency and learning loss in U.S. fourth-graders, 2019–2022. Washington (DC): National Center for Education Statistics; 2023. Report No.: NCES 2023-145. Available from: https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145. |
-| Conference paper | Tanaka Y, Hoffmann M. A unified model of attention in dual-task performance. In: Proceedings of the 63rd Annual Meeting of the Psychonomic Society; 2022 Nov 4–6; Boston (MA). |
-| Doctoral dissertation | Kowalski ER. Memory consolidation in bilingual speakers: an fMRI investigation [doctoral dissertation]. Ann Arbor (MI): University of Michigan; 2020. |
+| Book (single author) | Chen MS. The architecture of working memory. Cambridge, UK: Cambridge University Press; 2021. |
+| Chapter in edited book | Lin DK, Patel HJ. Cross-modal attention in early development. In: Morrison RT, editor. Handbook of developmental cognition. London: Routledge; 2022. p. 142–68. |
+| Journal article with DOI | Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. doi:10.1037/cogdev0000412. |
+| Web article | Alvarez S. Psychology Today [Internet]. 2023 [cited 2026 May 20]. How working memory predicts reading comprehension. Available from: https://www.psychologytoday.com/intl/blog/working-memory-reading-comprehension. |
+| Government report | U.S. Department of Education, Institute of Education Sciences. Reading proficiency and learning loss in U.S. fourth-graders, 2019–2022. Washington, DC: National Center for Education Statistics; 2023. Report NCES 2023-145. Available from: https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145. |
+| Conference paper | Tanaka Y, Hoffmann M. A unified model of attention in dual-task performance. In: Proceedings of the 63rd Annual Meeting of the Psychonomic Society. 2022. |
+| Doctoral dissertation | Kowalski ER. Memory consolidation in bilingual speakers: an fMRI investigation [doctoral dissertation]. [Ann Arbor, MI]: University of Michigan; 2020. |
 
-A few details to notice. The book entry uses `Cambridge (UK)` to disambiguate the city — NLM *Citing Medicine* recommends a country or U.S. state abbreviation for any city that could be confused with another (Cambridge UK vs. Cambridge MA). The chapter entry uses `In:` (no italics) and labels the editor explicitly (`Morrison RT, editor.`) rather than wrapping the name in parentheses the way APA does. The journal entry collapses the title to its NLM abbreviation and packs year, volume, issue, and pages into the no-space `2024;19(2):87–104` block, with the DOI hanging at the end as a full URL. The web article uses NLM's bracketed `[cited 2026 May 20]` for the access date and prefixes the URL with `Available from:` — different from MLA's `Available at:`. The government report carries a `Report No.:` element after the publisher and year. The conference paper opens with `In: Proceedings of…` and gives the dates in NLM's `2022 Nov 4–6` form. The dissertation is bracketed as `[doctoral dissertation]`. If you're entering one of these into the generator at /, the tool assembles the dense punctuation for you.
+A few details to notice. Place is rendered as `City, Region:` — `Cambridge, UK:` or `Washington, DC:`. For works where the place is inferred rather than printed on the source, the place is bracketed: `[Ann Arbor, MI]:`. NLM *Citing Medicine* uses parentheses around the disambiguator (`Cambridge (UK)`); the comma form is what this site's generator produces. The chapter entry uses `In:` (no italics) and labels the editor explicitly (`Morrison RT, editor.`) rather than wrapping the name in parentheses the way APA does. Page ranges use minimal elision — the engine drops leading digits shared by the start and end pages, so `142–168` becomes `142–68`. The journal entry packs year, volume, issue, and pages into the no-space `2024;19(2):87–104` block, with the DOI in the compact `doi:10.1037/cogdev0000412` form (lowercase prefix, no `https://`). Web articles invert what print conventions would suggest: the container (site name) comes first, followed by `[Internet]`, then the year, then the bracketed access date, then the title. Month and day drop from the issued date for web articles — `2023 Mar 12` becomes just `2023`. The URL is prefixed with `Available from:` — different from MLA's `Available at:`. The government report carries a `Report` element (`Report NCES 2023-145`) after the publisher and year, with no `No.:` label. The conference paper drops the host city and collapses the date to just the year — `In: Proceedings of the 63rd Annual Meeting of the Psychonomic Society. 2022.` — using periods rather than semicolons between elements. The dissertation is bracketed as `[doctoral dissertation]`.
 
 ## Common mistakes
 
@@ -119,7 +119,7 @@ Vancouver italicizes nothing in standard references. If your word-processor temp
 Wrong: …predicts reading comprehension¹.
 Right: …predicts reading comprehension (1).
 
-Both forms exist across Vancouver-style journals. The ICMJE *Recommendations* accept either as long as the choice is consistent. This site's generator produces parentheses; if your target journal requires superscript, convert by hand.
+Both forms exist across Vancouver-style journals. The ICMJE *Recommendations* accept either as long as the choice is consistent. If your target journal requires superscript, convert by hand.
 
 **Spelling out the journal name in full.**
 Wrong: Journal of Cognitive Development. 2024;19(2):87–104.
@@ -149,9 +149,9 @@ Take the journal-article fixture. In APA 7, the reference is:
 
 In Vancouver (NLM *Citing Medicine* 2nd ed.), the same source is:
 
-> Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. https://doi.org/10.1037/cogdev0000412.
+> Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. doi:10.1037/cogdev0000412.
 
-The two entries point to the same article. They differ in five places, every one reflecting Vancouver's compactness ethos. The authors lose their commas, their periods after initials, and the ampersand. The year moves from immediately-after-the-author to immediately-after-the-journal-title. The journal name shrinks to its NLM abbreviation and loses its italics. The volume, issue, and pages compress into a no-space `19(2):87–104` block. The DOI hangs at the end with a trailing period.
+The two entries point to the same article. They differ in five places, every one reflecting Vancouver's compactness ethos. The authors lose their commas, their periods after initials, and the ampersand. The year moves from immediately-after-the-author to immediately-after-the-journal-title. The journal name shrinks to its NLM abbreviation and loses its italics. The volume, issue, and pages compress into a no-space `19(2):87–104` block. The DOI shrinks from the full URL form to the compact `doi:10.1037/cogdev0000412` prefix.
 
 The in-text citations differ even more visibly. APA wants `(Goldstein et al., 2024)`; Vancouver wants `(1)`. APA's parenthetical carries authorship and date that the reader can interpret without flipping pages; Vancouver's number means nothing until you turn to the reference list. The trade-off is that APA's parentheticals become unreadable when several stack up — `(Goldstein et al., 2024; Chen, 2021; Lin & Patel, 2022; Tanaka & Hoffmann, 2022)` is a mouthful — while Vancouver collapses the same string to `(1–4)`. The ICMJE *Recommendations* prefer the numeric form precisely because clinical writing supports dense, multi-source claims that author–date parentheticals cannot carry without disrupting the reader.
 

--- a/src/content/guides/vancouver.mdx
+++ b/src/content/guides/vancouver.mdx
@@ -1,0 +1,160 @@
+---
+title: 'Vancouver Citation Guide: NLM Citing Medicine, Numeric Citation-Sequence'
+pubDate: 2026-05-27
+updatedDate: 2026-05-27
+description: 'Complete Vancouver guide following NLM Citing Medicine 2nd edition (the variant this site generates). Numeric citation-sequence in-text citations, numbered reference list, NLM-abbreviated journal names, worked examples for every common source type. Written and reviewed by the MLA Generator Editorial Team.'
+category: 'style-guide'
+keywords: ['Vancouver citation', 'NLM citation', 'Vancouver style', 'numeric citation', 'ICMJE references', 'biomedical citation', 'PubMed citation format']
+tags: ['Vancouver', 'NLM', 'ICMJE', 'biomedical', 'medical citation', 'numeric citations', 'references']
+relatedGuides: ['apa', 'ieee', 'ama', 'how-to-cite-a-journal-article', 'in-text-citations']
+faq:
+  - question: 'What is Vancouver style and who maintains it?'
+    answer: 'Vancouver is a numeric citation-sequence system used in biomedical writing. It''s maintained jointly by the U.S. National Library of Medicine (NLM) — whose *Citing Medicine* manual is the authoritative reference — and the International Committee of Medical Journal Editors (ICMJE), whose *Recommendations for the Conduct, Reporting, Editing, and Publication of Scholarly Work in Medical Journals* set the rules most biomedical journals follow. This guide and this site''s generator both follow NLM *Citing Medicine* 2nd edition.'
+  - question: 'How do Vancouver in-text citations work?'
+    answer: 'Each source gets a number when it''s first cited. The number goes in parentheses where you''d normally see an author–date parenthetical: "Working memory predicts reading comprehension (1)." If you cite the same source again later, you reuse the original number — not assign a new one. The reference list is numbered in the same order, so the reader can flip to the matching entry by number rather than alphabetically by author.'
+  - question: 'Why doesn''t Vancouver italicize journal names?'
+    answer: 'Vancouver is descended from a tradition of compact biomedical printing where italics were used sparingly to save space and avoid typesetting cost. The convention has stuck. Vancouver references use almost no italics — neither journal names nor book titles in most variants. The NLM-style abbreviated journal names ("J Cogn Dev" rather than "Journal of Cognitive Development") are part of the same compactness ethos.'
+  - question: 'Where do I find a journal''s official Vancouver abbreviation?'
+    answer: 'The NLM Catalog (https://www.ncbi.nlm.nih.gov/nlmcatalog/journals) is the canonical source. Search for the journal name and the "Title Abbreviation" field gives the NLM-standard short form. If the journal isn''t indexed by NLM, abbreviate using the same conventions (drop articles like "the" and "of"; abbreviate common words per ISO 4 / List of Title Word Abbreviations). When in doubt, use the full name — readers and editors find that less confusing than a guessed abbreviation.'
+  - question: 'Do I include DOIs in Vancouver references?'
+    answer: 'Yes when one exists. NLM *Citing Medicine* recommends including the DOI for any journal article when available, formatted as the full URL: "https://doi.org/...". Add a colon and the DOI after the page range, with no space before. For online-only sources without a DOI, include the full URL with an "Available from:" prefix (note: NLM uses "Available from:" with a colon, not Cite Them Right''s "Available at:").'
+ogImage: '/images/banner.png'
+---
+
+Vancouver is the citation style of medicine, nursing, dentistry, public health, and most of the biomedical sciences. The variant this site generates is **NLM/Vancouver: Citing Medicine 2nd edition (citation-sequence)** — the version maintained by the U.S. National Library of Medicine and aligned with the ICMJE *Recommendations*. If your manuscript guidelines say "Vancouver" or "NLM" or point to the ICMJE Uniform Requirements, this is the style you want.
+
+> The shortest version of Vancouver: numbered citations in parentheses in the text — `(1)` — and a numbered reference list at the back, in the order sources first appeared. Author names use surname-and-initials with no commas inside. Journal names are NLM-abbreviated. Almost nothing is italicized.
+
+## What Vancouver is and when you'll use it
+
+Vancouver took its name from a 1978 meeting in Vancouver, British Columbia, where a small group of medical-journal editors agreed on a single reference format that participating journals would accept. That group became the International Committee of Medical Journal Editors (ICMJE), and the format became the spine of nearly every biomedical journal's instructions to authors. The U.S. National Library of Medicine maintains the authoritative reference — *Citing Medicine: The NLM Style Guide for Authors, Editors, and Publishers*, 2nd edition. Every rule below is keyed to that manual and to the ICMJE *Recommendations for the Conduct, Reporting, Editing, and Publication of Scholarly Work in Medical Journals*, which adopt the same conventions.
+
+You'll be asked for Vancouver in medicine, nursing, dentistry, pharmacy, public health, epidemiology, biomedical engineering, and most basic-science journals indexed in PubMed. If your target journal lists the ICMJE Recommendations in its instructions to authors, the references must be in Vancouver.
+
+Why a numeric system rather than the author–date format that dominates the social sciences? Biomedical papers cite densely — several sources for a single clinical claim. A string of `(Smith 2024; Chen 2023; Goldstein 2022; Patel 2021)` reads slowly. A string of `(1–4)` does not. The numeric form trades informativeness for compactness, which is the trade-off a clinical-trial report wants. Numbers are assigned in **citation-sequence order**: the first source cited becomes reference 1, the second *new* source becomes reference 2, and so on. The list is not alphabetical.
+
+## In-text citations
+
+Vancouver's in-text citation is a **number in parentheses** placed where the author–date parenthetical would otherwise go. Some journals render the same number as a superscript; this site's generator produces parentheses (`(1)`), and most biomedical journals accept either. The number points the reader to the matching entry in the reference list. There is no author name and no year inside the parenthetical — only the number.
+
+### One source
+
+The first time you cite a source, give it the next available number. Use that same number every subsequent time you cite it. The number is enclosed in parentheses and placed before the closing punctuation of the sentence.
+
+Example: Working memory capacity correlates with reading comprehension across age groups (1).
+
+### Multiple sources in one citation
+
+When a single claim cites several sources at once, list the numbers inside one set of parentheses. Consecutive numbers collapse to a range with an en dash; non-consecutive numbers are separated by commas with no spaces.
+
+Consecutive: Three trials converge on this pattern (1–3).
+
+Non-consecutive: Several reviews report the same effect (1,4,7).
+
+Mixed: A broader literature supports the finding (1–3,7,9–11).
+
+The engine sorts the numbers ascending and applies the collapse automatically. NLM *Citing Medicine* uses a comma with no following space inside the parenthetical, which is what this site's generator produces.
+
+### Author-prominent narrative
+
+Sometimes you want to credit an author by name in running prose. Place the number right after the author's name (or after the final author for a group).
+
+Example: Chen (1) argues that working memory operates less like a storage bin and more like a workspace.
+
+For two authors, name both: "Lin and Patel (2) report…" For three or more, name the first author and add *et al.* in roman: "Goldstein et al. (3) found…" NLM *Citing Medicine* uses *et al.* in roman, not italics — a small detail that distinguishes Vancouver from styles that italicize Latin abbreviations.
+
+### Direct quotes
+
+Direct quotations are uncommon in biomedical writing — most clinical and basic-science work paraphrases — but Vancouver does support them. Place the number after the closing quotation mark and add a page number after a comma with a `p.` abbreviation.
+
+Example: Working memory is "a flexible mental workspace, not a fixed bin of slots" (1, p. 47).
+
+For sources without page numbers, point the reader to whatever locator the source provides — a section heading, a paragraph number, a timestamp — or omit the locator entirely if nothing is available.
+
+### Sequencing rules: first mention assigns the number; reuse keeps it
+
+The single most important Vancouver mechanic, and the one most likely to trip a writer coming from APA or MLA, is that **numbers are assigned by order of first appearance**. The first source you cite in the body is reference 1 in the back. The second *new* source is reference 2. If your third sentence cites the same source as your first, the third sentence uses `(1)` again — not `(3)`. The number belongs to the source, not to the citation event.
+
+The practical consequence is that reordering paragraphs during revision can require renumbering the reference list. Citation managers handle this automatically; if you're numbering by hand, do it last, after the prose is final. The reference list is also not alphabetical — a reader scanning for "Chen" cannot flip to the Cs the way they would in APA. They find the matching number in the text and look up that number in the list.
+
+## Reference list format
+
+The reference list goes on its own page at the end of the manuscript with the heading **References** at the top — not italicized, not bolded, just the word "References" in the same font as the body. Some journals prefer "Bibliography" or no heading at all; check your target journal's instructions to authors. Every source cited in the body must appear here, and every entry here must be cited at least once.
+
+Entries are **numbered**, starting at 1, in the order they were first cited in the text. The number is followed by a period and a single space, then the entry. The page is single-spaced within and between entries in most submission formats. There is no hanging indent — Vancouver entries are flush left, or the citation number is set apart in its own column with the entry text aligned beside it. Either rendering is correct.
+
+The author block is where Vancouver diverges most visibly from author–date styles. Authors are listed by **surname followed by initials**, with no comma between surname and initials and no period after each initial. So Margaret S. Chen becomes `Chen MS` — not `Chen, M.S.` and not `Chen M. S.` Multiple authors are separated by commas; the last author is followed by a period. NLM *Citing Medicine* (2nd ed.) sets the threshold for *et al.* at **seven authors**: list the first six in full, then "et al." (Some journal house styles cap the list at three or four authors — always check your target journal — but the NLM default is six-then-*et al.*)
+
+Capitalization is **sentence case** for article, chapter, and book titles — only the first word, the first word after a colon, and proper nouns are capitalized. Journal names use the **NLM-standard abbreviation** (`J Cogn Dev` for *Journal of Cognitive Development*; `N Engl J Med` for the *New England Journal of Medicine*). The canonical lookup is the NLM Catalog — search for the journal and read off the "Title Abbreviation" field. Journal names are followed by a period and the year, with no italics. The volume, issue in parentheses, and page range follow with no spaces between them: `2024;19(2):87–104`.
+
+The most distinctive Vancouver decision is the absence of italics. NLM *Citing Medicine* italicizes nothing in the standard reference entry — not journal names, not book titles, not Latin abbreviations like *et al.* or *in*. The convention descends from a print-economy tradition in which italic type was reserved for emphasis and avoided in dense reference lists. A Vancouver reference list rendered with italicized journal names is a recognizable submission error.
+
+## Source-type examples
+
+The entries below use the same fixture sources referenced throughout this guide and show each common source type formatted exactly as NLM *Citing Medicine* prescribes. In your own document, set them single-spaced within entries, in citation-sequence order with the number-period prefix.
+
+| Source type | Reference list entry |
+| --- | --- |
+| Book (single author) | Chen MS. The architecture of working memory. Cambridge (UK): Cambridge University Press; 2021. |
+| Chapter in edited book | Lin DK, Patel HJ. Cross-modal attention in early development. In: Morrison RT, editor. Handbook of developmental cognition. London: Routledge; 2022. p. 142–168. |
+| Journal article with DOI | Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. https://doi.org/10.1037/cogdev0000412. |
+| Web article | Alvarez S. How working memory predicts reading comprehension. Psychology Today. 2023 Mar 12 [cited 2026 May 20]. Available from: https://www.psychologytoday.com/intl/blog/working-memory-reading-comprehension. |
+| Government report | U.S. Department of Education, Institute of Education Sciences. Reading proficiency and learning loss in U.S. fourth-graders, 2019–2022. Washington (DC): National Center for Education Statistics; 2023. Report No.: NCES 2023-145. Available from: https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145. |
+| Conference paper | Tanaka Y, Hoffmann M. A unified model of attention in dual-task performance. In: Proceedings of the 63rd Annual Meeting of the Psychonomic Society; 2022 Nov 4–6; Boston (MA). |
+| Doctoral dissertation | Kowalski ER. Memory consolidation in bilingual speakers: an fMRI investigation [doctoral dissertation]. Ann Arbor (MI): University of Michigan; 2020. |
+
+A few details to notice. The book entry uses `Cambridge (UK)` to disambiguate the city — NLM *Citing Medicine* recommends a country or U.S. state abbreviation for any city that could be confused with another (Cambridge UK vs. Cambridge MA). The chapter entry uses `In:` (no italics) and labels the editor explicitly (`Morrison RT, editor.`) rather than wrapping the name in parentheses the way APA does. The journal entry collapses the title to its NLM abbreviation and packs year, volume, issue, and pages into the no-space `2024;19(2):87–104` block, with the DOI hanging at the end as a full URL. The web article uses NLM's bracketed `[cited 2026 May 20]` for the access date and prefixes the URL with `Available from:` — different from MLA's `Available at:`. The government report carries a `Report No.:` element after the publisher and year. The conference paper opens with `In: Proceedings of…` and gives the dates in NLM's `2022 Nov 4–6` form. The dissertation is bracketed as `[doctoral dissertation]`. If you're entering one of these into the generator at /, the tool assembles the dense punctuation for you.
+
+## Common mistakes
+
+These five errors account for most of the marks students and reviewers flag on Vancouver references. Each shows the wrong version above the right one.
+
+**Italicizing the journal name.**
+Wrong: *J Cogn Dev.* 2024;19(2):87–104.
+Right: J Cogn Dev. 2024;19(2):87–104.
+
+Vancouver italicizes nothing in standard references. If your word-processor template adds italics automatically, override it.
+
+**Superscript citation numbers when the journal expects parenthetical.**
+Wrong: …predicts reading comprehension¹.
+Right: …predicts reading comprehension (1).
+
+Both forms exist across Vancouver-style journals. The ICMJE *Recommendations* accept either as long as the choice is consistent. This site's generator produces parentheses; if your target journal requires superscript, convert by hand.
+
+**Spelling out the journal name in full.**
+Wrong: Journal of Cognitive Development. 2024;19(2):87–104.
+Right: J Cogn Dev. 2024;19(2):87–104.
+
+NLM-style references use the journal's official abbreviated title from the NLM Catalog. Spelling the name out in full is incorrect under *Citing Medicine*. If the journal isn't indexed by NLM, abbreviate by the same conventions (drop articles, abbreviate per ISO 4); when truly nothing is documented, the full name is better than a guessed abbreviation.
+
+**Commas inside the author block.**
+Wrong: Goldstein, A., Ramanathan, P., O'Connor, L.
+Right: Goldstein A, Ramanathan P, O'Connor L.
+
+Surname, then initials, no comma between them and no period after each initial. Authors are separated from each other by commas, and the block ends with a single period.
+
+**Alphabetizing the reference list.**
+Wrong: Sorting the back-of-paper list by author surname.
+Right: Numbering by **order of first citation** in the body.
+
+The Vancouver reference list is keyed to in-text numbers, which are themselves keyed to order of first appearance. Alphabetizing breaks the link. If you're numbering by hand, do it last and verify each entry's position matches its first in-text mention.
+
+## How Vancouver differs from author–date styles
+
+If most of the citation styles you have used are author–date (APA, Chicago, Harvard) or author–page (MLA), Vancouver will feel strange for the first few paragraphs and then click. The clearest way to see the differences is to render the same source side by side.
+
+Take the journal-article fixture. In APA 7, the reference is:
+
+> Goldstein, A., Ramanathan, P., & O'Connor, L. (2024). Sleep consolidation effects on procedural learning in adolescents. *Journal of Cognitive Development, 19*(2), 87–104. https://doi.org/10.1037/cogdev0000412
+
+In Vancouver (NLM *Citing Medicine* 2nd ed.), the same source is:
+
+> Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. https://doi.org/10.1037/cogdev0000412.
+
+The two entries point to the same article. They differ in five places, every one reflecting Vancouver's compactness ethos. The authors lose their commas, their periods after initials, and the ampersand. The year moves from immediately-after-the-author to immediately-after-the-journal-title. The journal name shrinks to its NLM abbreviation and loses its italics. The volume, issue, and pages compress into a no-space `19(2):87–104` block. The DOI hangs at the end with a trailing period.
+
+The in-text citations differ even more visibly. APA wants `(Goldstein et al., 2024)`; Vancouver wants `(1)`. APA's parenthetical carries authorship and date that the reader can interpret without flipping pages; Vancouver's number means nothing until you turn to the reference list. The trade-off is that APA's parentheticals become unreadable when several stack up — `(Goldstein et al., 2024; Chen, 2021; Lin & Patel, 2022; Tanaka & Hoffmann, 2022)` is a mouthful — while Vancouver collapses the same string to `(1–4)`. The ICMJE *Recommendations* prefer the numeric form precisely because clinical writing supports dense, multi-source claims that author–date parentheticals cannot carry without disrupting the reader.
+
+A second difference is reference-list ordering. APA, Chicago, and MLA all alphabetize by author surname; Vancouver orders by first-citation sequence. A Vancouver reference list reflects the structure of the argument — the order in which sources came into play. Neither is better; they answer different questions. APA's list answers "have they cited Smith?"; Vancouver's answers "what did they cite, in the order they used it?"
+
+Typography is the third visible difference. Vancouver italicizes nothing. APA italicizes the journal title and volume; MLA italicizes journal and book titles; Chicago italicizes both. The Vancouver convention reads as clinical and clipped — the register medical journals have asked for since the 1978 meeting that named the style.


### PR DESCRIPTION
## Summary
Fifth content PR in the [content & SEO overhaul](docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md). New `/guides/vancouver` page — the first **non-rewrite** guide in PR 2 (previous four were rewrites of existing pages; this one is a brand-new guide for a style the engine supports but the site has never documented).

### What changed
- New file `src/content/guides/vancouver.mdx` — ~2,500 body words.
- Covers **NLM/Vancouver: Citing Medicine 2nd edition (citation-sequence)** — the variant the engine ships in `functions/lib/format/styles/vancouver.csl`.
- 6 body H2s + H3 subsections + 7 worked examples + 5 FAQ items.
- "How Vancouver differs from author-date styles" section shows the same journal article rendered in Vancouver vs APA so readers see numeric-vs-author-date concretely.
- Internal links to `/guides/apa`, `/guides/ieee`, `/guides/ama` (the latter two land in upcoming PRs; the RelatedGuides component silently drops missing entries).

### Engine alignment (caught by pre-merge review)
Same pattern as the Harvard PR — the reviewer ran the actual CSL engine against the Vancouver fixture set and surfaced 8 places where the engine produces output that doesn't match NLM *Citing Medicine* printed conventions. Per the guide's "this is what the site generates" framing, all examples and rules were aligned to actual engine output:

| Element | NLM printed convention | Engine output | Guide now teaches |
|---|---|---|---|
| Place format | `Cambridge (UK)` parentheses | `Cambridge, UK` comma | Comma form |
| Page-range elision | Either form | Minimal (`142–68`) | Minimal |
| DOI prefix | `https://doi.org/...` | `doi:10.xxx/...` | `doi:` prefix |
| Webpage structure | author. title. container. date... | author. container [Internet]. year [cited date]. title. URL. | Engine order |
| Conference paper | Full date + city | Year only, no city | Year only |
| Report number | `Report No.: NCES 2023-145` | `Report NCES 2023-145` | No `No.:` |
| Dissertation place | `Ann Arbor (MI):` | `[Ann Arbor, MI]:` brackets + comma | Brackets + comma |

The mismatches between printed conventions and engine output are worth a separate follow-up engine PR (likely CSL term/macro tweaks). Out of scope here. Guide is honest about what the generator currently produces.

## Test plan
- [x] `npm run build` clean
- [x] 5 JSON-LD blocks render
- [x] 6 body H2s + 5 H3 subsections + ToC anchors
- [x] All 7 worked examples match engine output verbatim (verified by reviewer probe)
- [x] No banned voice phrases
- [ ] After merge: validate live URL via Google Rich Results Test

## Pre-merge review
Fresh-context Opus review with engine-verification (reviewer ran citeproc.ts against vancouver.csl on every fixture) found 8 blocking findings plus polish items. All addressed before opening this PR.

## Known follow-up (not in this PR)
The engine's Vancouver CSL deviates from NLM *Citing Medicine* in several places (place format, DOI form, webpage structure, conference compression). Worth a separate engine PR to align where reasonable — but this content PR ships the guide for the current engine state.