### PR TITLE
Fix Add Person / Add Organization in the edit-citation dialog

### DIFF
--- a/src/components/react/EditCitationForm.tsx
+++ b/src/components/react/EditCitationForm.tsx
@@ -86,7 +86,7 @@ export default function EditCitationForm({ source, setSources, currentRef }: Pro
                 <WebsiteName value={local['container-title'] || ''} onChange={(v) => patch({ 'container-title': v })} />
             )}
             <Line className="my-4" />
-            <Contributors source={{ ...source, csl: local }} setSources={setSources} />
+            <Contributors authors={local.author ?? []} onChange={(next) => patch({ author: next })} />
             <Line className="my-4" />
             <PublicationDate value={local.issued} onChange={(d) => patch({ issued: d })} isRecommended />
             <AccessDate value={local.accessed} onChange={(d) => patch({ accessed: d })} />

--- a/src/components/react/EditCitationFormComponents.tsx
+++ b/src/components/react/EditCitationFormComponents.tsx
@@ -5,7 +5,6 @@ import { Button } from "./Button";
 import { Building2, Calendar, ChevronDown, Trash2, UserRound } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
 import type { CSLDate, CSLName } from "../../lib/citations/csl-types";
-import type { StoredSource } from "../../lib/references/storage";
 import type { Option } from './Dropdown';
 import SimpleDropdown from './SimpleDropdown';
 
@@ -46,8 +45,8 @@ const months: Option[] = [
 export const Line = ({ className }: { className?: string }) => <div className={cn("h-[1px] w-full bg-border", className)} />
 
 interface ContributorsProps {
-    source: StoredSource;
-    setSources: (s: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => void;
+    authors: CSLName[];
+    onChange: (authors: CSLName[]) => void;
 }
 
 const isPerson = (n: CSLName): n is Exclude<CSLName, { literal: string }> => !('literal' in n);
@@ -55,15 +54,8 @@ const isPerson = (n: CSLName): n is Exclude<CSLName, { literal: string }> => !('
 /**
  * Contributors component — operates on CSL-JSON `author` arrays.
  */
-export const Contributors = ({ source, setSources }: ContributorsProps) => {
-    const authors = source.csl.author ?? [];
+export const Contributors = ({ authors, onChange }: ContributorsProps) => {
     const [lastOpenedIdx, setLastOpenedIdx] = useState<number | null>(null);
-
-    const update = (next: CSLName[]) => {
-        setSources((prev) => prev.map((s) =>
-            s.uuid === source.uuid ? { ...s, csl: { ...s.csl, author: next } } : s,
-        ));
-    };
 
     const previewName = (n: CSLName) => {
         if (isPerson(n)) {
@@ -73,22 +65,22 @@ export const Contributors = ({ source, setSources }: ContributorsProps) => {
     };
 
     const handleEdit = (idx: number, patch: Partial<CSLName>) => {
-        update(authors.map((a, i) => i === idx ? ({ ...a, ...patch } as CSLName) : a));
+        onChange(authors.map((a, i) => i === idx ? ({ ...a, ...patch } as CSLName) : a));
     };
 
     const handleAddPerson = () => {
         const next = [...authors, { family: '', given: '' } as CSLName];
-        update(next);
+        onChange(next);
         setLastOpenedIdx(next.length - 1);
     };
 
     const handleAddOrganization = () => {
         const next = [...authors, { literal: '' } as CSLName];
-        update(next);
+        onChange(next);
         setLastOpenedIdx(next.length - 1);
     };
 
-    const handleDelete = (idx: number) => update(authors.filter((_, i) => i !== idx));
+    const handleDelete = (idx: number) => onChange(authors.filter((_, i) => i !== idx));
 
     return (
         <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:gap-4">

--- a/tests/client/EditCitationForm.test.tsx
+++ b/tests/client/EditCitationForm.test.tsx
@@ -51,3 +51,31 @@ describe('EditCitationForm currentRef sync', () => {
     expect(setSources).not.toHaveBeenCalled();
   });
 });
+
+describe('EditCitationForm contributors', () => {
+  // Regression: Add Person / Add Organization wrote to the global store instead
+  // of the form's local state. The form renders contributors from local state,
+  // so the new row never appeared — clicking the buttons looked like a no-op.
+  const clickButton = (container: HTMLElement, label: string) => {
+    const btn = Array.from(container.querySelectorAll('button')).find(
+      (b) => b.textContent?.includes(label),
+    ) as HTMLButtonElement | undefined;
+    expect(btn).toBeTruthy();
+    fireEvent.click(btn!);
+  };
+
+  it('Add Person adds a contributor row rendered from the form local state', () => {
+    const source: StoredSource = { uuid: 'u1', csl: { id: 'u1', type: 'webpage', title: 'T' } };
+    const { container } = render(<EditCitationForm source={source} setSources={() => {}} />);
+    expect(container.querySelectorAll('details').length).toBe(0);
+    clickButton(container, 'Add Person');
+    expect(container.querySelectorAll('details').length).toBe(1);
+  });
+
+  it('Add Organization adds a contributor row', () => {
+    const source: StoredSource = { uuid: 'u1', csl: { id: 'u1', type: 'webpage' } };
+    const { container } = render(<EditCitationForm source={source} setSources={() => {}} />);
+    clickButton(container, 'Add Organization');
+    expect(container.querySelectorAll('details').length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes the **Add Person** / **Add Organization** buttons in the edit-citation dialog — they did nothing when clicked (while "Set to Today" worked).

## Root cause

`Contributors` wrote new/edited authors to the **global** sources store (`setSources`), but `EditCitationForm` renders contributors from its **local** CSL state (`local`, seeded once via `useState`). So clicks updated the store but never the form's displayed list — and the form's debounced flush later overwrote the change with stale `local`. Every other field (Title, dates, "Set to Today") works because it routes through the form's `patch()` → `setLocal` → re-render.

## Fix

Route contributor add/edit/delete through `patch()`/local like every other field: `Contributors` now takes `authors` + `onChange`, and the form wires `onChange={(next) => patch({ author: next })}`. New rows appear immediately and persist via the existing debounce (which also flushes on unmount, so an added author survives an immediate dialog close).

## Tests

`npm test` → **374 pass**. Adds a form-level regression test: render the form, click Add Person / Add Organization, assert a contributor row appears.
