### PR TITLE
PR 5: Three comparison + two FAQ/meta guides (closes the overhaul spec)

### DIFF
--- a/src/content/guides/chicago-notes-vs-author-date.mdx
+++ b/src/content/guides/chicago-notes-vs-author-date.mdx
@@ -1,0 +1,110 @@
+---
+title: 'Chicago Notes–Bibliography vs Author–Date: The Two Chicago Systems Compared'
+pubDate: 2026-03-04
+description: 'The Chicago Manual of Style supports two citation systems — notes–bibliography (footnotes plus Bibliography) and author–date (parenthetical citations plus References). This guide compares them side by side, explains when each is used, and shows the same source formatted in both. Written and reviewed by the MLA Generator Editorial Team against the 2024 Chicago Manual.'
+category: 'comparison'
+keywords: ['Chicago notes bibliography vs author date', 'Chicago two systems', 'Chicago footnotes vs parenthetical', 'Chicago N-B', 'Chicago author-date', 'when to use Chicago N-B', 'Chicago 18 systems']
+tags: ['Chicago', 'notes-bibliography', 'author-date', 'footnotes', 'comparison', 'humanities', 'history']
+relatedGuides: ['chicago', 'mla-vs-apa', 'apa', 'mla', 'in-text-citations', 'works-cited-vs-bibliography']
+faq:
+  - question: 'Which Chicago system should I use?'
+    answer: 'Your discipline picks for you. History, art history, religion, philosophy, and most humanities use notes–bibliography — superscript numbers in the text pointing to footnotes, with a Bibliography at the end. Sciences and social sciences that have adopted Chicago (some economics journals, some political-science journals) use author–date — parenthetical (Author Year) in the text with a References list at the end. If your discipline is not on either list, your assignment or journal specifies which to use; if neither does, the safe default is notes–bibliography for humanities work and author–date for everything else.'
+  - question: 'What is the difference between a footnote and a bibliography entry?'
+    answer: 'A footnote is the inline citation that appears at the bottom of the page where the source is referenced. A bibliography entry is the full reference that appears at the end of the paper in a Bibliography section. Both can carry full bibliographic information for the same source, but the punctuation and author-name order differ: footnotes use the author''s name in normal order (Margaret S. Chen) with commas separating elements; bibliography entries invert the name (Chen, Margaret S.) and use periods between elements. The first time a source appears in a footnote, the note carries full information; subsequent references to the same source use a shortened form.'
+  - question: 'Can I use both systems in the same paper?'
+    answer: 'No — pick one and stay with it. Mixing notes–bibliography footnotes with author–date parentheticals in the same paper produces an internally inconsistent text that no marker or editor would accept. The choice between the two is made before you start writing, based on your discipline and your assignment. If you started in one and realize partway through you should have used the other, switching is mechanical but tedious — convert every in-text citation and the back-matter heading together.'
+  - question: 'Does this site''s generator support notes–bibliography?'
+    answer: 'The generator produces Chicago 18 author–date citations. If you need notes–bibliography, you can use the generated reference-list output as a starting point for your Bibliography (the punctuation and author format are close enough to adapt by hand) and write the footnotes using the rules in the dedicated Chicago guide. The generator''s Chicago output ships the author–date variant because that is what the official Chicago CSL style file produces for that style key.'
+  - question: 'Why does Chicago have two systems anyway?'
+    answer: 'The two systems serve different reading patterns. Humanities readers want to follow the argument continuously without breaking to parse "(Smith 1987, 47)" mid-sentence — so notes–bibliography keeps citations at the bottom of the page where they can be checked when needed and ignored when not. Sciences and social-science readers want to see how recent a finding is at a glance — so author–date puts the year in front of them on every citation. The Chicago Manual maintains both because it serves both kinds of writing, and the choice between them follows the field''s reading conventions.'
+ogImage: '/images/banner.png'
+---
+
+The *Chicago Manual of Style* is two citation systems sharing one manual. Notes–bibliography uses superscript footnote numbers in the text, full footnotes at the bottom of the page, and a Bibliography at the end of the paper. Author–date uses parenthetical (Author Year) citations in the text and a References list at the end. The two are not interchangeable — the choice between them is determined by discipline before you start writing — and confusing them produces a paper that does neither well. This guide compares the two systems side by side and clarifies which one your assignment most likely expects.
+
+> The shortest answer: notes–bibliography for humanities (history, art history, religion, philosophy); author–date for sciences and social sciences that use Chicago. Pick one and apply it consistently — they are not mix-and-match.
+
+## What each system is for
+
+**Notes–bibliography** is the traditional Chicago system, descended from the 1906 first edition of the *Manual*. Citations appear as numbered footnotes at the bottom of the page (or as endnotes at the end of the chapter), and a Bibliography at the end of the paper lists all sources cited plus any consulted in research. The system is used by history journals, art history journals, religion journals, philosophy journals, and most humanities work that prefers footnotes to parentheticals.
+
+**Author–date** is the newer Chicago system, added to the *Manual* in the 1970s when more disciplines adopted the parenthetical style that APA had popularized. Citations appear as `(Author Year)` in the text, and a References list at the end alphabetizes the sources. The system is used by some economics journals, some political-science journals, and any author who is required to use Chicago but writes in a tradition that expects in-text citations rather than footnotes.
+
+If your discipline is in the humanities, notes–bibliography is your default. If your discipline is in the sciences or social sciences but Chicago is required (rather than APA or another disciplinary default), author–date is your default. If your assignment or journal specifies otherwise, follow what is specified — the *Manual* permits either.
+
+## In-text citation mechanics
+
+The most visible difference. Same single-author source — Chen's 2021 book *The Architecture of Working Memory*, page 47.
+
+| | Notes–bibliography | Author–date |
+| --- | --- | --- |
+| First citation | ¹ (superscript pointing to footnote 1) | (Chen 2021, 47) |
+| Subsequent citation | ⁵ (superscript pointing to footnote 5) | (Chen 2021, 92) |
+| Narrative | Chen argues that … ³ | Chen (2021, 47) argues that … |
+| Quote | A "consolidation effect"⁴ … | … "consolidation effect" (Chen 2021, 47) |
+
+In notes–bibliography, the in-text marker is just a number. The actual citation content lives in the footnote. In author–date, the citation content is in the parenthetical itself, and there are no footnotes.
+
+This shapes how the systems read. A notes–bibliography page can carry dense citation traffic without interrupting the prose — five footnote numbers in a paragraph add five superscripts. The same paragraph in author–date carries five parentheticals, each disclosing the author and year inline. Humanities readers tend to find the first arrangement easier to follow; sciences readers tend to prefer the second because the year is always visible.
+
+## The footnote itself
+
+In notes–bibliography, the first citation of any source carries a full footnote. Subsequent citations use a shortened form.
+
+> **First footnote:** 1. Margaret S. Chen, *The Architecture of Working Memory* (Cambridge: Cambridge University Press, 2021), 47.
+>
+> **Subsequent footnote:** 8. Chen, *Architecture of Working Memory*, 89.
+
+The first footnote contains author (in normal order — first name first), title, publication information, and the specific page. The subsequent footnote contains author surname only, a shortened version of the title, and the page. The shortened title omits initial articles (`The`, `A`, `An`) and uses just enough of the title to identify the source unambiguously.
+
+The Chicago Manual of Style 18th edition (2024) discourages the older `Ibid.` shortcut — once standard for referring back to the immediately preceding citation — in favor of the shortened-citation form above. The reasoning is practical: `Ibid.` is fragile during revision (insert a new citation between two `Ibid.` references and the second one now refers to the wrong source), while the shortened form remains accurate regardless of what surrounds it.
+
+## Bibliography versus References
+
+Both systems have a back-of-paper source list. They use different names and slightly different formats.
+
+The same book in each system's back-matter format:
+
+> **Notes–bibliography (Bibliography entry):** Chen, Margaret S. *The Architecture of Working Memory*. Cambridge: Cambridge University Press, 2021.
+>
+> **Author–date (References entry):** Chen, Margaret S. 2021. *The Architecture of Working Memory*. Cambridge: Cambridge University Press.
+
+Three differences:
+
+- **Year placement.** Notes–bibliography places the year at the end of the entry, after the publisher. Author–date places it immediately after the inverted author name.
+- **Punctuation between elements.** Notes–bibliography separates author, title, and publication info with periods. Author–date does the same but inserts the year between author and title, which slightly changes the rhythm.
+- **What the section is called.** Notes–bibliography uses "Bibliography." Author–date uses "References."
+
+The Bibliography in notes–bibliography may include both cited and consulted sources — works the writer read for background but did not directly cite. The References list in author–date is restricted to sources actually cited in the body, like APA's References or MLA's Works Cited. This is the meaningful difference between the two labels and one of the few cases where the system name is a substantive content rule, not just a labeling choice.
+
+## When to pick which
+
+The disciplinary defaults are clear enough that most papers do not face a choice. When they do:
+
+**Pick notes–bibliography** when:
+- Your paper is in history, art history, religion, philosophy, or another humanities field.
+- Your prose carries extensive discursive material that footnotes can absorb (qualifications, asides, brief discussions of secondary sources).
+- Your readers expect to see citations at the bottom of the page rather than interrupting the prose.
+- Your journal or instructor specifies it.
+
+**Pick author–date** when:
+- Your paper is in a science or social-science field that has adopted Chicago rather than APA.
+- Your readers expect to see the year of publication on every citation (which signals currency of evidence).
+- Your prose is short on discursive footnote material and would benefit from the cleaner running text.
+- Your journal or instructor specifies it.
+
+When in doubt, look at the journals your discipline publishes in. If they use footnotes, your paper should use notes–bibliography. If they use parentheticals, your paper should use author–date.
+
+## Common cross-system mistakes
+
+**Mixing footnotes with parentheticals.** A paper that uses footnotes for some citations and `(Author Year)` for others is in neither system. Pick one before you start drafting.
+
+**Using "Bibliography" as the heading on author–date papers.** Author–date uses "References." Using "Bibliography" suggests you set out to write notes–bibliography and forgot to commit to one system.
+
+**Using `Ibid.` for repeated citations.** *Chicago Manual* 18 prefers the shortened-citation form. `Ibid.` still appears in older Chicago papers and remains permitted, but the current convention is the surname-plus-short-title form because it survives revisions that move text around.
+
+**Inverting the author's name in a footnote.** Footnotes use normal name order: "Margaret S. Chen," not "Chen, Margaret S." The bibliography entry uses the inverted form ("Chen, Margaret S.") because that is what supports alphabetization. Mixing the two looks like a draft that was reformatted halfway.
+
+**Forgetting to switch to the shortened form after the first footnote.** Every footnote after the first reference to a source should use the surname-plus-short-title form. Repeating the full footnote each time is correct in some older styles but is treated as a mistake in current Chicago.
+
+**Writing parenthetical citations without the year.** Some students transfer the MLA habit of `(Chen 47)` to Chicago author–date. Chicago author–date requires the year: `(Chen 2021, 47)`. The page locator follows a comma; there is no `p.` abbreviation.

