### PR TITLE
Rewrite research-and-works-cited meta guide

### DIFF
--- a/src/content/guides/research-and-works-cited.mdx
+++ b/src/content/guides/research-and-works-cited.mdx
@@ -1,98 +1,120 @@
 ---
-title: 'Mastering Your Sources: A Guide to Research & Works Cited Pages'
+title: 'Research and Works Cited: A Complete Guide to Sourcing Academic Papers'
 pubDate: 2024-03-11
 updatedDate: 2026-05-27
-description: 'Strong research is the backbone of any credible academic paper. But gathering information is just the first step. Effectively using and citing your sources is crucial for establishing your credibility and avoiding plagiarism. This guide will equip you with the knowledge to navigate the most common citation styles (MLA, APA, Chicago, Harvard) and craft a polished works cited page.'
+description: 'How to find, evaluate, integrate, and cite sources across the seven major academic styles. Coverage of finding reliable sources, avoiding plagiarism, choosing the right citation style, and building a polished works cited page. Written and reviewed by the MLA Generator Editorial Team.'
 category: 'meta'
-tags: ['research', 'citations', 'works cited', 'MLA', 'APA', 'Chicago', 'Harvard']
+keywords: ['research and citation', 'works cited page', 'how to cite sources', 'evaluating sources', 'choosing citation style', 'avoiding plagiarism', 'integrating sources']
+tags: ['research', 'citations', 'works cited', 'sources', 'academic writing', 'plagiarism', 'MLA', 'APA', 'Chicago', 'Harvard']
+relatedGuides: ['apa', 'mla', 'chicago', 'harvard', 'vancouver', 'ieee', 'ama']
+faq:
+  - question: 'How do I evaluate whether a source is reliable?'
+    answer: 'Check four things in order: who wrote it (named expert with credentials in the field, or anonymous/AI?), where it was published (peer-reviewed journal, university press, reputable publisher, .gov/.edu site, or content farm?), when it was written (current for fast-moving fields like medicine or tech; less critical for historical analysis), and why it was written (to inform, to persuade, to sell, to rank in search). If you can answer the first three with confidence and the fourth points toward informing rather than selling, the source is probably reliable enough to cite. Combine multiple sources whenever possible — a claim that appears in three independent reliable sources is much stronger than one.'
+  - question: 'What''s the difference between paraphrasing and summarizing?'
+    answer: 'Paraphrasing restates a specific passage in your own words and runs roughly the same length as the original (or slightly shorter). Summarizing condenses a longer passage or whole work into a much shorter version that captures the main idea. Both require citation — paraphrasing especially, because the line between "paraphrasing" and "lightly rewording someone else''s prose" is where most accidental plagiarism happens. If you can''t paraphrase a passage without your version looking 60% similar to the original, quote it directly instead.'
+  - question: 'Can I cite Wikipedia in an academic paper?'
+    answer: 'For undergraduate coursework: generally no, with exceptions. Wikipedia is excellent for orientation — getting the lay of an unfamiliar topic, finding key terms, locating the seminal sources via its References section. But the article itself is anonymous, can change without notice, and varies enormously in quality between topics. Cite the sources Wikipedia cites, not Wikipedia itself. For graduate work and beyond, Wikipedia is almost never appropriate as a cited source. Exceptions exist for studies about Wikipedia itself or about online encyclopedia content.'
+  - question: 'How do I choose between APA, MLA, Chicago, and the others?'
+    answer: 'Your discipline and your assignment decide for you most of the time. APA is the default for psychology, education, nursing, and social sciences. MLA is the default for literature, languages, and humanities. Chicago is for history, art history, and journals that prefer footnotes. Harvard is widely used in UK universities and business schools. Vancouver and AMA are for biomedical writing. IEEE is for engineering and computer science. If your assignment says "use APA" or "use Chicago," that''s your answer. If it doesn''t specify, look at the journals your discipline publishes in and match their house style. When still unsure, ask your instructor — it''s a one-line email and saves you re-citing thirty sources later.'
+  - question: 'Is using AI-generated content for research considered plagiarism?'
+    answer: 'It depends on what you mean by "use." Using an LLM to summarize a long paper you''ve already read, to brainstorm angles, or to check the grammar of your own draft is generally fine — most institutions treat it like spell-check. Using an LLM to write paragraphs you then submit as your own work is plagiarism in the strict sense (presenting non-original content as original) AND can constitute fabrication if the model makes up facts or citations. The safe rule: any AI assistance more substantial than spell-check should be disclosed in your methods section or acknowledgments. Many journals now require AI-disclosure statements; many courses have explicit policies. Check yours before assuming.'
+ogImage: '/images/banner.png'
 ---
 
