### PR TITLE
Hamburger menu fix: drop 2-col grid override at <650px

### DIFF
--- a/src/components/astro/Header.astro
+++ b/src/components/astro/Header.astro
@@ -192,9 +192,10 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
     }
   }
   @media (max-width: 650px) {
-    header {
-      grid-template-columns: 1fr auto !important;
-    }
+    /* Keep the default 3-column grid (1fr auto auto) — overriding to 2 columns
+       caused the hamburger button to wrap to a new row at narrow widths even
+       with #primary-nav using display:contents. The button-primary is still
+       hidden so the third column ends up zero-width auto. */
     header .button-primary {
       display: none;
     }


### PR DESCRIPTION
## Summary
Empirical fix you found: removing the 2-column grid override at <650px stops the hamburger from wrapping. The default 3-col grid (`1fr auto auto`) inherits down and the hidden button-primary just leaves an empty trailing column.

## Why my earlier fix wasn't enough
PR #26 added `#primary-nav { display: contents }` at <1050px so the nav wrapper would stop occupying a grid slot. In theory that should leave 2 grid items (logo + hamburger) at <650px, which a 2-col grid handles. In practice it didn't — the hamburger still wrapped. The compiled CSS verified `display: contents` was active, but something about the browser's layout still wasn't cooperating with 2 cols. Your test confirmed the 2-col override itself is the source of the regression.

The 3-col default keeps `1fr auto auto`. With button-primary `display: none` at <650px, the third `auto` column is zero-width and the hamburger sits in column 2 on the right edge — same visual outcome you wanted, no wrapping.

## Test plan
- [x] `npm run build` clean
- [ ] After deploy, confirm hamburger sits inline at all mobile widths