### PR TITLE
Fix mobile header layout, a11y gaps, and unused font preload

### DIFF
--- a/src/components/astro/BaseHead.astro
+++ b/src/components/astro/BaseHead.astro
@@ -40,9 +40,9 @@ const allSchemas = [...baseSchemas, ...extraSchemas];
 
 <link
     rel="preload"
-    href="https://mlagenerator.com/fonts/Manrope-VariableFont_wght.ttf"
+    href="https://mlagenerator.com/fonts/FormaDJRVariable.woff2"
     as="font"
-    type="font/ttf"
+    type="font/woff2"
     crossorigin
 />
 

--- a/src/components/astro/Header.astro
+++ b/src/components/astro/Header.astro
@@ -36,10 +36,10 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
     </ul>
   </nav>
   <div id="obscure"></div>
-  <button id="mobile-menu-toggle">
-    <div class="menu-bar"></div>
-    <div class="menu-bar"></div>
-    <div class="menu-bar"></div>
+  <button id="mobile-menu-toggle" type="button" aria-label="Toggle menu" aria-expanded="false" aria-controls="primary-nav">
+    <div class="menu-bar" aria-hidden="true"></div>
+    <div class="menu-bar" aria-hidden="true"></div>
+    <div class="menu-bar" aria-hidden="true"></div>
   </button>
   <a class="button-primary" href="/">
     <BookOpenIcon className="button-icon" />
@@ -135,6 +135,14 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
     }
   }
   @media (max-width: 1050px) {
+    /* Take the nav landmark out of the header grid below 1050px so the
+       hamburger doesn't get pushed onto a second row. The nav still exists
+       in the DOM (its role is preserved by modern browsers/screen readers);
+       its children become direct grid items, and the menu ul is itself
+       display:none until header[open] adds the position-absolute dropdown. */
+    #primary-nav {
+      display: contents;
+    }
     .sub-menu {
       flex-direction: column;
       align-items: flex-start !important;
@@ -252,11 +260,13 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
   const obscure = document.getElementById("obscure");
 
   mobileMenuToggle!.addEventListener("click", () => {
-    header!.toggleAttribute("open");
+    const isOpen = header!.toggleAttribute("open");
+    mobileMenuToggle!.setAttribute("aria-expanded", String(isOpen));
   });
 
   obscure!.addEventListener("click", (e) => {
     header!.removeAttribute("open");
+    mobileMenuToggle!.setAttribute("aria-expanded", "false");
   });
 
   // Sub-menu trigger: toggle aria-expanded on the button so screen readers

--- a/src/components/react/CitationSearch.tsx
+++ b/src/components/react/CitationSearch.tsx
@@ -8,12 +8,13 @@ import styles from "../../styles/citation-search.module.css";
 
 // Component for each search input field
 const SearchPanel = ({ label, placeholder, name }) => {
+    const inputId = `${name}-input`;
     return (
-        <div role="group" aria-labelledby={name} className={styles.labelContent}>
-            <span id={name} className={styles.inputLabel}>{label}</span>
+        <div className={styles.labelContent}>
+            <label htmlFor={inputId} id={name} className={styles.inputLabel}>{label}</label>
             <div className={styles.inputWrapper}>
-                <div className={styles.inputFade}></div>
-                <input type="text" placeholder={placeholder} name={name} autoComplete="off" />
+                <div className={styles.inputFade} aria-hidden="true"></div>
+                <input id={inputId} type="text" placeholder={placeholder} name={name} autoComplete="off" />
             </div>
         </div>
     );
@@ -73,7 +74,7 @@ const CitationSearch = forwardRef((props: { includeDropdown: Boolean, includeMan
             {props.includeManualCite && (
                 <a href="/my-references" className={styles.smallButton}>
                     <span>Cite Manually</span>
-                    <ChevronRightIcon className={styles.icon} />
+                    <ChevronRightIcon className={styles.icon} aria-hidden="true" />
                 </a>
             )}
         </Tabs>


### PR DESCRIPTION
## Summary
Three related fixes addressing live-site issues you flagged: mobile hamburger folding to a new line, Lighthouse a11y score 92 (should be 100), and Lighthouse perf 64.

### 1. Mobile hamburger layout
**Root cause:** The header grid has `grid-template-columns: 1fr auto auto` (3 cols) on desktop, narrows to 2 cols below 650px. After PR #15 added a `<nav>` landmark wrapper around the menu `<ul>`, the header has 4 visible grid items at <1050px (logo, nav wrapper with hidden menu inside, hamburger button, Create Citation button) — one wraps to a second row. Same problem at <650px when the grid shrinks to 2 cols.

**Fix:** `#primary-nav { display: contents }` below 1050px. The nav stops occupying a grid slot but its landmark role is preserved by modern browsers/screen readers. The menu `<ul>` inside is still `display: none` on mobile and becomes a position:absolute dropdown when `header[open]` — neither state contests the grid layout.

### 2. Lighthouse accessibility 92 → ~100
Two real gaps the audit was almost certainly flagging:

- **`#mobile-menu-toggle` had no accessible name.** Three `<div class="menu-bar">` icon bars with no text and no aria-label. Added `type="button"`, `aria-label="Toggle menu"`, `aria-expanded` (now syncs with open/close), `aria-controls="primary-nav"`. The icon bars are `aria-hidden="true"`. Open/close script updates `aria-expanded` on both toggle click and overlay-click-to-close.
- **CitationSearch inputs had no accessible name on the input itself** — only `aria-labelledby` on the parent `<div role="group">`. Lighthouse expects the input itself to be labeled. Replaced with a proper `<label htmlFor>` association. Also added `aria-hidden` to the decorative gradient fade `<div>` and to the `ChevronRightIcon` in the Cite Manually link.

### 3. Lighthouse performance — concrete win
**The biggest finding:** `BaseHead.astro` preloads `Manrope-VariableFont_wght.ttf` — **162 KB of TTF font that is never actually used.** The Manrope `@font-face` is commented out in `global.css`; the actual font is Forma DJR Variable (WOFF2, 114 KB), which had no preload at all.

Two birds: dropped the unused 162 KB Manrope preload, added the Forma WOFF2 preload (the font that's actually applied to text on the page). Net bandwidth saving on every page load.

Other perf observations not in this PR:
- `client:load` hydration on CitationSearch / References is appropriate (these are the primary tools — users interact immediately).
- Banner and site-icon PNGs are already small (9 KB / 2 KB).
- AdSense and Cloudflare beacon scripts already `async` / `defer`.
- React shared bundle is ~130 KB — heavy but not unusual. Code-splitting/route-based bundles could shave more later but it's a bigger refactor.

## Test plan
- [x] `npm run build` clean
- [x] No new banned voice phrases
- [ ] After deploy: verify hamburger sits inline at all mobile widths
- [ ] After deploy: re-run Lighthouse, confirm a11y goes to ~100 and perf moves materially (font preload alone should help LCP/CLS scores)