-import TryMe from '../../components/astro/TryMe.astro';
+Strong research starts before you write a single sentence and ends only after every source on the page traces back to the moment you found it. This guide is for students and early-career researchers working on the part that comes before style mechanics: finding sources that hold up, reading them in a way that doesn't lose attribution, integrating them into your own argument, and ending with a works cited page that doesn't quietly lose marks. The seven style guides linked from here cover the punctuation; this one covers the thinking around it.
 
-Strong research is the backbone of any credible academic paper. But gathering information is just the first step. Effectively using and citing your sources is crucial for establishing your credibility and avoiding plagiarism. This guide will equip you with the knowledge to navigate the most common citation styles (MLA, APA, Chicago, Harvard) and craft a polished works cited page.
+> The two skills that carry the most weight: evaluating a source on the way in (so you don't cite something you'll regret), and tracking the citation as soon as you decide to use it (so you don't lose it at 2 a.m. the night before the paper is due).
 
-## Understanding Citation Styles
+## Finding reliable sources
 
-There are several prominent citation styles, each with its own formatting guidelines. Here's a quick overview of the most common ones:
+The web has gotten worse as a research substrate over the last few years, not better. The first page of search results for almost any academic topic now mixes peer-reviewed work with AI-generated summaries, content-farm rewrites, and "answer engine" pages that synthesize sources without naming them. Sorting signal from noise takes more deliberate work than it did a decade ago.
 
-* **MLA**: The Modern Language Association (MLA) style is primarily used for literature and humanities, MLA focuses on author names and in-text citations with page numbers.
-* **APA**: The American Psychological Association (APA) style is commonly used in the social sciences, education, and business. APA emphasizes the author's name and the date of publication in in-text citations.
-* **Chicago**: The Chicago Manual of Style is often used in history, art history, and humanities. Chicago uses footnotes and endnotes for in-text citations and includes a bibliography at the end of the paper.
-* **Harvard**: The Harvard style is used in business, law, and social sciences. Harvard uses in-text citations and a references page at the end of the paper.
+Start with venues where the editorial gate is actually closed. **Academic databases** — JSTOR, ProQuest, PubMed, Scopus, your library's discovery layer — restrict their indexes to peer-reviewed journals, and most universities pay for institutional access. **Google Scholar** indexes more broadly, including preprints and grey literature, but it filters for academic publishers and citation graphs in a way regular Google does not. **University library catalogs** surface books vetted by acquisitions librarians. **Government and educational sites** (.gov, .edu) carry institutional accountability that .com domains don't.
 
-To summarize, each citation style has its own unique features and is commonly used in specific academic disciplines. Understanding these differences is essential for crafting a works cited page that meets the requirements of your assignment.
+Once you've found a source, the evaluation question is not "is this a good source" but "is this a good source for what I'm using it for." A blog post by a working researcher might be the right citation for "what does the field's current debate look like" and the wrong one for "what is the established consensus." The classic CRAAP heuristic — currency, relevance, authority, accuracy, purpose — is useful as a checklist, but the underlying question is the same every time: would a careful reader of your paper accept this source as evidence for the specific claim you're attaching it to?
 
-| Citation Style | Commonly Used In | Key Features |
-|----------------|------------------|--------------|
-| MLA            | Literature and Humanities       | In-text citations, works cited page |
-| APA            | Social Sciences, Education, and Business | In-text citations, references page |
-| Chicago        | History, Art History, and Humanities | Footnotes, bibliography |
-| Harvard        | Business, Law, and Social Sciences | In-text citations, references page |
+Spotting AI-generated and content-mill pages has become a research skill in itself. The tells: confident but unspecific claims, sentences that paraphrase without ever attributing, a References section that mixes real papers with hallucinated ones, identical phrasings appearing across multiple sites, and a complete absence of any named human author or editorial masthead. If a page tells you something definite but you can't trace the claim to a primary source within two clicks, treat it as unverified and look for the underlying study yourself.
 
-## Finding Reliable Sources
+Wikipedia is the perennial special case. It is excellent for orientation — the lay of an unfamiliar topic, key terms, seminal sources via the References section — and almost never appropriate to cite directly. The article is anonymous, can change between the time you read it and the time your professor reads your paper, and varies enormously in quality. Use it as a launching pad and cite the sources it cites.
 
-The quality of your research hinges on the credibility of your sources. Here are some tips for finding reliable information:
+## Reading and tracking sources as you go
 
-* **Academic Databases**: Use databases like JSTOR, ProQuest, and Google Scholar to access peer-reviewed articles, books, and scholarly journals.
-* **Library Resources**: Your school or local library is a treasure trove of academic resources. Librarians can help you find relevant sources and navigate databases.
-* **Credible Websites**: Websites ending in .gov, .edu, and .org are generally more reliable than .com sites. Always evaluate the author's credentials and the publication date of the content.
-   * **.gov**: Government websites provide official information and statistics.
-    * **.edu**: Educational institutions publish scholarly articles and research papers.
-    * **.org**: Non-profit organizations often share valuable data and research findings.
-* **Peer-Reviewed Journals**: Look for articles published in peer-reviewed journals, which undergo rigorous evaluation by experts in the field.
-* **Books from Reputable Publishers**: Books from university presses and established publishing houses are typically more trustworthy than self-published works.
+The single highest-leverage habit in academic research is **capturing the citation at the moment you decide a source is worth using**. Not at the end. Not when you write the works cited page. Now, while the tab is still open. The cost of capturing it now is fifteen seconds; the cost of reconstructing it later — Googling the title, hoping the same edition comes up, hoping the URL still resolves — is often an hour per source.
 
-## Citing Sources in Your Paper
+What "capture" means depends on your tooling. **Reference managers** like Zotero, Mendeley, EndNote, and Paperpile let you save a source with a single browser-extension click; they pull the metadata, attach the PDF when available, and let you tag and group sources by argument. Zotero is the usual starting point: free, open-source, syncs across devices, exports to every major style. **General-purpose tools** — Notion, Obsidian, a plain spreadsheet — work fine if you're disciplined about filling in the same columns every time (author, title, year, venue, URL, page, claim). **This site's [My References page](/my-references)** stores every citation you generate so you can come back to them later without re-entering the source data — useful when a paper takes weeks.
 
-In-text citations are a crucial component of academic writing. They provide readers with the information they need to locate the original source of the information you're referencing. Here's how to create in-text citations in the most common citation styles:
+The other under-appreciated habit is **organizing notes by argument rather than by source**. Most students take notes the way they read: one document per source, summarizing it from start to finish. That structure is comfortable to produce and almost useless when you sit down to write, because your paper isn't organized that way. Try the inverse: keep one note per claim you're considering making, and under each claim collect the quotes, paraphrases, and citations that bear on it. When you write, you're stitching together claims you already have evidence for, not flipping through six PDFs hoping to remember which one made the point.
 
-### MLA In-Text Citations
+A working note looks like this: full bibliographic data at the top, direct quotes in quotation marks with page numbers, paraphrases marked as such (so you don't mistake them for your own words six weeks later), and your own reactions in square brackets. The brackets matter — confusing your synthesis with the source's own claim is a frequent path to accidental plagiarism.
 
-MLA in-text citations typically include the author's last name and the page number where the information can be found. For example:
+## Integrating sources into your writing
 
-| In-text Citation | Works Cited Entry |
-|------------------|-------------------|
-| <p style="font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Intriguingly, recent studies suggest that dolphins possess a form of  "natural sonar" capable of navigating complex underwater environments (Evans and Norris 45).</p> | <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Evans, William E., and Kenneth C. Norris. _Marine mammals: Anatomy, physiology, behavior, and conservation_. 2nd ed., Academic Press, 2008.</p> |
+A paper that strings together citations without doing anything with them is a list, not research writing. The point of citing a source is to bring it into a conversation you're building, and the three basic moves are **direct quotation**, **paraphrase**, and **summary**. Knowing when to use which is half the craft.
 
-### APA In-Text Citations
+**Quote directly** when the exact wording matters — because the author phrased something so precisely that paraphrasing would lose the meaning, because you're going to analyze the language itself, or because the source's authority depends on hearing them speak. A four-word phrase from a Supreme Court opinion is a direct quote. A literary critic's coinage is a direct quote. A study's methodology summary almost never is.
 
-APA in-text citations include the author's last name and the publication date. For example:
+**Paraphrase** when the idea matters but the wording doesn't. Paraphrasing demonstrates that you understood the source well enough to restate it in your own structure and vocabulary, which is itself analysis. The risk is paraphrasing too closely — keeping the original sentence shape and swapping in synonyms — which produces text that reads like plagiarism even when you've cited the source. If your paraphrase looks 60% similar to the original, you haven't paraphrased; you've reworded. Quote it directly or rewrite from a level higher.
 
-| In-text Citation | Reference List |
-|------------------|----------------|
-| <p style="font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Intriguingly, recent studies suggest that dolphins possess a form of  "natural sonar" capable of navigating complex underwater environments (Evans & Norris, 2008).</p> | <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Evans, W. E., & Norris, K. C. (2008). _Marine mammals: Anatomy, physiology, behavior, and conservation_ (2nd ed.). New York, NY: Academic Press.</p> |
+**Summarize** when you need to compress a longer argument — a whole article or chapter — into a sentence or two that contextualizes your own move. Summary is where you give the reader the version of the source that matters for your purposes; it's expected to leave a lot out.
 
-### Chicago In-Text Citations
+Within each of these, **signal phrases** earn their keep. "Chen argues that …" or "Lin and Patel (2022) found that …" tells the reader whose claim they're about to hear and how confident the source was about it — a researcher who "found" something has different epistemic weight than one who "suggests" it. Signal phrases also let you cite for engagement rather than support: "Goldstein et al. argue X, but their sample of twelve undergraduates …" puts the source in conversation with your analysis, where a parenthetical citation alone would have left X unchallenged. For the punctuation specifics in your style, the dedicated guides — [APA](/guides/apa), [MLA](/guides/mla), [Chicago](/guides/chicago), [Harvard](/guides/harvard), [Vancouver](/guides/vancouver), [IEEE](/guides/ieee), [AMA](/guides/ama) — show the format your discipline expects.
 
-Chicago style uses footnotes or endnotes for in-text citations. The first citation of a source includes the full publication information, while subsequent citations can be shortened. For example:
+The antipattern to watch for is the *citation cluster*: a paragraph in which every other sentence ends in a parenthetical and nothing is synthesized. A reader who finishes it cannot tell you what *you* think, only that several other people have written on the topic. The fix is to write one or two sentences of your own analysis between each move into a source.
 
-| In-text Citation | Footnote/Endnote |
-|------------------|------------------|
-| <p style="font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Intriguingly, recent studies suggest that dolphins possess a form of  "natural sonar" capable of navigating complex underwater environments<sup>1</sup>.</p> | <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">1. William E. Evans and Kenneth C. Norris, _Marine mammals: Anatomy, physiology, behavior, and conservation_ (2nd ed.; New York, NY: Academic Press, 2008), 45.</p> |
+## Choosing the right citation style
 
-### Harvard In-Text Citations
+Most of the time, your discipline picks the style for you and your assignment confirms it. When it doesn't, the table below summarizes the seven styles this site supports and where each one tends to land. Click through to a style's dedicated guide for the in-text mechanics, reference-list format, and worked examples.
 
-Harvard in-text citations include the author's last name and the publication year. For example:
+| Style | Typical disciplines | Key features | When to pick it |
+| --- | --- | --- | --- |
+| [APA](/guides/apa) | Psychology, education, nursing, social sciences | Author–date in-text (`Chen, 2021`); sentence case for article titles; "References" list; double-spaced, hanging indent | Default for the social and behavioral sciences and most evidence-based health writing |
+| [MLA](/guides/mla) | Literature, languages, film, humanities composition | Author–page in-text (`Chen 47`); nine core elements; "Works Cited" list; title case throughout | Default for humanities coursework and most modern-language journals |
+| [Chicago](/guides/chicago) | History, art history, religion; sciences via author–date | Two systems: author–date and notes–bibliography; title case; "References" or "Bibliography" | History and art history use notes–bibliography; sciences using Chicago use author–date |
+| [Harvard](/guides/harvard) | Business, law, social sciences (UK/Commonwealth) | Author–date in-text (`Chen, 2021`); "Reference list"; varies by institution | UK universities and business/management programs that specify "Harvard" without a sub-variant |
+| [Vancouver](/guides/vancouver) | Medicine, biomedical sciences, nursing journals | Numeric in-text (`[1]` or superscript); references in citation order; Index Medicus journal abbreviations | Biomedical writing where the ICMJE recommendations apply |
+| [IEEE](/guides/ieee) | Engineering, computer science, applied sciences | Numeric in-text (`[1]`); references in citation order; abbreviated names | Engineering papers, technical reports, and IEEE conference and journal submissions |
+| [AMA](/guides/ama) | Clinical medicine, JAMA-network journals | Superscript numeric in-text; references in citation order; Index Medicus abbreviations | U.S. clinical medicine and any JAMA-family journal |
 
-| In-text Citation | Reference List |
-|------------------|----------------|
-| <p style="font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Intriguingly, recent studies suggest that dolphins possess a form of  "natural sonar" capable of navigating complex underwater environments (Evans & Norris, 2008).</p> | <p style="text-indent: -1.5rem; margin-left: 1.5rem; font-family: 'Source Serif 4', serif; font-weight: 400; letter-spacing: 0;">Evans, W. E., & Norris, K. C. (2008). _Marine mammals: Anatomy, physiology, behavior, and conservation_ (2nd ed.). New York, NY: Academic Press.</p> |
+A few decisions recur. APA and Harvard look almost identical in the in-text — both author–date in parentheses — and students sometimes pick whichever their tool defaults to. They diverge in reference-list punctuation and in author/editor treatment, so picking the wrong one produces a paper that looks subtly off. Chicago is two styles in one manual: humanities papers usually want notes–bibliography, and sciences using Chicago want author–date. Vancouver and AMA are siblings — both numeric, both biomedical — with AMA the U.S. clinical default and Vancouver the international biomedical default. IEEE is numeric and tuned for engineering's reference patterns. When the assignment doesn't specify, match the house style of the journals your field publishes in. When still ambiguous, ask your instructor — it's a one-line email and saves a lot of retroactive reformatting.
 
-<TryMe />
+## Building a polished works cited or references page
 
-## Crafting a Works Cited Page
+The works cited page (MLA), reference list (APA, Harvard, Chicago author–date), or bibliography (Chicago notes–bibliography) is the part of your paper a grader checks first when spot-checking for citation rigor. Two minutes of consistency work here changes how the whole paper reads.
 
-Your works cited page serves as a bibliography, listing all the sources you referenced in your paper. Each entry should be formatted following the chosen citation style's guidelines. Here are some general tips for creating a works cited page:
+The mechanics that hold across styles are smaller than they look. Almost every style wants the heading centered at the top of its own page in the same font as the body, the page double-spaced throughout (within entries and between them), and each entry formatted with a hanging indent of half an inch. Apply hanging indents through the paragraph formatting menu rather than through manual tabs — the manual version breaks the first time you change font size.
 
-* **Alphabetize Entries**: Arrange your works cited page in alphabetical order by the author's last name. If there's no author, use the title of the source.
-* **Use Hanging Indentation**: The first line of each entry should align with the left margin, while subsequent lines are indented.
-* **Include All Necessary Information**: Each entry should include the author's name, the title of the source, publication information, and the medium of publication (print, web, etc.).
-* **Follow the Correct Format**: Ensure that your works cited page adheres to the formatting guidelines of your chosen citation style.
+**Alphabetization or numbering** depends on the style family. Author–date styles (APA, MLA, Chicago author–date, Harvard) alphabetize by the first author's surname; with no named author, alphabetize by the first significant word of the title, ignoring *A*, *An*, and *The*. Numeric styles (Vancouver, IEEE, AMA) list entries in the order they were first cited in the body — the first source cited is entry [1] regardless of surname.
 
-## Conclusion
+**Consistency** is what separates a polished list from a flawed one. Pick one date format and use it everywhere. Pick one capitalization convention — sentence case for APA article titles, title case for MLA and Chicago — and apply it without slipping. Use the en dash (`–`) for page and date ranges, not a hyphen. Use straight or curly quotes consistently, not a mix. The grader who notices six inconsistencies on one page assumes there are dozens more in the body.
 
-Mastering the art of research and citation is essential for academic success. By understanding the nuances of different citation styles, evaluating sources critically, and crafting a polished works cited page, you'll be well-equipped to produce high-quality academic papers that are well-supported and properly cited.
+The mistakes that cost the most marks are the ones a careful re-read would catch: mismatched in-text and reference-list entries, missing italics on journal titles, URLs that don't resolve (paste each into a fresh browser window before submission), DOIs formatted as bare strings instead of full `https://doi.org/...` links, place of publication on a book in a style that no longer requires it (APA 7 and Chicago 18 both made it optional or dropped it). The [generator at /](/) handles the punctuation, italics, and hanging indent automatically once you've selected a style, but the consistency check above the fold is still on you. For style-specific worked examples — book, journal article, website, government report — each dedicated style guide above includes a source-type table you can pattern-match against.
 
-## Tools and Resources
+## Avoiding plagiarism (and the gray areas)
 
-* [MLA Generator: A free tool for creating citations](https://mlagenerator.com)
+The obvious rules are obvious. Don't submit someone else's paper as your own. Don't copy and paste from a source without quotation marks and a citation. Don't fabricate sources. These bright lines get people expelled in coursework and fired in professional research.
+
+The gray areas are where most actual plagiarism — and most plagiarism accusations — live.
+
+**Paraphrasing too closely** is the most common form of accidental plagiarism. You read a source, write a sentence that keeps the original's structure with synonyms swapped in, and cite it. You followed the citation rule; you violated the originality rule. The test is whether your version reads like an independently composed sentence or the original with a thesaurus pass. If it's the latter, quote the passage directly or step back and write the idea in your own structure.
+
+**Citing the secondary source instead of the primary source** is subtler. You read Lin and Patel, who discuss Chen's earlier finding, and you cite Chen without ever opening Chen yourself. This is risky for two reasons: secondary sources sometimes paraphrase inaccurately, and graders who recognize the primary work can tell. The honest formats are either "Chen (as cited in Lin and Patel, 2022)" — which signals you didn't read Chen directly — or, better, read Chen and cite the primary. Reserve "as cited in" for sources you genuinely can't access.
+
+**AI-generated content and AI assistance** sits in a category institutions are still working out. Using an LLM to spell-check your draft, brainstorm angles, or summarize a paper you've already read is generally treated like any other writing aid. Using an LLM to write paragraphs you submit as your own is plagiarism in the strict sense — presenting non-original content as original — and can constitute fabrication if the model invents facts or citations. Many journals now require AI-disclosure statements; many courses have explicit policies. The safe rule: any use more substantial than spell-check gets disclosed, and any AI-generated text in your final draft gets a citation under your style's AI-source rules (see [Chicago](/guides/chicago) and [APA](/guides/apa) for current worked examples).
+
+**Self-plagiarism** is re-using your own previously submitted work without disclosure — turning in a paper for two classes, or recycling a published paragraph into a new article. Whether it's misconduct depends on context, but disclosing the prior use is always safer than not.
+
+Citing well is the strongest defense against most plagiarism accusations — not because citations are a magic shield, but because the habit of attaching attribution to every claim trains you to keep your voice and your sources distinct. The style-specific formats in the [APA](/guides/apa), [MLA](/guides/mla), and [Chicago](/guides/chicago) guides are the tools; using them every time is the actual protection.
+
+## What changes when you submit professionally
+
+Most of what's above is calibrated for student writing. When you submit to a peer-reviewed journal or deposit research outputs publicly, a few additional expectations layer on top. You probably won't encounter them in coursework, but it's worth knowing they exist.
+
+**Anonymized submissions.** Most journals use double- or single-blind review and want the manuscript stripped of identifying information: no author names on the title page, no acknowledgments that name funders, sometimes self-citations rephrased so they don't identify you. Read the author guidelines before formatting.
+
+**Preprint deposits.** Posting to arXiv, bioRxiv, SSRN, or your discipline's equivalent before formal publication is standard in physics, biology, and economics and uncommon in most humanities. Preprints have their own citation format and are eventually superseded by the published version.
+
+**Data and code citations.** Empirical work increasingly requires a citation to the underlying dataset and analysis code, not just the paper. Repositories like Zenodo, Dryad, and OSF mint DOIs for these so they can be cited with the same permanence as a journal article.
+
+**ORCID identifiers.** An ORCID iD is a persistent personal identifier that links your author profile across journals and funders regardless of name changes. Most major journals now request one at submission; registration takes a minute at orcid.org.
+
+The habits that produce a polished student paper — verifying sources, capturing citations as you go, integrating rather than listing, formatting with care — are the habits that make professional submission painless later. The tools scale; the discipline travels.


### PR DESCRIPTION
## Summary
**Last content PR in the [content & SEO overhaul](docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md).** Rewrites `/guides/research-and-works-cited` — the meta guide that targets searchers earlier in the research process and serves as a hub linking into all 7 individual style guides.

### What changed
- Full content rewrite of `src/content/guides/research-and-works-cited.mdx` — ~2,900 body words.
- 7 H2 sections covering finding reliable sources / reading and tracking / integrating sources / choosing the right style / building a polished works cited / avoiding plagiarism / professional submission norms.
- 7-row comparison table under "Choosing the right citation style" with each style linked to its dedicated guide.
- 5 FAQ items (FAQPage schema) including AI-disclosure guidance hedged appropriately for 2026 (rapidly-evolving area).
- 10 internal links across the body (`/guides/<style>` × 7 + `/my-references` + `/` + extra dispersed links).
- Preserved `pubDate: 2024-03-11`; updated to `2026-05-27`.

### Pre-merge review
Opus fresh-context review: **Approved.** No blocking issues. Verified every discipline claim in the comparison table against the matching style guide; all consistent. All internal links resolve. Voice matches the established template.

Non-blocking notes:
- Word count is 99 over the soft 2,800 ceiling (2,899 body words) — within the discursive-content flex.
- Two contextual generator mentions (My References + the inline generator link) — both organic, not promotional.

## Test plan
- [x] `npm run build` clean
- [x] All 7 style guide links resolve
- [x] FAQ schema renders (5 Question entries)
- [x] No banned voice phrases, no AI tics
- [ ] After merge: validate live URL via Google Rich Results Test

## What's next
PR 2 is complete. The remaining work in the [spec](docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md):
- PR 3: 6 "how to cite a [source]" pages
- PR 4: 5 concept guides
- PR 5: 3 comparison + 3 FAQ/meta pages
- Analytics phase 2 (URL recording + localStorage UUID) — decisions saved to memory