### PR TITLE
SEO: optimize internal link structure and site hierarchy

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -47,14 +47,26 @@ export default defineConfig({
             serialize(item) {
                 const pathname = new URL(item.url).pathname.replace(/\/$/, '') || '/';
                 if (pathname.startsWith('/admin')) return undefined;
+                // Tier priority to match the link-graph emphasis: the generator,
+                // the guides hub, and the seven cornerstone style guides outrank
+                // the long-tail how-to/concept guides (was a flat 0.9 for all guides
+                // with the hub below its own children).
+                const STYLE_GUIDES = ['apa', 'mla', 'chicago', 'harvard', 'vancouver', 'ieee', 'ama']
+                    .map((s) => `/guides/${s}`);
                 if (pathname === '/') {
                     item.priority = 1.0;
                     item.changefreq = 'weekly';
-                } else if (pathname.startsWith('/guides/')) {
+                } else if (pathname === '/guides') {
+                    item.priority = 0.9;
+                    item.changefreq = 'weekly';
+                } else if (STYLE_GUIDES.includes(pathname)) {
                     item.priority = 0.9;
                     item.changefreq = 'monthly';
-                } else if (pathname === '/guides' || pathname === '/about') {
-                    item.priority = 0.7;
+                } else if (pathname.startsWith('/guides/')) {
+                    item.priority = 0.8;
+                    item.changefreq = 'monthly';
+                } else if (pathname === '/about') {
+                    item.priority = 0.6;
                     item.changefreq = 'monthly';
                 } else {
                     item.priority = 0.5;

--- a/src/components/astro/Footer.astro
+++ b/src/components/astro/Footer.astro
@@ -31,9 +31,24 @@ import Logo from '../../../public/images/logo.svg';
                 <li><a href={`${site}guides/mla`}>MLA Format</a></li>
                 <li><a href={`${site}guides/chicago`}>Chicago Format</a></li>
                 <li><a href={`${site}guides/harvard`}>Harvard Format</a></li>
+                <li><a href={`${site}guides/vancouver`}>Vancouver Format</a></li>
+                <li><a href={`${site}guides/ieee`}>IEEE Format</a></li>
+                <li><a href={`${site}guides/ama`}>AMA Format</a></li>
             </ul>
             <ul>
+                <li><a href={`${site}guides/how-to-cite-a-website`}>Cite a Website</a></li>
+                <li><a href={`${site}guides/how-to-cite-a-book`}>Cite a Book</a></li>
+                <li><a href={`${site}guides/how-to-cite-a-journal-article`}>Cite a Journal Article</a></li>
+                <li><a href={`${site}guides/how-to-cite-a-pdf`}>Cite a PDF</a></li>
+            </ul>
+            <ul>
+                <li><a href={`${site}guides`}>All Guides</a></li>
                 <li><a href={`${site}guides/research-and-works-cited`}>Mastering Your Sources</a></li>
+                <li><a href={`${site}guides/in-text-citations`}>In-Text Citations</a></li>
+                <li><a href={`${site}guides/when-to-use-each-style`}>Which Style to Use</a></li>
+                <li><a href={`${site}guides/avoiding-plagiarism`}>Avoiding Plagiarism</a></li>
+                <li><a href={`${site}guides/citation-generator-faq`}>FAQ</a></li>
+                <li><a href={`${site}guides/whats-new`}>What's New</a></li>
             </ul>
         </div>
     </nav>

--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -1,10 +1,17 @@
 ---
 import Layout from "../../layouts/page.astro";
+import Breadcrumbs from "../../components/astro/Breadcrumbs.astro";
+import { buildBreadcrumbList } from "../../lib/schema-org";
 import { getCollection } from "astro:content";
 
 const title = "Citation Guides — APA, MLA, Chicago, Harvard, Vancouver, IEEE, AMA";
 const description =
     "In-depth citation guides for APA, MLA, Chicago, Harvard, Vancouver, IEEE, and AMA — plus how-to guides for citing websites, books, journal articles, and more.";
+
+const breadcrumbSchema = buildBreadcrumbList([
+    { name: 'Home', url: new URL('/', Astro.site).href },
+    { name: 'Guides', url: new URL('/guides', Astro.site).href },
+]);
 
 const all = await getCollection("guides");
 const sortByTitle = (a: typeof all[number], b: typeof all[number]) =>
@@ -24,14 +31,16 @@ const grouped = categories.map((cat) => ({
 }));
 ---
 
-<Layout title={title} description={description}>
+<Layout title={title} description={description} extraSchemas={[breadcrumbSchema]}>
     <article class="guides-hub">
+        <Breadcrumbs items={[{ name: 'Home', href: '/' }, { name: 'Guides', href: '/guides', current: true }]} />
         <header>
             <h1>Citation Guides</h1>
             <p class="lede">
                 Authoritative guides covering every supported style — written
                 and reviewed by the MLA Generator Editorial Team against the
-                current editions of their respective style manuals.
+                current editions of their respective style manuals. Or jump
+                straight to the <a href="/">citation generator</a>.
             </p>
         </header>
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -198,27 +198,33 @@ const extraSchemas = [buildSoftwareApplication()];
 
                 <ul>
                     <li>
-                        MLA (Modern Language Association): Widely used in the
-                        humanities, particularly in literature, language, and
-                        cultural studies.
+                        <a href="/guides/mla">MLA (Modern Language Association)</a>:
+                        Widely used in the humanities, particularly in
+                        literature, language, and cultural studies.
                     </li>
                     <li>
-                        APA (American Psychological Association): Common in
-                        social sciences, education, and psychology.
+                        <a href="/guides/apa">APA (American Psychological Association)</a>:
+                        Common in social sciences, education, and psychology.
                     </li>
                     <li>
-                        Chicago/Turabian: Used in history, art history, and
-                        other disciplines.
+                        <a href="/guides/chicago">Chicago/Turabian</a>: Used in
+                        history, art history, and other disciplines.
                     </li>
                     <li>
-                        IEEE: Often used in engineering and computer science.
+                        <a href="/guides/ieee">IEEE</a>: Often used in
+                        engineering and computer science.
                     </li>
                     <li>
-                        Harvard: A commonly used style across multiple
-                        disciplines.
+                        <a href="/guides/harvard">Harvard</a>: A commonly used
+                        style across multiple disciplines.
                     </li>
                     <li>
-                        Vancouver: Often used in medical and scientific fields.
+                        <a href="/guides/vancouver">Vancouver</a>: Often used in
+                        medical and scientific fields.
+                    </li>
+                    <li>
+                        <a href="/guides/ama">AMA (American Medical Association)</a>:
+                        Used in medicine and the health sciences.
                     </li>
                 </ul>
 


### PR DESCRIPTION
## Summary

Internal link-structure + hierarchy improvements from the SEO audit (a link-structure agent + a technical/on-page agent). This PR ships the **high-impact, low-risk, contained** structural wins; deeper content work is listed as follow-ups.

## Changes

- **Homepage → spokes** (`index.astro`): the "Popular Citation Styles" list was plain text. Each of the 7 styles now links to its guide (`/guides/<style>`), and AMA is added. The strongest page on the domain now passes equity into the guide cluster.
- **Footer** (`Footer.astro`): expanded the Guides nav from 5 links to three columns — all 7 styles, the how-to cluster (website/book/journal-article/PDF), and the previously **orphaned** guides (FAQ, What's New, Which Style to Use, Avoiding Plagiarism) — giving them a sitewide inbound link.
- **`/guides` hub** (`guides/index.astro`): added breadcrumbs (visible `Breadcrumbs` + `BreadcrumbList` JSON-LD via `extraSchemas`) and a link back to the generator. The hub previously had no Home crumb and no up-link to the tool.
- **Sitemap** (`astro.config.mjs`): tiered priorities — generator `1.0`, hub + 7 style guides `0.9`, other guides `0.8`, about `0.6` — instead of a flat `0.9` for all guides with the hub *below* its own children.

## Deferred follow-ups (reported, not in this PR)

The audit surfaced larger content/structure work worth a dedicated pass:
- **Inline contextual links inside the 7 style guides** (they currently have zero in-body cross-links — the single biggest remaining win; converts link "sinks" into hubs). Content-only MDX editing.
- `relatedGuides` rebalancing for under-linked long-tail guides.
- Sitemap `<lastmod>` from guide `pubDate`/`updatedDate` (needs the collection read out of `serialize`).
- `privacy.astro` / `terms.astro` routed through the shared `Layout` (they hand-roll `<head>`, have no canonical/nav).
- Homepage `FAQPage` JSON-LD; connected schema `@graph` with `@id` + `SearchAction`; per-guide OG images; category-tier breadcrumbs / category hub pages; H3 anchor links.

## Testing

`npm run build` succeeds (sitemap regenerated with tiered priorities). No test-covered code changed.
