### PR TITLE
Add AMA guide (AMA Manual of Style 11th edition)

### DIFF
--- a/src/content/guides/ama.mdx
+++ b/src/content/guides/ama.mdx
@@ -145,7 +145,7 @@ AMA 11th caps the in-list author count at three before truncating with `et al` o
 
 ## How AMA differs from Vancouver
 
-AMA and Vancouver are first cousins. Both are numeric citation-sequence systems from the same NLM tradition, both use surname-plus-initials author blocks, both order references by first appearance. If a reviewer asks "is this AMA or Vancouver?" the answer comes down to four typographical tells. Rendering the same journal article in both styles makes them concrete.
+AMA and Vancouver are first cousins. Both are numeric citation-sequence systems from the same NLM tradition, both use surname-plus-initials author blocks, both order references by first appearance. If a reviewer asks "is this AMA or Vancouver?" the answer comes down to three typographical tells. Rendering the same journal article in both styles makes them concrete.
 
 In AMA (AMA Manual of Style, 11th ed.):
 
@@ -153,9 +153,9 @@ In AMA (AMA Manual of Style, 11th ed.):
 
 In Vancouver (NLM *Citing Medicine*, 2nd ed.):
 
-> 1. Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. doi:10.1037/cogdev0000412.
+> 1. Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. doi:10.1037/cogdev0000412
 
-The two entries point to the same article. Four differences stand out:
+The two entries point to the same article. Three differences stand out:
 
 **Journal-name italicization.** AMA italicizes the abbreviated journal title (`*J Cogn Dev*`); Vancouver does not. This is the most visually obvious distinction and the one a typesetter will spot immediately.
 
@@ -163,8 +163,6 @@ The two entries point to the same article. Four differences stand out:
 
 **Author cap before *et al.*** AMA truncates after the third author for seven-or-more-author sources. Vancouver truncates after the sixth. A six-author paper renders all six in both styles; a seven-author paper renders three-plus-*et al.* in AMA and six-plus-*et al.* in Vancouver.
 
-**Terminal punctuation on the DOI.** AMA omits the trailing period after the DOI (`doi:10.1037/cogdev0000412`); Vancouver appends one. A small but consistent distinction.
-
 The in-text format also differs. AMA prescribes superscript numerals as the published default (`…reading comprehension.¹`), while Vancouver renders the same number in parentheses on the baseline (`…reading comprehension (1).`). Both styles permit the alternative form, but the defaults distinguish them at a glance.
 
-If your manuscript guidelines say "AMA" and you are coming from Vancouver, the conversion checklist is short: italicize abbreviated journal names, convert en dashes to hyphens, drop the trailing period from DOIs, and truncate author lists at three instead of six. Most reference managers offer an AMA output style that handles all four in one switch.
+If your manuscript guidelines say "AMA" and you are coming from Vancouver, the conversion checklist is short: italicize abbreviated journal names, convert en dashes to hyphens, and truncate author lists at three instead of six. Most reference managers offer an AMA output style that handles all three in one switch.

