### PR TITLE
Front-end reliability + UI bug fixes (React/Vercel audit)

### DIFF
--- a/src/components/astro/BaseHead.astro
+++ b/src/components/astro/BaseHead.astro
@@ -56,10 +56,10 @@ const allSchemas = [...baseSchemas, ...extraSchemas];
 <meta name="googlebot" content="index, follow, max-image-preview:large, max-snippet:-1" />
 
 <meta property="og:type" content={pageType} />
-<meta property="og:url" content={Astro.url} />
+<meta property="og:url" content={canonicalURL} />
 <meta property="og:title" content={title} />
 <meta property="og:description" content={description} />
-<meta property="og:image" content={new URL(image, Astro.url)} />
+<meta property="og:image" content={new URL(image, Astro.site)} />
 <meta property="og:locale" content="en_US" />
 <meta property="og:site_name" content="MLA Generator" />
 
@@ -74,10 +74,10 @@ const allSchemas = [...baseSchemas, ...extraSchemas];
 )}
 
 <meta property="twitter:card" content="summary_large_image" />
-<meta property="twitter:url" content={Astro.url} />
+<meta property="twitter:url" content={canonicalURL} />
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
-<meta property="twitter:image" content={new URL(image, Astro.url)} />
+<meta property="twitter:image" content={new URL(image, Astro.site)} />
 
 <link rel="sitemap" href="/sitemap-index.xml" />
 