--- a/src/content/guides/citation-generator-faq.mdx
+++ b/src/content/guides/citation-generator-faq.mdx
@@ -73,10 +73,10 @@ What the feature does not do: sync across devices, back up to a server, export t
 
 ## Privacy
 
-Because there is no account, the site does not collect identifying information. The references you generate are stored only in your browser. Server-side, we log basic usage analytics (citation styles requested, source types extracted, response times) to monitor performance; we do not log the URLs, ISBNs, or DOIs you submit alongside personal identifiers. The privacy details are documented on the [privacy page](/privacy).
+There is no account, no email signup, and no server-side storage of your reference list — references live in your browser's local storage. Standard web logging (IP address, browser type, referring URL) and ad-network cookies from Google AdSense apply across the site like any other ad-supported web property. The full details — what is collected, how long it is retained, and your rights — are documented on the [privacy page](/privacy).
 
 ## Browser and device support
 
-The tool runs in any current browser — Chrome, Edge, Firefox, Safari — on desktop and mobile. The citation engine is small enough (about 186 KB gzipped) to load comfortably even on a slow connection. Mobile layouts are responsive; the main use case is reading the generated citation to copy it into a word processor on the same device or a different one.
+The tool runs in any current browser — Chrome, Edge, Firefox, Safari — on desktop and mobile. The citation engine runs server-side on Cloudflare Pages Functions, so your browser never has to download a heavy formatting library — only the small amount of JavaScript needed to submit a source and display the result. Mobile layouts are responsive; the main use case is reading the generated citation to copy it into a word processor on the same device or a different one.
 
-The site does not require JavaScript to read the guides (every page is statically rendered); JavaScript is required for the citation generator and the references page, which manage state in the browser.
+The site does not require JavaScript to read the guides (every guide page is statically rendered); JavaScript is required for the citation generator and the references page, which manage state in the browser.