--- a/src/content/guides/ama.mdx
+++ b/src/content/guides/ama.mdx
@@ -1,0 +1,170 @@
+---
+title: 'AMA Citation Guide: AMA Manual of Style 11th Edition'
+pubDate: 2026-05-27
+updatedDate: 2026-05-27
+description: 'Complete AMA guide following the AMA Manual of Style 11th edition (the variant this site generates). Numeric in-text citations, numbered reference list, italicized abbreviated journal names, worked examples for every common source type. Written and reviewed by the MLA Generator Editorial Team.'
+category: 'style-guide'
+keywords: ['AMA citation', 'AMA Manual of Style', 'AMA format', 'medical citation', 'JAMA citation', 'NEJM citation', 'numeric citation medical']
+tags: ['AMA', 'medical citation', 'JAMA', 'numeric citations', 'references', 'medicine']
+relatedGuides: ['vancouver', 'apa', 'ieee', 'how-to-cite-a-journal-article', 'in-text-citations']
+faq:
+  - question: 'Who maintains AMA style and what edition is current?'
+    answer: 'The American Medical Association publishes *AMA Manual of Style: A Guide for Authors and Editors* through Oxford University Press. The current edition is the 11th, released in February 2020. This guide and this site''s generator both follow that edition. AMA style is the house style at *JAMA* and the *JAMA Network* family of journals, and is widely adopted across U.S. medical and clinical publishing.'
+  - question: 'What does an AMA in-text citation look like?'
+    answer: 'The AMA Manual of Style prescribes a **superscript Arabic numeral** placed after the punctuation it follows — for example, "Working memory predicts reading comprehension.¹" Numbers are assigned in the order sources first appear; if you cite the same source again, you reuse the original number. Consecutive numbers collapse to a range with a hyphen (¹⁻³), and non-consecutive numbers are separated by commas with no spaces (¹,⁴,⁷). Some manuscript templates render the numerals as parenthetical (1) instead — the AMA Manual permits the parenthetical form, but the superscript form is the published default.'
+  - question: 'How does AMA differ from Vancouver if both are numeric NLM-derived styles?'
+    answer: 'Both order references in citation-sequence and both use surname-plus-initials author blocks with no commas inside (`Chen MS`). The visible differences: AMA italicizes the abbreviated journal name (*J Cogn Dev*), Vancouver does not (J Cogn Dev). AMA uses a hyphen in page ranges (87-104), Vancouver uses an en dash (87–104). AMA caps the in-list author list at three before *et al.* (first 3, then et al. for 7+ authors); NLM Vancouver caps at six (first 6, then et al. for 7+). AMA writes web access dates as `Accessed May 20, 2026.`; Vancouver uses bracketed `[cited 2026 May 20]`. The two styles are siblings, but anyone reading carefully can tell them apart.'
+  - question: 'How do I find the AMA-approved abbreviation for a journal name?'
+    answer: 'The AMA Manual directs authors to use the abbreviated journal title indexed by the U.S. National Library of Medicine. The NLM Catalog (https://www.ncbi.nlm.nih.gov/nlmcatalog/journals) is the canonical lookup — search for the journal and read the "Title Abbreviation" field. *The New England Journal of Medicine* is *N Engl J Med*. *JAMA Internal Medicine* is *JAMA Intern Med*. If a journal is not indexed by NLM, abbreviate using the same ISO 4 conventions (drop articles like "the" and "of"; reduce common words to standard short forms). When in doubt, use the full italicized name — readers find a guessed abbreviation more confusing than a long one. This site''s generator emits whatever abbreviated form you supply in the journal field; it does not look up NLM abbreviations automatically.'
+  - question: 'How does AMA format DOIs and URLs?'
+    answer: 'For sources with a DOI, AMA appends the DOI in the compact form `doi:10.xxxx/xxxxx` (lowercase prefix, no space after the colon, no `https://` URL form). For sources without a DOI but with a URL — typically web articles and online reports — AMA uses `Accessed Month DD, YYYY.` followed by the bare URL. The Manual no longer requires the `Available at:` prefix; the URL appears on its own after the access sentence. If both a DOI and a URL are available, prefer the DOI.'
+ogImage: '/images/banner.png'
+---
+
+AMA is the citation style of American medical publishing — the house style at *JAMA*, the *JAMA Network* family of journals, and most U.S. clinical and biomedical venues that do not specifically require Vancouver or NLM. The variant this site generates is the **AMA Manual of Style, 11th edition** (Oxford University Press, 2020). If your manuscript guidelines say "AMA," reference a *JAMA* author kit, or point to the AMA Manual itself, this is the style you want.
+
+> The shortest version of AMA: a superscript number in the text (¹), a numbered reference list at the back ordered by first citation, surname-plus-initials author blocks (`Chen MS`), italicized abbreviated journal names (*J Cogn Dev*), and page ranges with a hyphen. First three authors then `et al.` once you reach seven.
+
+## What AMA is and when you'll use it
+
+The *AMA Manual of Style* began as a slim editorial handbook for *JAMA* contributors and now runs more than a thousand pages, governing reference formatting at *JAMA*, *JAMA Internal Medicine*, *JAMA Pediatrics*, and dozens of allied U.S. medical journals. The 11th edition was released in February 2020 by Oxford University Press, and every rule below is keyed to that revision.
+
+You'll be asked for AMA in clinical medicine, public health, health-services research, surgery, oncology, pediatrics, and most U.S. medical-school coursework. The style descends from the same numeric-citation tradition that produced Vancouver and the NLM *Citing Medicine* guidelines, and it borrows much of NLM's mechanics — abbreviated journal names from the NLM Catalog, surname-plus-initials author blocks, citation-sequence ordering. Where AMA diverges is mostly typographical: italicized journal abbreviations, hyphenated page ranges, a tighter author cap before *et al.*, and a superscript in-text format.
+
+Why a numeric system at all? Medical writing cites densely — a single clinical-trial discussion sentence routinely supports its claim with three or four prior trials, a systematic review, and a guideline document. Author–date parentheticals turn into speed bumps in that context, while superscript numerals stay out of the way. The trade-off is identification at a glance: AMA's `¹` tells the reader nothing about *who* or *when* until they look it up.
+
+## In-text citations
+
+The AMA Manual prescribes **superscript Arabic numerals** for in-text citations. The numeral sits after the punctuation when the citation refers to the whole sentence, and immediately after the word or phrase when it refers to a single mid-sentence point. There is no author name and no year inside the citation — only the number.
+
+### One source
+
+The first time you cite a source, give it the next available number. Use that same number every subsequent time you cite it. The numeral sits in superscript after the closing punctuation of the sentence.
+
+Example: Working memory capacity correlates with reading comprehension across age groups.¹
+
+If the cited source supports only one clause of a longer sentence, place the numeral immediately after that clause: "Working memory predicts reading comprehension¹ and is correlated with executive function² in school-age children."
+
+### Multiple sources in one citation
+
+When a single claim cites several sources, list the numerals together in superscript. Consecutive numbers collapse to a range with a hyphen; non-consecutive numbers are separated by commas with no spaces.
+
+Consecutive: Three trials converge on this pattern.¹⁻³
+
+Non-consecutive: Several reviews report the same effect.¹,⁴,⁷
+
+Mixed: A broader literature supports the finding.¹⁻³,⁷,⁹⁻¹¹
+
+Some journal copy desks render the in-text numerals as parenthetical `(1)` instead of superscript — the Manual permits the parenthetical form when superscript is not available — but superscript is the *JAMA* default.
+
+### Author-prominent narrative
+
+Sometimes you want to credit an author by name in running prose. Place the superscript numeral after the author's name (or after the final author for a group). The number sits in superscript immediately after the name, with no space.
+
+Example: Chen¹ argues that working memory operates less like a storage bin and more like a workspace.
+
+For two authors, name both: "Lin and Patel² report…" For three or more, use the first author's surname plus *et al.* in italics: "Goldstein et al³ found…" (AMA italicizes *et al.* in body text; the reference list itself sets the abbreviation in plain text.)
+
+### Direct quotes
+
+Direct quotations are uncommon in clinical writing — most biomedical work paraphrases — but AMA supports them. The Manual places the superscript numeral after the closing quotation mark, with the page locator in parentheses after the citation number.
+
+Example: Working memory is "a flexible mental workspace, not a fixed bin of slots."¹⁽ᵖ⁴⁷⁾
+
+Most authors avoid the awkward superscripted parenthetical and render the locator in the running text instead: "as Chen describes,¹ working memory is 'a flexible mental workspace, not a fixed bin of slots' (p 47)." Either is acceptable when the journal's instructions do not specify.
+
+### Sequencing rules: first mention assigns the number; reuse keeps it
+
+The most important AMA mechanic — and the one most likely to trip a writer coming from APA or MLA — is that **numbers are assigned by order of first appearance**. The first source cited becomes reference 1 in the back. The second *new* source is reference 2. If your third sentence cites the same source as your first, the third sentence uses `¹` again — not `³`. The number belongs to the source, not the citation event.
+
+Reordering paragraphs during revision can require renumbering. Reference managers handle this automatically; if you are numbering by hand, do it last, after the prose is final. The reference list is not alphabetical — a reader looking for "Chen" finds the matching number in the text and reads it off the list.
+
+## Reference list format
+
+The reference list goes on its own page at the end of the manuscript with the heading **References** at the top — not italicized, not bolded, just the word in the same font as the body. Every source cited must appear here, and every entry must be cited at least once.
+
+Entries are **numbered**, starting at 1, in the order first cited. The citation number is followed by a period and a single space, then the entry. AMA layouts typically render the page single-spaced within entries and double-spaced between them; consult your target journal's instructions for the exact rendering. There is no hanging indent — AMA entries are flush left, with the citation number leading the line.
+
+The author block follows the NLM convention with a tighter cap. Authors are listed by **surname followed by initials**, with no comma between surname and initials and no period after each initial. Margaret S. Chen becomes `Chen MS` — not `Chen, M.S.` Multiple authors are separated by commas; the block ends with a period. AMA caps the in-list author count at **three** before truncating: when a source has seven or more authors, list the first three and append `et al` (no italics in the reference list, no terminal period before the next element). For six or fewer authors, list everyone. This is tighter than NLM Vancouver's first-six-then-*et al.* rule.
+
+Article and chapter titles use **sentence case** — only the first word, the first word after a colon, and proper nouns capitalized — and carry no quotation marks and no italics. Book, report, and dissertation titles use **title case** and are **italicized**. Journal titles are **italicized** and **abbreviated** using the NLM Catalog short form: *Journal of Cognitive Development* becomes `*J Cogn Dev*`; *New England Journal of Medicine* becomes `*N Engl J Med*`. This italicization is the most visible AMA-vs-Vancouver difference — Vancouver uses the same abbreviation in roman.
+
+The bibliographic block packs year, volume, issue, and pages into a no-space sequence with semicolon and colon delimiters: `2024;19(2):87-104`. The page range uses a **hyphen**, not an en dash. DOIs follow in the compact form `doi:10.xxxx/xxxxx` (lowercase prefix, no space, no URL prefix), appended after the page range with no terminal period. When only a URL is available, the access sentence reads `Accessed Month DD, YYYY.` followed by the bare URL.
+
+This site's generator does not look up NLM abbreviations automatically. Supply the abbreviated journal name in the source's journal field if you want the AMA-correct short form; supply the full name and the engine will italicize it as you typed it. The canonical NLM abbreviation lookup is the NLM Catalog at https://www.ncbi.nlm.nih.gov/nlmcatalog/journals.
+
+## Source-type examples
+
+The entries below show each common source type formatted exactly as the *AMA Manual of Style* (11th ed.) prescribes — and exactly as this site's generator emits them. In your own document, set the citation number and entry on the same line, flush left, and follow your target journal's instructions for line spacing.
+
+| Source type | Reference list entry |
+| --- | --- |
+| Book (single author) | 1. Chen MS. *The Architecture of Working Memory*. Cambridge University Press; 2021. |
+| Chapter in edited book | 2. Lin DK, Patel HJ. Cross-modal attention in early development. In: Morrison RT, ed. *Handbook of Developmental Cognition*. Routledge; 2022:142-168. |
+| Journal article with DOI | 3. Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. *J Cogn Dev*. 2024;19(2):87-104. doi:10.1037/cogdev0000412 |
+| Web article | 4. Alvarez S. How working memory predicts reading comprehension. Psychology Today. March 12, 2023. Accessed May 20, 2026. https://www.psychologytoday.com/intl/blog/working-memory-reading-comprehension |
+| Government report | 5. U.S. Department of Education, Institute of Education Sciences. *Reading Proficiency and Learning Loss in U.S. Fourth-Graders, 2019-2022*. National Center for Education Statistics; 2023. Accessed May 20, 2026. https://nces.ed.gov/pubsearch/pubsinfo.asp?pubid=2023145 |
+| Conference paper | 6. Tanaka Y, Hoffmann M. A unified model of attention in dual-task performance. In: *Proceedings of the 63rd Annual Meeting of the Psychonomic Society*. 2022:412-419. |
+| Doctoral dissertation | 7. Kowalski ER. *Memory Consolidation in Bilingual Speakers: An fMRI Investigation*. Doctoral dissertation. University of Michigan; 2020. |
+
+A few details to notice. The book uses the publisher-semicolon-year form (`Cambridge University Press; 2021`) with no place-of-publication element — AMA 11th drops the publisher city from book references, a 10th-to-11th-edition simplification. The chapter uses `In:` (no italics) followed by the editor in initials-after-surname form with the `ed.` label (`Morrison RT, ed.`), then the italicized container in title case, publisher and year, and a colon-then-page-range with no space. The journal article packs year, volume, issue, and pages into the no-space `2024;19(2):87-104` block; the DOI follows in compact form with no terminal period. The web article italicizes nothing — AMA italicizes journal containers but treats web-content containers as plain text — and the issued date renders in full as `March 12, 2023`, distinct from journal entries that collapse the date to just the year. The government report sets its title in italicized title case (AMA italicizes report titles, where journal-article titles are roman sentence case). The conference paper uses the same `In:` introducer with no editor — the italicized proceedings title carries the venue. The dissertation carries its genre label (`Doctoral dissertation`) as a separate element between the italicized title and the granting institution.
+
+## Common mistakes
+
+These five errors account for most of the marks reviewers flag on AMA references. Each shows the wrong version above the right one.
+
+**Failing to italicize the abbreviated journal name.**
+Wrong: J Cogn Dev. 2024;19(2):87-104.
+Right: *J Cogn Dev*. 2024;19(2):87-104.
+
+The single most common AMA error in submissions from authors used to Vancouver. AMA italicizes the abbreviated journal title; Vancouver does not.
+
+**Spelling out the journal name in full.**
+Wrong: *Journal of Cognitive Development*. 2024;19(2):87-104.
+Right: *J Cogn Dev*. 2024;19(2):87-104.
+
+AMA, like Vancouver, uses the abbreviated title from the NLM Catalog. Look up the journal at https://www.ncbi.nlm.nih.gov/nlmcatalog/journals and read off the "Title Abbreviation" field. If the journal is not indexed, abbreviate by ISO 4 (drop articles such as "the" and "of"; reduce common words). When truly nothing is documented, the full name beats a guess.
+
+**Using an en dash in the page range.**
+Wrong: *J Cogn Dev*. 2024;19(2):87–104.
+Right: *J Cogn Dev*. 2024;19(2):87-104.
+
+AMA uses a **hyphen** in page ranges, not an en dash. The CSL locale this site ships overrides the default delimiter to a hyphen for AMA output. Vancouver uses an en dash — a recurring conversion gotcha.
+
+**Commas inside the author block.**
+Wrong: Goldstein, A., Ramanathan, P., O'Connor, L.
+Right: Goldstein A, Ramanathan P, O'Connor L.
+
+Surname, then initials, no comma between them and no period after each initial. Authors are separated from each other by commas, and the block ends with a single period. Authors moving from APA or MLA often carry over the period-after-initial habit.
+
+**Listing too many authors before truncating.**
+Wrong: Smith A, Jones B, Williams C, Brown D, Davis E, Miller F, Wilson G. …
+Right: Smith A, Jones B, Williams C, et al. …
+
+AMA 11th caps the in-list author count at three before truncating with `et al` once a source has seven or more authors. This is *tighter* than Vancouver's first-six rule and a frequent rejection trigger when an AMA-style manuscript is prepared with a Vancouver-configured reference manager.
+
+## How AMA differs from Vancouver
+
+AMA and Vancouver are first cousins. Both are numeric citation-sequence systems from the same NLM tradition, both use surname-plus-initials author blocks, both order references by first appearance. If a reviewer asks "is this AMA or Vancouver?" the answer comes down to four typographical tells. Rendering the same journal article in both styles makes them concrete.
+
+In AMA (AMA Manual of Style, 11th ed.):
+
+> 1. Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. *J Cogn Dev*. 2024;19(2):87-104. doi:10.1037/cogdev0000412
+
+In Vancouver (NLM *Citing Medicine*, 2nd ed.):
+
+> 1. Goldstein A, Ramanathan P, O'Connor L. Sleep consolidation effects on procedural learning in adolescents. J Cogn Dev. 2024;19(2):87–104. doi:10.1037/cogdev0000412.
+
+The two entries point to the same article. Four differences stand out:
+
+**Journal-name italicization.** AMA italicizes the abbreviated journal title (`*J Cogn Dev*`); Vancouver does not. This is the most visually obvious distinction and the one a typesetter will spot immediately.
+
+**Page-range glyph.** AMA uses a hyphen (`87-104`); Vancouver uses an en dash (`87–104`). The difference is set at the locale level — AMA's CSL overrides the page-range delimiter to a hyphen, while Vancouver inherits the en-dash default.
+
+**Author cap before *et al.*** AMA truncates after the third author for seven-or-more-author sources. Vancouver truncates after the sixth. A six-author paper renders all six in both styles; a seven-author paper renders three-plus-*et al.* in AMA and six-plus-*et al.* in Vancouver.
+
+**Terminal punctuation on the DOI.** AMA omits the trailing period after the DOI (`doi:10.1037/cogdev0000412`); Vancouver appends one. A small but consistent distinction.
+
+The in-text format also differs. AMA prescribes superscript numerals as the published default (`…reading comprehension.¹`), while Vancouver renders the same number in parentheses on the baseline (`…reading comprehension (1).`). Both styles permit the alternative form, but the defaults distinguish them at a glance.
+
+If your manuscript guidelines say "AMA" and you are coming from Vancouver, the conversion checklist is short: italicize abbreviated journal names, convert en dashes to hyphens, drop the trailing period from DOIs, and truncate author lists at three instead of six. Most reference managers offer an AMA output style that handles all four in one switch.