--- a/src/components/react/Dropdown.tsx
+++ b/src/components/react/Dropdown.tsx
@@ -24,16 +24,26 @@ export default function Dropdown({ options, className, value, onChange }: Dropdo
     const defaultOption = value || options.find(option => option.default) || options[0];
 
     const [open, setOpen] = useState(false);
-    const [matchingOptions, setMatchingOptions] = useState(options);
+    const [searchText, setSearchText] = useState('');
     const [selectedOption, setSelectedOption] = useState(defaultOption);
 
     useEffect(() => {
         setSelectedOption(defaultOption);
     }, [defaultOption]);
 
+    // Filtered + alphabetized list derived during render (no shadow state to go
+    // stale across opens). Falls back to all options when a search matches none.
+    // `.slice()` before sort so we never mutate the shared `options` array.
+    const q = searchText.trim().toLowerCase();
+    const filtered = q ? options.filter((o) => o.label.toLowerCase().includes(q)) : options;
+    const visibleOptions = (filtered.length > 0 ? filtered : options)
+        .slice()
+        .sort((a, b) => a.label.localeCompare(b.label));
+
     // Handle opening/closing dropdown
     const handleOpen = (event: any) => {
         if (event.target.closest(`.${styles.dropdownBtn}`)) {
+            if (!open) setSearchText(''); // start each open with a clean, unfiltered list
             setOpen(!open);
         }
     }
@@ -42,15 +52,6 @@ export default function Dropdown({ options, className, value, onChange }: Dropdo
     const handleClickOutside = (event: any) => {
         if (event.target.closest(`.${styles.dropdown}`)) return;
         setOpen(false);
-    }
-
-    // Handle search filtering
-    const handleSearch = (event: any) => {
-        const searchValue = event.target.value.toLowerCase();
-        const matching = options.filter((option) =>
-            option.label.toLowerCase().includes(searchValue)
-        );
-        setMatchingOptions(matching.length > 0 ? matching : options);
     }
 
     // Handle option selection
@@ -103,14 +104,11 @@ export default function Dropdown({ options, className, value, onChange }: Dropdo
             </button>
             <div className={styles.dropdownList}>
                 <div className={styles.dropdownSearch}>
-                    <input type="text" placeholder="Search" onChange={handleSearch} />
+                    <input type="text" placeholder="Search" value={searchText} onChange={(e) => setSearchText(e.target.value)} />
                 </div>
                 <ul>
-                    {matchingOptions
-                    // sort alphabetically
-                    .sort((a, b) => a.label.localeCompare(b.label))
-                    .map((option, index) => (
-                        <li key={index}>
+                    {visibleOptions.map((option) => (
+                        <li key={option.value}>
                             <button
                                 type="button"
                                 className={clsx(styles.dropdownOption, option.label === selectedOption.label && styles.selected)}

--- a/src/components/react/EditCitationFormComponents.tsx
+++ b/src/components/react/EditCitationFormComponents.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Input } from "./Input";
 import { cn } from "./utils";
 import { Button } from "./Button";
@@ -55,7 +55,23 @@ const isPerson = (n: CSLName): n is Exclude<CSLName, { literal: string }> => !('
  * Contributors component — operates on CSL-JSON `author` arrays.
  */
 export const Contributors = ({ authors, onChange }: ContributorsProps) => {
-    const [lastOpenedIdx, setLastOpenedIdx] = useState<number | null>(null);
+    // Stable per-row ids kept parallel to `authors`, used as React keys and to
+    // track the expanded row. Index keys + an uncontrolled <details> meant that
+    // deleting a middle contributor left the wrong row expanded showing another
+    // person's data; stable keys fix that. Ids never enter the saved CSL.
+    const idCounter = useRef(0);
+    const [ids, setIds] = useState<string[]>(() => authors.map(() => `c${idCounter.current++}`));
+    const [openId, setOpenId] = useState<string | null>(null);
+
+    // Best-effort length-sync if `authors` changes from outside the mutators below.
+    useEffect(() => {
+        setIds((prev) => {
+            if (prev.length === authors.length) return prev;
+            const next = prev.slice(0, authors.length);
+            while (next.length < authors.length) next.push(`c${idCounter.current++}`);
+            return next;
+        });
+    }, [authors.length]);
 
     const previewName = (n: CSLName) => {
         if (isPerson(n)) {
@@ -69,18 +85,25 @@ export const Contributors = ({ authors, onChange }: ContributorsProps) => {
     };
 
     const handleAddPerson = () => {
-        const next = [...authors, { family: '', given: '' } as CSLName];
-        onChange(next);
-        setLastOpenedIdx(next.length - 1);
+        const id = `c${idCounter.current++}`;
+        onChange([...authors, { family: '', given: '' } as CSLName]);
+        setIds((prev) => [...prev, id]);
+        setOpenId(id);
     };
 
     const handleAddOrganization = () => {
-        const next = [...authors, { literal: '' } as CSLName];
-        onChange(next);
-        setLastOpenedIdx(next.length - 1);
+        const id = `c${idCounter.current++}`;
+        onChange([...authors, { literal: '' } as CSLName]);
+        setIds((prev) => [...prev, id]);
+        setOpenId(id);
     };
 
-    const handleDelete = (idx: number) => onChange(authors.filter((_, i) => i !== idx));
+    const handleDelete = (idx: number) => {
+        const removed = ids[idx];
+        onChange(authors.filter((_, i) => i !== idx));
+        setIds((prev) => prev.filter((_, i) => i !== idx));
+        if (openId === removed) setOpenId(null);
+    };
 
     return (
         <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:gap-4">
@@ -90,7 +113,7 @@ export const Contributors = ({ authors, onChange }: ContributorsProps) => {
             </span>
             <div className="flex flex-col gap-4">
                 {authors.map((author, idx) => (
-                    <details key={idx} className="border border-border rounded-md shadow-sm [&[open]_summary_[data-chevron]]:rotate-180" open={idx === lastOpenedIdx}>
+                    <details key={ids[idx] ?? `i${idx}`} className="border border-border rounded-md shadow-sm [&[open]_summary_[data-chevron]]:rotate-180" open={openId === (ids[idx] ?? `i${idx}`)} onToggle={(e) => { const id = ids[idx] ?? `i${idx}`; if (e.currentTarget.open) setOpenId(id); else if (openId === id) setOpenId(null); }}>
                         <summary className="pl-3 cursor-pointer w-full h-9 flex justify-between items-center">
                             <span className="leading-none">{previewName(author)}</span>
                             <div className="flex gap-2 items-center">

--- a/src/components/react/ReferenceItem.tsx
+++ b/src/components/react/ReferenceItem.tsx
@@ -61,7 +61,7 @@ function ReferenceItem({ source, checked, onToggle, citationFormat, setSources, 
                     className={styles.checkboxElement}
                     checked={checked}
                     onChange={(e) => onToggle(source.uuid, e.target.checked)}
-                    aria-label="Select this reference"
+                    aria-label={`Select reference: ${source.csl.title || 'untitled'}`}
                 />
                 <div className={styles.checkbox} aria-hidden="true"></div>
                 <div className={styles.citationSourceWrapper}>

--- a/src/components/react/References.tsx
+++ b/src/components/react/References.tsx
@@ -35,6 +35,14 @@ export default function References() {
     const citationFormatRef = useRef<HTMLInputElement>(null);
     const selectAllRef = useRef<HTMLInputElement>(null);
 
+    // Mirror the active style into the hidden search-form input so re-citing from
+    // this page submits the right citationStyle. Covers the ?citationStyle=… URL-
+    // seeded path, where the dropdown onChange never fired and the input stayed
+    // empty (the form then silently reverted the next page to MLA).
+    useEffect(() => {
+        if (citationFormatRef.current) citationFormatRef.current.value = citationFormat;
+    }, [citationFormat]);
+
     // `indeterminate` has no React prop; sync it imperatively when selection changes.
     useEffect(() => {
         if (selectAllRef.current) {

--- a/src/lib/citations/useFormattedCitation.ts
+++ b/src/lib/citations/useFormattedCitation.ts
@@ -80,15 +80,27 @@ export function useFormattedCitation(source: Args, style: SupportedStyle): State
 // Cache-aware fetch used by the hook and exported for callers (e.g. Copy
 // Selected) that need the same memoization but outside the React tree.
 async function fetchFormatted(csl: CSLItem, style: SupportedStyle, key: string): Promise<RichText[]> {
-  const res = await fetch('/api/format', {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ csl, style }),
-  });
-  if (!res.ok) throw new Error(`Format failed: HTTP ${res.status}`);
-  const body = await res.json() as { formatted: RichText[] };
-  cache.set(key, body.formatted);
-  return body.formatted;
+  // Bound the request so a slow/hung /api/format can't leave rows stuck on
+  // "Loading…" forever. The timeout is owned here (on the shared request) and
+  // flows into the hook's existing .catch → error state; we deliberately do NOT
+  // abort from a per-row effect cleanup, which would reject the shared promise
+  // for sibling rows and Copy-Selected.
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 15_000);
+  try {
+    const res = await fetch('/api/format', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ csl, style }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`Format failed: HTTP ${res.status}`);
+    const body = await res.json() as { formatted: RichText[] };
+    cache.set(key, body.formatted);
+    return body.formatted;
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export function formatCitation(source: Args, style: SupportedStyle): Promise<RichText[]> {

--- a/src/lib/references/useReferences.ts
+++ b/src/lib/references/useReferences.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
-import { loadSources, saveSources, type StoredSource } from './storage';
+import { loadSources, saveSources, STORAGE_KEY, type StoredSource } from './storage';
 import type { CSLItem, SupportedStyle } from '../citations/csl-types';
 
 export interface UseReferencesReturn {
@@ -106,6 +106,17 @@ export function useReferences(): UseReferencesReturn {
       .finally(() => clearTimeout(timeout));
     return () => { cancelled = true; controller.abort(); clearTimeout(timeout); };
   }, [setSources]);
+
+  // Reload when another tab writes our localStorage key so two open tabs don't
+  // clobber each other's references on the next save. The `storage` event fires
+  // only in OTHER tabs, so this never loops with the writing tab.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setSourcesState(loadSources());
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
 
   // Prune stale uuids when sources change (e.g. deletions outside handleDelete).
   useEffect(() => {

--- a/tests/client/Dropdown.test.tsx
+++ b/tests/client/Dropdown.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, fireEvent } from '@testing-library/react';
+import React from 'react';
+import Dropdown from '../../src/components/react/Dropdown';
+
+const OPTIONS = [
+  { label: 'APA 7th edition', value: 'apa-7' },
+  { label: 'MLA 9th edition', value: 'mla-9', default: true },
+  { label: 'Chicago 18th edition', value: 'chicago-18' },
+];
+
+beforeEach(() => {
+  if (!(window as any).matchMedia) {
+    (window as any).matchMedia = (q: string) => ({
+      matches: false, media: q, onchange: null,
+      addListener: () => {}, removeListener: () => {},
+      addEventListener: () => {}, removeEventListener: () => {}, dispatchEvent: () => false,
+    });
+  }
+});
+
+describe('Dropdown search filter', () => {
+  it('resets the filter and clears the search box each time it opens', () => {
+    const { container } = render(<Dropdown options={OPTIONS} className="" />);
+    const openBtn = container.querySelector('button') as HTMLButtonElement; // the trigger
+    const search = () => container.querySelector('input[type="text"]') as HTMLInputElement;
+    const optionCount = () => container.querySelectorAll('ul li').length;
+
+    fireEvent.click(openBtn);
+    expect(optionCount()).toBe(3);
+    fireEvent.change(search(), { target: { value: 'apa' } });
+    expect(optionCount()).toBe(1);
+
+    // Close, then reopen — the filter must reset (regression: it used to persist).
+    fireEvent.click(openBtn);
+    fireEvent.click(openBtn);
+    expect(search().value).toBe('');
+    expect(optionCount()).toBe(3);
+  });
+
+  it('does not mutate the shared options array when sorting alphabetically', () => {
+    const before = OPTIONS.map((o) => o.value).join(',');
+    render(<Dropdown options={OPTIONS} className="" />);
+    expect(OPTIONS.map((o) => o.value).join(',')).toBe(before);
+  });
+});

--- a/tests/client/EditCitationForm.test.tsx
+++ b/tests/client/EditCitationForm.test.tsx
@@ -78,4 +78,22 @@ describe('EditCitationForm contributors', () => {
     clickButton(container, 'Add Organization');
     expect(container.querySelectorAll('details').length).toBe(1);
   });
+
+  it('deleting a contributor removes its row and keeps the rest (stable keys)', () => {
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: { id: 'u1', type: 'webpage', author: [{ family: 'Alpha', given: '' }, { family: 'Beta', given: '' }] },
+    };
+    const { container } = render(<EditCitationForm source={source} setSources={() => {}} />);
+    expect(container.querySelectorAll('details').length).toBe(2);
+    // Trash button lives in the first row's <summary>.
+    const firstRow = container.querySelector('details')!;
+    const trash = firstRow.querySelector('summary button') as HTMLButtonElement;
+    fireEvent.click(trash);
+    const rows = container.querySelectorAll('details');
+    expect(rows.length).toBe(1);
+    // The surviving row is Beta, not Alpha (correct identity mapping after delete).
+    expect(rows[0].textContent).toContain('Beta');
+    expect(rows[0].textContent).not.toContain('Alpha');
+  });
 });

--- a/tests/client/References.test.tsx
+++ b/tests/client/References.test.tsx
@@ -33,7 +33,7 @@ beforeEach(() => {
 describe('References selection label', () => {
   it('shows the SELECTED count, not the total, when references are selected', async () => {
     const { container } = render(<References />);
-    const sel = 'input[type="checkbox"][aria-label="Select this reference"]';
+    const sel = 'input[type="checkbox"][aria-label^="Select reference"]';
     // Both stored sources load from localStorage.
     await waitFor(() => expect(container.querySelectorAll(sel).length).toBe(2));
     const boxes = container.querySelectorAll(sel);


### PR DESCRIPTION
## Summary

Front-end reliability + UI-bug fixes from a multi-agent review (4 reviewers applying the Vercel React Best Practices guide + UI-bug hunting, with adversarial verification of every bug finding). Only the **verified, low-risk** findings are applied here; riskier/low-value ones are deferred (see below).

## Bugs fixed

- **Re-citing reverted to MLA** (`References.tsx`): the active style was kept in React state + the dropdown, but the hidden search-form input was only written by the dropdown's `onChange`. On the `?citationStyle=…` URL-seeded path the input stayed empty, so submitting the search form sent an empty style and the next page fell back to MLA. Now an effect mirrors the active style into the input.
- **Dropdown stayed filtered across opens** (`Dropdown.tsx`): the search filter/text were never reset, so after one search+select, reopening showed only the previously-filtered results. Now the list is derived during render and the search resets on each open.
- **Contributor accordion showed the wrong row after delete** (`EditCitationFormComponents.tsx`): index keys + an uncontrolled `<details>` meant deleting a middle contributor left the wrong row expanded with another person's data/tab. Now each row has a stable id used as its key and to track the open row.
- **Rows could hang on "Loading…"** (`useFormattedCitation.ts`): `/api/format` had no timeout. Added a 15s timeout on the shared request that surfaces the existing error state. (Deliberately not a per-row abort, which would break sibling rows + Copy-Selected.)
- **Two tabs clobbered each other's references** (`useReferences.ts`): added a `storage`-event listener so a tab reloads when another writes the references key.
- **Non-canonical social URLs** (`BaseHead.astro`): `og:url`/`twitter:url` + the social image used the live request URL, leaking `*.pages.dev` preview hosts and query strings. Pinned to the canonical site origin (also an SEO win).

## Minor / quality

- `Dropdown` no longer mutates the shared `citationStyles` module array via an in-render `.sort()`.
- `ReferenceItem` checkbox `aria-label` now names the citation (screen-reader list navigability).

## Deferred (documented, not applied)

- Async Clipboard API rewrite (converts sync handlers to async; `execCommand` still works in all current browsers — low practical impact).
- Format-cache in-session invalidation (a known/accepted tradeoff, like the 24h extract cache).
- `client:idle` on the hero generator (it's the primary control; immediate interactivity is preferable).
- Removing the AdSense loader (a monetization decision — flagged separately, not changed here).
- Dropdown/`SimpleDropdown` full combobox keyboard a11y (`aria-expanded`/Escape/arrow-keys) — worth a focused follow-up.

## Testing

`npm test` → full suite green. Added regression tests: contributor delete (stable keys), Dropdown filter-reset + no-mutation. `npm run build` verified the Astro change compiles.