--- a/src/content/guides/citation-generator-faq.mdx
+++ b/src/content/guides/citation-generator-faq.mdx
@@ -1,0 +1,82 @@
+---
+title: 'Citation Generator FAQ: How the Tool Works, What It Supports, and How Accurate It Is'
+pubDate: 2026-05-06
+description: 'Frequently asked questions about the MLA Generator citation tool — which styles and editions are supported, how citations are produced from URLs/ISBNs/DOIs, what to do if a citation looks wrong, and how to use the saved-references feature. Written and reviewed by the MLA Generator Editorial Team.'
+category: 'meta'
+keywords: ['citation generator FAQ', 'how does citation generator work', 'is citation generator accurate', 'MLA Generator FAQ', 'free citation generator', 'citation generator supported styles', 'cite from URL', 'cite from DOI']
+tags: ['FAQ', 'citation generator', 'tool documentation', 'CSL', 'support']
+relatedGuides: ['apa', 'mla', 'chicago', 'how-to-cite-a-website', 'how-to-cite-a-journal-article', 'how-to-cite-a-book']
+faq:
+  - question: 'How accurate are the generated citations?'
+    answer: 'Every citation is rendered using the official Citation Style Language (CSL) definitions through citeproc-js — the same engine used by Zotero, Mendeley, and Pandoc. Output that comes from a complete set of source metadata (a DOI for a journal article, an ISBN for a book, full JSON-LD on a web page) is accurate to the style manual. Output from incomplete metadata is only as accurate as the metadata available — a web page with no author, no publication date, and no canonical URL produces a partial citation that needs manual review. The shortest reliable rule: verify the generated entry against the source itself before submission, especially for any source the generator could not fully extract.'
+  - question: 'Which citation styles do you support?'
+    answer: 'Seven styles, each current as of 2026: APA 7th Edition (2020), MLA 9th Edition (2021), Chicago Manual of Style 18th Edition, Harvard (Cite Them Right 12th Edition), Vancouver (ICMJE recommendations), IEEE (current edition of the IEEE Editorial Style Manual), and AMA Manual of Style 11th Edition. Each style produces output that follows its current edition''s rules. Style updates are tracked on the [What''s New](/guides/whats-new) page.'
+  - question: 'What source types can the generator handle?'
+    answer: 'URLs (any web page), DOIs (for journal articles), ISBNs (for books), and manual entry for any source type that doesn''t have a discoverable identifier. The URL extractor reads multiple signal sources in parallel — JSON-LD, Open Graph, Twitter cards, microdata, meta tags, and HTML heuristics — and merges them into a best-confidence reference. ISBNs are resolved against Google Books and Open Library; DOIs are resolved against Crossref and OpenAlex. For source types the automatic extractors do not cover (interviews you conducted, in-class lectures, archived material), use the manual-entry form.'
+  - question: 'Can I save my citations?'
+    answer: 'Yes. The [My References](/my-references) page stores every citation you generate, so you can come back to them later without re-entering the source data. References are saved locally in your browser — there is no account and no server-side storage of your reference list. If you switch browsers or clear your browser data, you will need to regenerate the references; an export feature is on the roadmap.'
+  - question: 'Is the generator free? Do I need to sign up?'
+    answer: 'Yes, free. No account, no sign-up, no paywall. The site runs on minimal ad revenue, which is why ads appear on the citation-output pages. Premium features that other citation tools paywall — multiple styles, full source-type coverage, saved references — are free here because the underlying CSL project is open source and accuracy does not need to be locked behind a subscription.'
+ogImage: '/images/banner.png'
+---
+
+This page collects the questions readers ask most often about how the citation generator on this site works — which styles it supports, what to do when a citation looks wrong, what the saved-references feature does, and the basics of how the underlying engine builds references. For the details on each style's formatting rules, follow the links to the dedicated style guides; this page is about the tool itself.
+
+> The shortest answer: the tool produces citations in seven styles using the official CSL definitions, supports URLs, DOIs, ISBNs, and manual entry, saves your references locally in your browser, and is free. If a citation looks wrong, it is usually because the source did not expose complete metadata — fix the missing fields in the generated entry and verify against the original source.
+
+## How the tool builds citations
+
+Every reference is rendered using the [Citation Style Language](https://citationstyles.org/) (CSL) project — the same machine-readable style definitions used by Zotero, Mendeley, and Pandoc. This site ships the current CSL definition for each supported style and runs them through citeproc-js, the reference implementation. The practical consequence is that a citation produced here follows the same formatting rules as any CSL-compliant tool, which is the standard for academic citation tooling.
+
+When you paste a URL, the extractor fetches the page and reads multiple signal sources in parallel — JSON-LD, Open Graph, Twitter cards, microdata, meta tags, and HTML heuristics — and merges them into one best-confidence reference. The architecture is multi-signal rather than single-source because no single metadata channel is reliable across the open web: news sites use one approach, academic journals another, blog platforms a third. Pulling from several signals at once and reconciling them produces a more accurate citation than reading any single source alone.
+
+For books, an ISBN is resolved against Google Books and Open Library. For journal articles, a DOI is resolved against Crossref and OpenAlex. Both pipelines fall back to manual fields when the external services do not return complete data.
+
+## What the tool supports
+
+| Source type | Input | What the extractor uses |
+| --- | --- | --- |
+| Website / web article | URL | JSON-LD, Open Graph, Twitter cards, microdata, meta tags, HTML heuristics |
+| Journal article | DOI | Crossref, OpenAlex |
+| Book | ISBN | Google Books, Open Library |
+| Other source types | Manual entry | Form fields filled by hand |
+
+The supported automatic source types are the ones with reliable external metadata. Source types that do not have a single canonical identifier — personal interviews you conducted, in-class lectures, archived correspondence, unpublished manuscripts — are handled through the manual-entry form. The per-source-type how-to guides explain what fields to fill in for each case.
+
+## How accurate the citations are
+
+Output that comes from a complete set of source metadata is accurate to the style manual. A DOI for a journal article, an ISBN for a book, a well-formed JSON-LD record on a web page — these produce citations that match what the style manual specifies.
+
+Output from incomplete metadata is only as accurate as the metadata available. A web page that does not expose its author, its publication date, or a canonical URL produces a partial citation. The generator fills the gaps it can identify (using the URL as a partial publication date proxy, the domain as a partial publisher hint) and flags the rest for you to fill in. The shortest reliable rule for any submission: verify the generated entry against the source itself before submission, especially for any source the extractor could not fully extract.
+
+If you find an entry where the generator's output disagrees with the official style manual — not just incomplete because of source metadata, but actively wrong — that is a bug. The [About page](/about) lists how to report it; corrections are treated as priority work.
+
+## What to do if a citation looks wrong
+
+Three cases account for almost every "this citation looks wrong" message:
+
+**Missing fields.** The source did not expose enough metadata for the generator to fill every required slot. Fix: open the generated entry and fill the missing fields manually, then re-render.
+
+**Wrong style edition assumed by the engine.** The CSL definition for a given style sometimes lags behind a new edition by a few months. If you are writing for the latest edition and the output reflects an older convention, the dedicated style guide covers what the current edition specifies; reconcile by hand.
+
+**Style convention disagreement.** A few engine outputs follow the style's CSL definition but differ slightly from convention in printed style manuals (Cite Them Right Harvard's exact punctuation, NLM Citing Medicine's date format). The shipped style guides on this site reflect what the engine produces; if your assignment requires the printed-manual variant exactly, adjust the output by hand. The differences are small but real.
+
+In all three cases the same principle applies: a citation is only useful if it matches what the source-of-truth style manual says. Verify before submission.
+
+## What "My References" does
+
+The [My References](/my-references) page stores every citation you generate, in your browser's local storage. There is no account, no sign-up, and no server-side reference storage. When you generate a citation, it is saved locally and visible on the references page; when you return to the site, the saved references are still there as long as you have not cleared your browser data.
+
+The feature exists so a research project that takes weeks does not require re-entering source URLs every session. Each saved reference includes the source data, the rendered citation in your selected style, and a timestamp. You can switch the style on the references page to re-render all saved entries in a different style.
+
+What the feature does not do: sync across devices, back up to a server, export to Zotero or Mendeley. An export feature is on the roadmap; for now, treat the references page as a working draft list rather than a permanent archive.
+
+## Privacy
+
+Because there is no account, the site does not collect identifying information. The references you generate are stored only in your browser. Server-side, we log basic usage analytics (citation styles requested, source types extracted, response times) to monitor performance; we do not log the URLs, ISBNs, or DOIs you submit alongside personal identifiers. The privacy details are documented on the [privacy page](/privacy).
+
+## Browser and device support
+
+The tool runs in any current browser — Chrome, Edge, Firefox, Safari — on desktop and mobile. The citation engine is small enough (about 186 KB gzipped) to load comfortably even on a slow connection. Mobile layouts are responsive; the main use case is reading the generated citation to copy it into a word processor on the same device or a different one.
+
+The site does not require JavaScript to read the guides (every page is statically rendered); JavaScript is required for the citation generator and the references page, which manage state in the browser.

--- a/src/content/guides/mla-vs-apa.mdx
+++ b/src/content/guides/mla-vs-apa.mdx
@@ -59,8 +59,8 @@ The same journal article — Goldstein, Ramanathan, and O'Connor's 2024 paper �
 Six structural differences are visible at once:
 
 - **Heading.** APA labels the list **References** (centered, bolded). MLA labels it **Works Cited** (centered, no bold).
-- **Author format.** APA lists every author by surname and initial, separating the final two with an ampersand. MLA writes the first author's full given name and uses *et al.* for three or more authors.
-- **Year placement.** APA parenthesizes the year immediately after the author block. MLA pushes the date to the end of the entry, formatted with the day-month-year conventions of the publication.
+- **Author format.** APA lists authors by surname and initial, joining the final two with an ampersand; the reference-list cap is 20 authors before truncating with an ellipsis and the final author. MLA writes the first author's full given name and uses *et al.* for three or more authors.
+- **Year placement.** APA parenthesizes the year immediately after the author block. MLA places the year later — mid-entry for journal articles (after the issue number, before the page range), at the end of the publisher block for books — rather than directly after the author.
 - **Article title capitalization.** APA uses **sentence case** — only the first word, proper nouns, and the first word after a colon are capitalized. MLA uses **title case** — every significant word is capitalized.
 - **Journal title.** Both italicize. Both use title case. The volume and issue notation is slightly different — APA puts them tight to the journal name (`*Journal*, 19*(2),`); MLA writes them out (`*Journal*, vol. 19, no. 2`).
 - **Hanging indent.** Both use a half-inch hanging indent. This is the one place the two styles match exactly.
@@ -71,7 +71,7 @@ Six structural differences are visible at once:
 
 **Capitalization.** APA's sentence-case rule applies only to article and chapter titles; journal names, book titles, and proper nouns retain title case. MLA uses title case throughout. The two conventions produce reference lists that look different at a glance — APA's article titles read like prose; MLA's read like book covers.
 
-**URL handling.** APA dropped the "Retrieved from" prefix in APA 7. MLA never used a prefix phrase. Both styles now omit `http://` if the URL begins with `https://` and include the full URL on its own with no underline or hyperlink formatting. APA omits access dates for stable sources; MLA recommends an access date for any web source.
+**URL handling.** APA dropped the "Retrieved from" prefix in APA 7; MLA never used a prefix phrase. The two styles differ on the protocol: APA keeps the full URL including `https://`, while MLA 9 strips the protocol on plain URLs (`www.example.com/...`) but retains `https://doi.org/` on DOIs. APA omits access dates for stable sources; MLA treats them as optional but recommended for any web source likely to change.
 
 **DOI formatting.** Identical in both: full clickable URL beginning with `https://doi.org/`. The pre-APA-7 form `doi:10.xxx/yyy` is no longer current and should not appear in new writing.
 
@@ -91,7 +91,7 @@ When the assignment specifies a style, your choice is made. When it does not, th
 
 **Mixing the in-text formats.** Writing `(Chen, 2021)` (APA) in one paragraph and `(Chen 47)` (MLA) in another. This is the single most common citation error in undergraduate writing.
 
-**Putting a year in an MLA in-text citation.** `(Chen 2021)` — no comma, no page — is neither style. MLA's in-text never includes a year unless the writer is distinguishing two works by the same author.
+**Putting a year in an MLA in-text citation.** `(Chen 2021)` — no comma, no page — is neither style. MLA's in-text citation never includes a year; when you need to distinguish two works by the same author, MLA uses a short title (`(Chen, *Architecture* 47)`), not a year.
 
 **Using APA's `p.` abbreviation in MLA.** APA writes `(Chen, 2021, p. 47)`; MLA writes `(Chen 47)` with no abbreviation. Mixing them looks like a draft that was reformatted halfway.
 

--- a/src/content/guides/mla-vs-apa.mdx
+++ b/src/content/guides/mla-vs-apa.mdx
@@ -1,0 +1,102 @@
+---
+title: 'MLA vs APA: Differences in Format, Citations, and When to Use Each'
+pubDate: 2026-02-18
+description: 'Side-by-side comparison of MLA 9 and APA 7 — what each style is for, where they diverge in in-text citations, reference lists, capitalization, and the nine-element container model that distinguishes MLA. The same source formatted in both styles. Written and reviewed by the MLA Generator Editorial Team.'
+category: 'comparison'
+keywords: ['MLA vs APA', 'difference between MLA and APA', 'MLA or APA', 'APA or MLA', 'MLA vs APA in-text', 'MLA vs APA reference list', 'when to use MLA vs APA']
+tags: ['MLA', 'APA', 'comparison', 'citation styles', 'humanities', 'social sciences']
+relatedGuides: ['apa', 'mla', 'in-text-citations', 'works-cited-vs-bibliography', 'when-to-use-each-style', 'how-to-cite-a-journal-article']
+faq:
+  - question: 'Which style is "better"?'
+    answer: 'Neither — they were designed for different things. APA is the default in psychology, education, nursing, and the social sciences because it foregrounds the year of publication, which matters when readers want to know how current the evidence is. MLA is the default in literature, languages, and humanities composition because it foregrounds the page number, which matters when readers want to find the specific passage being analyzed. Picking one over the other for a discipline that uses the other is a recognizable error; picking the right one for your discipline is how the system is supposed to work.'
+  - question: 'Can I use MLA for a science paper or APA for English?'
+    answer: 'You can — but you will be working against the disciplinary expectation. Most assignments specify a style, and most journals require their discipline''s default. Using the "wrong" style in coursework rarely costs marks unless the rubric is explicit; using it in a thesis or journal submission usually requires re-formatting to whatever the program or journal mandates. If your assignment leaves it open, match the journals your discipline publishes in.'
+  - question: 'What is the most common error when mixing MLA and APA habits?'
+    answer: 'The comma between the author and year in the in-text citation. APA uses one — `(Chen, 2021)`. MLA does not use a year in the in-text citation at all — `(Chen 47)`. Students who learned MLA in high school and then switch to APA in undergraduate courses sometimes write `(Chen 2021)` (no comma, no page) — which is neither style. The second most common error is using sentence case (APA''s article-title convention) on a paper that requires title case (MLA''s convention everywhere).'
+  - question: 'Does my discipline strictly require one or the other?'
+    answer: 'Strict requirement is the norm in two cases: when your journal''s author guidelines specify it, and when your degree program''s thesis manual specifies it. Most undergraduate coursework treats the style as a teaching opportunity rather than a strict requirement — the instructor wants to see consistent application of one style, not necessarily the discipline''s default. Check the assignment rubric first; check the journal guidelines second; ask the instructor third.'
+  - question: 'Do MLA and APA handle digital sources differently?'
+    answer: 'In small but consistent ways. APA omits the access date for stable digital sources (DOI-bearing articles, archived pages) and includes it only for content expected to change (live dashboards, Wikipedia). MLA recommends an access date for any web source, on the rationale that web content is inherently mutable. APA''s URL handling has dropped "Retrieved from" since APA 7; MLA never used a prefix phrase. DOIs are formatted identically in both — as full clickable URLs beginning with https://doi.org/.'
+ogImage: '/images/banner.png'
+---
+
+MLA and APA are the two citation styles most students encounter, often in the same year — MLA in a literature seminar, APA in a psychology elective. They look superficially similar (both put author and source information in parentheses inside the text), but the conventions diverge in small ways that compound. A paper that uses APA conventions on an MLA rubric reads as off; a paper that mixes the two reads as careless. This guide covers what each style is for, where they actually differ, and the small handful of cases that cause most cross-style errors.
+
+> The shortest answer: APA puts author and year in the parenthetical, MLA puts author and page. APA uses sentence case for article titles, MLA uses title case throughout. APA labels the list "References," MLA labels it "Works Cited." Pick the one your discipline expects, then apply it consistently.
+
+## What each style is for
+
+[APA 7](/guides/apa) is the citation style for psychology, education, nursing, and most of the social sciences. The American Psychological Association has maintained it since 1929; the current edition is the seventh, released in October 2019. APA's author–date in-text format puts the year of publication in front of the reader on every citation — a deliberate design choice for evidence-based fields where the currency of a finding matters as much as the finding itself.
+
+[MLA 9](/guides/mla) is the citation style for literature, languages, film, and humanities composition. The Modern Language Association has published it since 1951; the current edition is the ninth, released in 2021. MLA's author–page in-text format prioritizes the location of the specific passage being analyzed — a deliberate design choice for humanities work, where readers and graders may want to flip directly to the lines under discussion.
+
+If your discipline is in the social sciences or health sciences, APA is your default. If your discipline is in the humanities, MLA is your default. The exceptions are small enough to be specified by the assignment or the journal.
+
+## In-text citation mechanics
+
+The most visible difference. Same single-author source — Chen's 2021 book *The Architecture of Working Memory*, with a quoted passage on page 47.
+
+| | APA 7 | MLA 9 |
+| --- | --- | --- |
+| Parenthetical | (Chen, 2021) | (Chen 47) |
+| Narrative | Chen (2021) found that … | Chen argues that … (47) |
+| With direct quote | (Chen, 2021, p. 47) | (Chen 47) |
+| Two authors | (Lin & Patel, 2022) | (Lin and Patel 122) |
+| Three+ authors | (Goldstein et al., 2024) | (Goldstein et al. 88) |
+| No author | ("Cognitive Load," 2023) | ("Cognitive Load") |
+| No date | (Author, n.d.) | (Author) |
+
+The differences are systematic. APA always shows the year; MLA never does. APA uses an ampersand for two authors in parentheticals (`Lin & Patel`); MLA spells out "and" (`Lin and Patel`). APA uses `p.` before page numbers; MLA writes the page number without an abbreviation. APA's *et al.* threshold is three or more authors; MLA's is the same. APA uses `n.d.` for no date; MLA simply omits the date.
+
+## Reference list versus Works Cited
+
+The same journal article — Goldstein, Ramanathan, and O'Connor's 2024 paper — formatted in each style's reference list.
+
+> **APA 7:** Goldstein, A., Ramanathan, P., & O'Connor, L. (2024). Sleep consolidation effects on procedural learning in adolescents. *Journal of Cognitive Development, 19*(2), 87–104. https://doi.org/10.1037/cogdev0000412
+>
+> **MLA 9:** Goldstein, Aaron, et al. "Sleep Consolidation Effects on Procedural Learning in Adolescents." *Journal of Cognitive Development*, vol. 19, no. 2, 2024, pp. 87–104. https://doi.org/10.1037/cogdev0000412.
+
+Six structural differences are visible at once:
+
+- **Heading.** APA labels the list **References** (centered, bolded). MLA labels it **Works Cited** (centered, no bold).
+- **Author format.** APA lists every author by surname and initial, separating the final two with an ampersand. MLA writes the first author's full given name and uses *et al.* for three or more authors.
+- **Year placement.** APA parenthesizes the year immediately after the author block. MLA pushes the date to the end of the entry, formatted with the day-month-year conventions of the publication.
+- **Article title capitalization.** APA uses **sentence case** — only the first word, proper nouns, and the first word after a colon are capitalized. MLA uses **title case** — every significant word is capitalized.
+- **Journal title.** Both italicize. Both use title case. The volume and issue notation is slightly different — APA puts them tight to the journal name (`*Journal*, 19*(2),`); MLA writes them out (`*Journal*, vol. 19, no. 2`).
+- **Hanging indent.** Both use a half-inch hanging indent. This is the one place the two styles match exactly.
+
+## Other structural differences
+
+**The nine-element container model.** MLA 9 organizes every Works Cited entry around nine "core elements," in order: author, title of source, title of container, other contributors, version, number, publisher, publication date, location. This is MLA's distinctive innovation since the eighth edition: rather than memorize a different template for each source type, you build any entry by filling in whichever of the nine elements apply. APA still uses source-type-specific templates — a book template, a journal article template, a website template — each with its own field order.
+
+**Capitalization.** APA's sentence-case rule applies only to article and chapter titles; journal names, book titles, and proper nouns retain title case. MLA uses title case throughout. The two conventions produce reference lists that look different at a glance — APA's article titles read like prose; MLA's read like book covers.
+
+**URL handling.** APA dropped the "Retrieved from" prefix in APA 7. MLA never used a prefix phrase. Both styles now omit `http://` if the URL begins with `https://` and include the full URL on its own with no underline or hyperlink formatting. APA omits access dates for stable sources; MLA recommends an access date for any web source.
+
+**DOI formatting.** Identical in both: full clickable URL beginning with `https://doi.org/`. The pre-APA-7 form `doi:10.xxx/yyy` is no longer current and should not appear in new writing.
+
+**The page number rule for paraphrases.** MLA requires page numbers for both quotes and paraphrases when the source has pages — every in-text citation that draws on a specific passage should locate it. APA requires page numbers only for direct quotes; paraphrases can use the author and year alone, though APA encourages including a locator when it helps the reader find the passage.
+
+## Which style to use when you have a choice
+
+When the assignment specifies a style, your choice is made. When it does not, three heuristics produce a reasonable default.
+
+**Match your discipline's journals.** If the journals you cite most are APA-formatted, your paper should be APA. If they are MLA-formatted, your paper should be MLA. Matching the house style of the work you cite makes the bibliography flow naturally and signals familiarity with the field's conventions.
+
+**Match the rest of your degree program's writing.** If every other paper you have written in your major was in APA, sticking with APA for one more is the path of least resistance — both for you and for graders who are reading dozens of papers in one style and will notice an outlier.
+
+**When in doubt, ask.** A one-line email to the instructor saves a re-format later. "The rubric says citations should follow a recognized academic style; would APA be appropriate, or do you prefer MLA?" gets a clear answer in most cases.
+
+## Common cross-style mistakes
+
+**Mixing the in-text formats.** Writing `(Chen, 2021)` (APA) in one paragraph and `(Chen 47)` (MLA) in another. This is the single most common citation error in undergraduate writing.
+
+**Putting a year in an MLA in-text citation.** `(Chen 2021)` — no comma, no page — is neither style. MLA's in-text never includes a year unless the writer is distinguishing two works by the same author.
+
+**Using APA's `p.` abbreviation in MLA.** APA writes `(Chen, 2021, p. 47)`; MLA writes `(Chen 47)` with no abbreviation. Mixing them looks like a draft that was reformatted halfway.
+
+**Using sentence case for article titles in MLA.** MLA uses title case for everything. Sentence case is APA's distinctive capitalization rule and looks wrong on an MLA paper.
+
+**Using "Works Cited" on an APA paper or "References" on an MLA paper.** The labels are required to match the style. A heading mismatch is one of the first things a marker notices, and it suggests the rest of the paper may also be in the wrong style.
+
+**Forgetting the bold heading in APA.** APA 7 specifies the **References** heading as centered and bold. MLA and Chicago do not bold. A non-bold References heading on an APA paper is a small but registered submission error.

--- a/src/content/guides/whats-new.mdx
+++ b/src/content/guides/whats-new.mdx
@@ -1,0 +1,126 @@
+---
+title: "What's New in Each Citation Style: APA 7, MLA 9, Chicago 18, and the Rest"
+pubDate: 2026-05-25
+description: 'A survey of the most recent edition changes for the seven major citation styles — APA 7, MLA 9, Chicago 18, Harvard (Cite Them Right 12), Vancouver, IEEE, and AMA 11. The changes that matter for writers updating from a previous edition, with notes on how to tell which edition a paper is in. Written and reviewed by the MLA Generator Editorial Team.'
+category: 'meta'
+keywords: ['citation style updates', 'APA 7 changes', 'MLA 9 changes', 'Chicago 18 changes', 'Cite Them Right 12', 'AMA 11 changes', 'new edition citation style', 'whats new citation']
+tags: ['updates', 'editions', 'APA 7', 'MLA 9', 'Chicago 18', 'Harvard', 'Vancouver', 'IEEE', 'AMA 11']
+relatedGuides: ['apa', 'mla', 'chicago', 'harvard', 'vancouver', 'ieee', 'ama']
+faq:
+  - question: 'How often do these style manuals update?'
+    answer: 'Roughly every 5–10 years for major editions, with intermittent web-based addenda between editions. APA has typically updated every decade (APA 6 in 2009; APA 7 in 2019). MLA updated in 2009, 2016, and 2021. Chicago updated in 2010, 2017, and 2024. Cite Them Right (the Harvard variant) updates every 3–4 years; the 12th edition came out in 2022. AMA 11 came out in 2020. Vancouver and IEEE update on rolling cycles with no fixed edition number. The implication: a paper written more than a decade ago is probably in an older edition than the current standard.'
+  - question: 'Does it matter which edition I cite from?'
+    answer: 'Yes. Each edition introduces real rule changes — the et al. threshold, the publisher-city requirement, the URL prefix, the page-number cutoff. A paper written to APA 6 rules looks subtly wrong against an APA 7 rubric; a paper using CMS 17 conventions in 2026 is two years behind the current Chicago manual. Markers and editors generally know the current edition and check against it.'
+  - question: 'Where can I see what changed since the last edition?'
+    answer: 'Each style''s dedicated guide on this site ends with a "What''s new in [latest edition]" section documenting the meaningful changes. This page surveys all seven styles at once; the per-style guides go deeper on the changes specific to each.'
+  - question: 'Does this site''s generator always use the latest edition?'
+    answer: 'The generator uses the most current CSL definitions for each style, which generally track the latest edition with a lag of a few months when a new edition ships. For APA 7, MLA 9, Chicago 18, Harvard (Cite Them Right 12), and AMA 11, the engine produces current-edition output. For Vancouver and IEEE — which do not follow a fixed edition cadence — the engine follows the CSL project''s current conventions, which mirror what current ICMJE and IEEE journals expect.'
+  - question: 'What happens to my older papers when a new edition comes out?'
+    answer: 'Nothing — they stay in whatever edition they were written in. The new edition does not invalidate older work. The practical question is whether you need to update an older paper for republication or for inclusion in a new submission. For journal resubmissions and thesis revisions, follow the current edition; for archival reasons (a paper already submitted and graded), leave it alone.'
+ogImage: '/images/banner.png'
+---
+
+Citation styles are not static. Every few years, a style organization publishes a new edition that adjusts the rules — sometimes substantively (the *et al.* threshold moved, the publisher city dropped) and sometimes lightly (a few new worked examples, a clarified ambiguity). This page surveys what changed in the most recent edition of each of the seven supported styles, what matters for writers updating from a prior edition, and how to identify which edition a given paper is in.
+
+> The shortest answer: APA 7 (2019/2020) eased its multi-author rules and added inclusive-language guidance. MLA 9 (2021) refined MLA 8's core elements model. Chicago 18 (2024) is the newest, with AI citation rules and a lowered et al. threshold. Cite Them Right 12 (2022) added digital-source coverage. AMA 11 (2020) dropped place of publication. Vancouver and IEEE update on rolling cycles.
+
+## APA 7 (2020)
+
+The seventh edition of the *Publication Manual of the American Psychological Association* was the first major overhaul of APA since 2009. The full breakdown is in the [APA guide](/guides/apa); the headline changes:
+
+- **Singular *they* is accepted** as both a generic pronoun (when gender is unknown) and a personal pronoun (when an individual uses it).
+- **Three or more authors collapse to *et al.* immediately** — APA 6 spelled out three to five surnames on first mention.
+- **Reference-list author cap moved from 7 to 20** before using an ellipsis.
+- **Publisher city dropped** entirely from book references.
+- **"Retrieved from" before URLs dropped** for stable sources; retained only for sources expected to change (Wikipedia, live dashboards).
+- **Bias-free language guidance expanded** to cover age, disability, gender, race and ethnicity, sexual orientation, and socioeconomic status.
+
+If you are still writing in APA 6 in 2026, the most visible giveaway is the comma-separated first mention of three authors. APA 7 eliminated that pattern.
+
+## MLA 9 (2021)
+
+The ninth edition of the *MLA Handbook* is a refinement of the eighth, not a reinvention. MLA 8 (2016) introduced the nine-element container model; MLA 9 tightened it and expanded the worked examples. The full breakdown is in the [MLA guide](/guides/mla); the headline changes:
+
+- **Core elements clarified.** The nine elements remained the same; MLA 9 walks through edge cases and ambiguous source types in much greater depth.
+- **Annotated bibliography guidance added** in section 5.132 — placement, indentation, and expected length.
+- **Inclusive language chapter added**, covering gender-neutral pronouns, identity-first versus person-first language, and racial/ethnic references.
+- **Worked examples for digital sources expanded** — social media posts, podcasts, video games, web comics, YouTube videos.
+- **Author cap before *et al.* unchanged** at three authors.
+
+MLA 9's continuity with MLA 8 means existing reference managers and templates configured for MLA 8 produce output that is still essentially current; only the worked examples for newer source types are likely to differ.
+
+## Chicago 18 (2024)
+
+The newest major release. The eighteenth edition of *The Chicago Manual of Style* is the first revision since 2017. The full breakdown is in the [Chicago guide](/guides/chicago); the headline changes:
+
+- **Explicit AI-generated content rules** — treat the AI service as the author, include the prompt or a description of what was asked, record the date used.
+- **Expanded digital-source treatment** — preprints, social-media posts, podcasts, streaming video, datasets all upgraded to first-class source types.
+- **Author–date promoted to equal status** with notes–bibliography rather than being treated as an alternative.
+- **Inclusive-language updates** parallel APA 7 and MLA 9.
+- ***Et al.* threshold lowered for in-text** to three or more authors (was four in CMS 17). Reference list lists up to six authors before "First three et al." (was up to ten with ellipsis in CMS 17).
+- **Place of publication is now optional** (§14.30). CMS 17 required it.
+- **Title case capitalizes prepositions of five or more letters** and lowercases shorter ones. CMS 17 lowercased prepositions of any length.
+
+Chicago 18 is the most recent major-edition release of any of the seven styles. Papers written before April 2024 are almost certainly in CMS 17.
+
+## Harvard — Cite Them Right 12 (2022)
+
+The Cite Them Right variant of Harvard, published by Bloomsbury Academic, updates every 3–4 years. The twelfth edition (2022) is the most recent. The full breakdown is in the [Harvard guide](/guides/harvard); the headline changes:
+
+- **Expanded digital source examples** for podcasts, social media, archived web pages, and generative AI.
+- **Updated guidance on accessing institutional repositories** and open-access platforms.
+- **Refinements to the in-text citation rules** around organizational authors and multi-volume works.
+- ***Et al.* threshold unchanged** at four or more authors.
+- **"Available at:" + "(Accessed: Month DD, YYYY)" convention** retained as the standard format for web sources.
+
+Cite Them Right 12 is the variant this site's generator produces and the basis for the dedicated Harvard guide.
+
+## Vancouver (NLM Citing Medicine, rolling updates)
+
+Vancouver does not follow a fixed edition cycle. The reference standard is the National Library of Medicine's *Citing Medicine*, currently in its second edition (2007) with periodic web-based addenda. The International Committee of Medical Journal Editors (ICMJE) publishes recommendations that complement *Citing Medicine* and update every few years. The full breakdown is in the [Vancouver guide](/guides/vancouver); recent areas of change:
+
+- **Preprint citation conventions** added — most clinical preprints now appear on medRxiv and bioRxiv; the ICMJE recommendations document how to cite them.
+- **Dataset citations** added — research datasets get DOIs through repositories like Zenodo and Dryad; Vancouver and ICMJE both now support citing these as first-class sources.
+- **DOI formatting unchanged** — bare DOI with `doi:` prefix and no space.
+- **Italics still absent** from journal names, book titles, and Latin abbreviations.
+
+Vancouver's rolling-update pattern means there is no single year to point to as "the new Vancouver." Currentness is checked against the latest ICMJE recommendations document.
+
+## IEEE (rolling updates)
+
+The IEEE *Editorial Style Manual* updates on a rolling cadence with no fixed edition. Recent changes:
+
+- **Reference format adjustments** to align with ORCID identifier inclusion.
+- **DOI rendering refinements** — `doi: 10.xxx/yyy` (lowercase, space after colon, terminal period).
+- **Expanded conference-paper examples** as virtual conference proceedings became standard.
+- ***Et al.* italicization** retained — IEEE remains distinctive in italicizing the abbreviation.
+- **Reference-list collapse to "first author *et al.*"** at seven or more authors.
+
+The full breakdown is in the [IEEE guide](/guides/ieee). IEEE journals publish current-style requirements on each journal's author-guidelines page; check the specific journal you are submitting to for any house modifications.
+
+## AMA 11 (2020)
+
+The eleventh edition of the *AMA Manual of Style* (2020) is the most recent. The full breakdown is in the [AMA guide](/guides/ama); the headline changes:
+
+- **Place of publication dropped** for most source types. Previous editions retained it.
+- **DOI formatting standardized** to `doi:10.xxx/yyy` (no space after colon, no terminal period).
+- **Author cap lowered to first three** before *et al.* for sources with seven or more authors. AMA 10 listed up to six.
+- **Expanded coverage of preprints, datasets, and supplementary materials.**
+- **Inclusive-language guidance updated** in parallel with APA 7.
+- **Superscript Arabic numerals** retained as the default in-text format.
+
+AMA 11 is what the *JAMA* network and most U.S. clinical journals expect in 2026.
+
+## How to tell which edition a paper is in
+
+A paper rarely announces its edition explicitly, but signals are usually visible in the reference list.
+
+**APA 6 versus APA 7:** APA 6 lists "Retrieved from" before URLs; APA 7 does not. APA 6 includes the publisher city; APA 7 does not. APA 6 spells out three authors on first in-text mention; APA 7 collapses to *et al.* immediately.
+
+**MLA 7 (pre-2016) versus MLA 8/9:** MLA 7 uses "Print" and "Web" medium tags; MLA 8 and 9 do not. MLA 8 and 9 use the nine-element container model with commas and periods in a specific order; MLA 7 used a more rigid template.
+
+**CMS 16 versus 17 versus 18:** CMS 16 and earlier required the publisher city; CMS 17 still required it; CMS 18 makes it optional. CMS 17 used a four-or-more threshold for *et al.* in text; CMS 18 lowers it to three or more.
+
+**AMA 10 versus 11:** AMA 10 includes publisher city; AMA 11 does not. AMA 10 uses `doi:10.xxx/yyy` differently in formatting; AMA 11 standardized.
+
+When a paper's reference list looks subtly off, identifying the edition mismatch is usually the answer.

--- a/src/content/guides/whats-new.mdx
+++ b/src/content/guides/whats-new.mdx
@@ -61,7 +61,7 @@ The newest major release. The eighteenth edition of *The Chicago Manual of Style
 - **Place of publication is now optional** (§14.30). CMS 17 required it.
 - **Title case capitalizes prepositions of five or more letters** and lowercases shorter ones. CMS 17 lowercased prepositions of any length.
 
-Chicago 18 is the most recent major-edition release of any of the seven styles. Papers written before April 2024 are almost certainly in CMS 17.
+Chicago 18 is the most recent major-edition release of any of the seven styles. Papers written before late 2024 are almost certainly in CMS 17.
 
 ## Harvard — Cite Them Right 12 (2022)
 
@@ -108,6 +108,7 @@ The eleventh edition of the *AMA Manual of Style* (2020) is the most recent. The
 - **Expanded coverage of preprints, datasets, and supplementary materials.**
 - **Inclusive-language guidance updated** in parallel with APA 7.
 - **Superscript Arabic numerals** retained as the default in-text format.
+- ***Et al.* italicization** distinction retained: italicized in body prose, set in roman in the reference list — distinct from IEEE, which italicizes in both places.
 
 AMA 11 is what the *JAMA* network and most U.S. clinical journals expect in 2026.
 

--- a/src/content/guides/when-to-use-each-style.mdx
+++ b/src/content/guides/when-to-use-each-style.mdx
@@ -1,0 +1,100 @@
+---
+title: 'When to Use Each Citation Style: APA, MLA, Chicago, Harvard, Vancouver, IEEE, or AMA'
+pubDate: 2026-04-01
+description: 'How to pick the right citation style for your paper. Per-discipline defaults for APA, MLA, Chicago, Harvard, Vancouver, IEEE, and AMA, plus what to do in interdisciplinary work and when the assignment leaves the choice open. Written and reviewed by the MLA Generator Editorial Team.'
+category: 'comparison'
+keywords: ['when to use APA', 'when to use MLA', 'which citation style', 'citation style by discipline', 'choosing citation style', 'APA vs MLA vs Chicago', 'best citation style']
+tags: ['citation styles', 'comparison', 'APA', 'MLA', 'Chicago', 'Harvard', 'Vancouver', 'IEEE', 'AMA', 'discipline']
+relatedGuides: ['mla-vs-apa', 'chicago-notes-vs-author-date', 'apa', 'mla', 'chicago', 'in-text-citations']
+faq:
+  - question: 'What if my paper crosses disciplines?'
+    answer: 'Pick the style of whichever discipline owns the paper''s home — the department it is submitted to, the journal it is targeting, the program issuing the degree. A psychology paper that draws on history of science still cites in APA because psychology is its home; a history paper that uses sociological methods still cites in Chicago notes–bibliography. The home discipline''s convention wins because that is who will grade or peer-review the work. If two disciplines have equal claim and your assignment is silent, pick one and apply it consistently.'
+  - question: 'Can I just use the style my generator or word processor defaults to?'
+    answer: 'Only if it happens to match your discipline''s expectation. Most citation tools default to the most-asked-for style (often APA), which is the right answer in psychology and social-science work and the wrong answer in literature or history. Set the style explicitly before you start, both in your generator and in your word processor''s reference manager if you use one. Switching styles partway through a paper costs an hour of cleanup at minimum.'
+  - question: 'What if I am publishing for a journal that has its own house style?'
+    answer: 'Follow the journal''s author guidelines exactly. Most major journals adopt one of the seven standard styles with small house modifications (a slightly different DOI format, a custom heading convention, page-number specifications). The journal''s instructions for authors document is the authoritative source — even if your discipline''s default is something else, the journal''s rules govern for that submission. Reformat after acceptance to whatever the production team requires.'
+  - question: 'Are there fields that do not use any of the seven major styles?'
+    answer: 'Yes. Law uses its own system (Bluebook in the U.S., OSCOLA in the U.K., similar national variants elsewhere). Linguistics has its own conventions (LSA-style). Several physical-science journals have idiosyncratic in-house styles that resemble IEEE or AMA but with their own modifications. When your target venue uses a style outside the seven this site supports, follow the venue''s instructions directly — the major styles are starting points, not the universe.'
+  - question: 'How big a deal is picking the "wrong" style?'
+    answer: 'In coursework, usually small — an inconsistent style is more often flagged than an "incorrect" style choice, and most instructors care more about consistent application than about which style. In journal submission, larger — most journals reject manuscripts that arrive in the wrong style without review, requiring the author to reformat and resubmit. In a thesis or dissertation, larger still — the department''s style manual is enforced strictly because the document is meant to be archival. Pick correctly the first time and you save real work.'
+ogImage: '/images/banner.png'
+---
+
+There are seven major citation styles supported by this site, and most papers do not need to compare them all — your discipline picks the style for you in most cases. But the cases where it does not, or where the rules are not obvious, are where students lose hours to picking the wrong style and reformatting. This guide maps disciplines to styles, covers the interdisciplinary cases, and explains how to handle the situations where the choice is genuinely open.
+
+> The shortest answer: APA for social sciences and health, MLA for literature and humanities, Chicago notes–bibliography for history and art history, Chicago author–date for sciences using Chicago, Harvard for UK universities and business, Vancouver for biomedical, IEEE for engineering, AMA for U.S. clinical medicine.
+
+## The three things that pick a style for you
+
+In order of priority:
+
+**Your assignment.** If the assignment specifies a style — and most do — that is your answer. The instructor or department has thought about which style fits the work and the discipline; matching the specified style is part of what you are being graded on.
+
+**The journal or venue.** If you are submitting for publication, the journal's instructions for authors are the authoritative source. Most journals specify a style, often with small house modifications (a custom heading format, a particular DOI rendering, specific page-number conventions). Submit in the journal's style; reformat for production after acceptance.
+
+**Your discipline's convention.** When neither the assignment nor a target venue specifies, fall back to your discipline's default. The convention is not arbitrary — it reflects how readers in the field expect to encounter citations, and it makes your work legible to those readers without friction.
+
+## The discipline-to-style map
+
+The styles arrange themselves along two axes: how citations appear in the text (author–date, author–page, or numeric), and which fields have adopted each. The table below summarizes the disciplinary defaults; the per-style guides cover the mechanics.
+
+| Discipline | Default style | Why |
+| --- | --- | --- |
+| Psychology | [APA 7](/guides/apa) | APA is the American Psychological Association's own style — adopted across the field since the 1950s. |
+| Education | [APA 7](/guides/apa) | Aligns with the social-science conventions and the journals education research publishes in. |
+| Nursing | [APA 7](/guides/apa) | Most nursing journals follow APA; some shift to AMA for clinical research. |
+| Sociology | [APA 7](/guides/apa) or [Chicago author–date](/guides/chicago) | Discipline-internal mix — *American Sociological Review* uses ASA style (Chicago-like); most other sociology journals use APA. |
+| Political science | [APA 7](/guides/apa), [Chicago author–date](/guides/chicago) | Depends on the subfield — comparative politics often uses Chicago; international relations often uses APA. |
+| Economics | [Chicago author–date](/guides/chicago) | Most economics journals use Chicago author–date; some use APA. |
+| Literature | [MLA 9](/guides/mla) | MLA is the Modern Language Association's own style — the default in English and comparative-literature departments. |
+| Languages and linguistics | [MLA 9](/guides/mla) | MLA is the default; linguistics journals often use LSA style for technical writing. |
+| Film studies | [MLA 9](/guides/mla) | MLA's container model handles film as a source type cleanly. |
+| Composition and rhetoric | [MLA 9](/guides/mla) | Most first-year composition courses use MLA. |
+| History | [Chicago notes–bibliography](/guides/chicago) | Footnotes carry discursive citation material that fits humanities writing patterns. |
+| Art history | [Chicago notes–bibliography](/guides/chicago) | Same rationale — footnotes for the long citations that art history requires (catalog entries, exhibition references). |
+| Religion and theology | [Chicago notes–bibliography](/guides/chicago) | SBL (Society of Biblical Literature) Handbook extends Chicago for biblical-studies-specific cases. |
+| Philosophy | [Chicago notes–bibliography](/guides/chicago) | Many philosophy journals use Chicago; some use a variant of MLA. |
+| Business / management (UK) | [Harvard (Cite Them Right)](/guides/harvard) | Standard in UK business schools and most UK universities. |
+| Business / management (US) | [APA 7](/guides/apa) | American business schools generally follow APA. |
+| Engineering | [IEEE](/guides/ieee) | IEEE is the Institute of Electrical and Electronics Engineers' own style; the default for engineering papers and IEEE journal submissions. |
+| Computer science | [IEEE](/guides/ieee) or [ACM](https://www.acm.org/publications/authors/reference-formatting) | IEEE for most journal submissions; ACM has its own style for ACM-published venues. |
+| Medicine (clinical, US) | [AMA 11](/guides/ama) | AMA is the American Medical Association's own style; default for JAMA-family journals. |
+| Medicine (biomedical, international) | [Vancouver](/guides/vancouver) | Vancouver follows the ICMJE recommendations and is the default for biomedical journals internationally. |
+| Public health | [AMA 11](/guides/ama) or [APA 7](/guides/apa) | AMA for clinical journals; APA for behavioral and policy work. |
+| Geography | [Harvard](/guides/harvard) or [APA 7](/guides/apa) | UK geography uses Harvard; American physical geography often uses APA. |
+| Law (US) | Bluebook (not covered) | Specialized legal-citation system; outside the seven major styles. |
+| Law (UK) | OSCOLA (not covered) | Oxford Standard for Citation of Legal Authorities; outside the seven major styles. |
+
+The strong signal in this table is that most disciplines have a clear default — and that the default reflects the field's writing conventions rather than an aesthetic choice. Where the table shows two styles, the secondary one is usually the right answer when the primary style is unfamiliar to the writer or when a specific journal prescribes otherwise.
+
+## When the assignment leaves it open
+
+Some assignments — particularly undergraduate research papers and capstone projects — leave the style choice to the student. Three heuristics produce a reasonable default.
+
+**Match the journals you are citing most.** Your reference list will be cleaner if the style you use matches the style of the work you cite. APA cites APA-formatted journals cleanly; MLA cites MLA-formatted humanities sources cleanly. The friction comes from citing many APA-formatted sources in MLA — every entry requires manual reformatting from how the source itself presents.
+
+**Match your degree program's other writing.** If every other paper in your major was in APA, sticking with APA is the path of least resistance. Graders reading dozens of papers in one style will notice an outlier; some will count it against you, others will not, but switching styles when you do not have to is friction you do not need.
+
+**Pick MLA for general humanities, APA for general social-science or scientific writing.** When the question is genuinely open and neither of the heuristics above applies, MLA is the safe humanities default and APA is the safe everything-else default. Both are widely recognized; both have extensive student-facing documentation; both are supported by every citation tool.
+
+## Interdisciplinary work and edge cases
+
+**Cross-disciplinary papers.** A psychology paper that draws on history of science still cites in APA, because psychology is its home discipline. A literature paper that uses sociological methods still cites in MLA. The home discipline's convention wins because that is who will grade or peer-review the work. If two disciplines have equal claim — a digital humanities paper that splits between literature and computer science — pick one based on where the paper will be submitted and apply it consistently throughout.
+
+**Theses and dissertations.** Most programs publish a thesis manual that specifies the style. The manual usually adopts one of the seven major styles with small modifications (a custom title-page format, specific spacing rules, sometimes a custom heading hierarchy). Follow the manual exactly — thesis examiners check formatting closely because the document is meant to be archival.
+
+**Multi-author papers.** When co-authors come from different disciplines and prefer different styles, the choice usually defaults to the discipline that owns the journal or venue you are targeting. If you are submitting to a psychology journal, use APA regardless of where the co-authors come from.
+
+**Conference papers vs journal papers.** A conference paper sometimes uses the conference's house style (often IEEE for engineering, ACM for computer science); the corresponding journal version may need to be reformatted to the target journal's style. Save the source-data extraction once; reformat the output as venues change.
+
+## Switching styles after you have started
+
+If you discover partway through a paper that you should have used a different style, the switch is mechanical but not free.
+
+**Generator-produced citations** can usually be regenerated in the new style by selecting the new style in your tool and re-running the references. This site's generator changes output by selecting the style; the work is the time required to re-paste each entry.
+
+**In-text citations** require manual conversion. Every `(Chen, 2021)` becomes `(Chen 2021)` or `(Chen 47)` depending on the target style. A search-and-replace pass catches most of them; a careful read-through catches the rest.
+
+**The heading and the back-matter format** need updating: "Works Cited" to "References" or "Bibliography," bolded to not-bolded (APA versus MLA/Chicago), alphabetization order if you are switching from a numeric style to an author–date style or vice versa.
+
+The cost of switching is high enough that picking the right style at the start is worth ten minutes of checking the assignment, the journal, and the discipline. The cost of not switching, when the wrong style has been used throughout, is usually higher.


### PR DESCRIPTION
## Summary

Final PR in the 5-PR content & SEO overhaul. Adds the three comparison pages and two FAQ/meta pages from the spec; the sixth spec'd page (\`/about\`) was already shipped in PR 1.

**New pages:**
- \`/guides/mla-vs-apa\` — side-by-side comparison of the two most-encountered styles
- \`/guides/chicago-notes-vs-author-date\` — the two Chicago systems compared
- \`/guides/when-to-use-each-style\` — discipline-to-style map with edge cases
- \`/guides/citation-generator-faq\` — meta page about the tool
- \`/guides/whats-new\` — survey of edition changes across all 7 styles

**Effect on internal linking:** Shipping these five slugs unblocks the last of the dangling \`relatedGuides\` references across the 19 already-shipped guides.

## Pre-merge review

Ran a fresh-context correctness review per global CLAUDE.md. The reviewer flagged 2 BLOCKERs, 2 HIGH-severity issues, and several MEDIUM/NONBLOCKING findings — lighter than PR 3 and PR 4's reviews, since most cross-style claims now have a calibrated template established. All BLOCKERs and the cheap MEDIUM/HIGH fixes were addressed in commit \`9381ef3\`. Fixes covered:

- **URL/protocol handling in mla-vs-apa** — APA keeps the full \`https://\` URL; MLA 9 strips the protocol on plain URLs but retains it on DOIs. The original draft wrongly said both styles omit the protocol.
- **MLA in-text never includes a year** — when distinguishing two works by the same author, MLA uses a short title, not a year. Original draft implied it sometimes carries a year.
- **citation-generator-faq bundle-size framing** — citeproc-js runs server-side on Cloudflare Pages Functions, not in the browser. The original draft implied a client-side download.
- **citation-generator-faq privacy claim** — the shipped privacy page discloses IP logging and AdSense cookies; reframed to "no account, no server-side reference storage" without the blanket "no identifying information" claim.
- **whats-new Chicago 18 timing** — CMS 18 published September 2024, not April. Softened to "before late 2024."
- **AMA *et al.* italicization** — added the body-italic / reference-roman distinction to the whats-new survey, since AMA's italics nuance has been a recurring error surface across past reviews.
- **mla-vs-apa year-placement framing** — MLA places the year mid-entry for journals (after issue, before page range), not uniformly "at the end."
- **APA 7 author cap** — added the 20-author reference-list cap to the author-format bullet for completeness.

**Non-blocking findings deferred:** minor phrasing precision in MLA access-date framing and AMA 10 author-cap comparison; both judged not worth the edit risk for this PR.

## Test plan

- [x] \`npm run build\` — clean
- [x] All 5 pages present in \`dist/sitemap-0.xml\`
- [ ] After CF Pages preview deploys, spot-check the mla-vs-apa comparison table on mobile
- [ ] After merge, verify in production at \`mlagenerator.com/guides/mla-vs-apa\` (append \`?nocache=1\` if needed)

## Closes the overhaul spec

Per overhaul spec section "Sequencing — 5 PRs":
- PR 1 (infrastructure) — shipped
- PR 2 (8 style guides) — shipped
- PR 3 (6 how-to pages) — shipped
- PR 4 (5 concept guides) — shipped
- **PR 5 (3 comparison + 2 FAQ/meta pages) — this PR**

After this merges, the entire \`docs/superpowers/specs/2026-05-27-content-and-seo-overhaul-design.md\` spec is complete. 24 guides + /about + /guides index + the citation pages.