### PR DESCRIPTION
## Summary
Seventh content PR in the [content & SEO overhaul](docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md). New `/guides/ama` page — AMA Manual of Style 11th edition (numeric, used in JAMA, NEJM, and other medical journals).

### What changed
- New file `src/content/guides/ama.mdx` — ~2,500 body words.
- 6 body H2s + H3 subsections + 7 worked examples + 5 FAQ items.
- "How AMA differs from Vancouver" section makes the AMA-vs-Vancouver comparison concrete with a side-by-side journal article rendering.

### Engine verification
Engine-verified approach (same as IEEE PR #24). Implementer wrote a temporary vitest probe against `formatCitation` for all 7 fixtures and aligned every claim to actual engine output. Verified:
- Superscript in-text via `<layout vertical-align="sup">`
- et al. threshold: 7+ authors → first 3 + et al. (tighter than Vancouver's 6 + et al.)
- Hyphen page-range delimiter (AMA locale override; differs from Vancouver's en-dash)
- DOI form `doi:10.1037/cogdev0000412` (no terminal period — both AMA and Vancouver render this way)
- Book reference drops publisher city in AMA 11
- Web article container plain text (not italic)
- Like IEEE, the engine doesn't auto-abbreviate journal names — guide is honest about user-supplied abbreviations

### Pre-merge review caught one false comparison
Initial draft claimed Vancouver appends a terminal period after DOIs while AMA omits it. The reviewer's engine probe showed neither style appends a period — both render `doi:10.1037/cogdev0000412` (no period). False claim removed, adjacent section count and conversion checklist updated accordingly.

(Worth noting: the existing Vancouver guide (currently on main) also makes the same wrong claim in its own worked example. Follow-up patch can fix that.)

## Test plan
- [x] `npm run build` clean
- [x] Engine probe confirms all 7 worked examples match output
- [x] 5 JSON-LD blocks, 6 body H2s, 5 H3 subsections
- [x] No banned voice phrases
- [ ] After merge: validate live URL via Google Rich Results Test

## What follows
PR 2h: research-and-works-cited rewrite (the last content PR in the spec). Plus separate work to address production issues the user just flagged (Lighthouse perf 64, accessibility 92, mobile hamburger layout bug).