### PR TITLE
Remove Google AdSense

### DIFF
--- a/src/components/astro/BaseHead.astro
+++ b/src/components/astro/BaseHead.astro
@@ -87,10 +87,3 @@ const allSchemas = [...baseSchemas, ...extraSchemas];
     defer
     src="https://static.cloudflareinsights.com/beacon.min.js"
     data-cf-beacon='{"token": "be4d6ced89604b3ba9e8c5137b6bc781"}'></script>
-
-<script
-    async
-    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3675571854758381"
-    crossorigin="anonymous"></script>
-
-<meta name="google-adsense-account" content="ca-pub-3675571854758381" />

--- a/src/content/guides/citation-generator-faq.mdx
+++ b/src/content/guides/citation-generator-faq.mdx
@@ -73,7 +73,7 @@ What the feature does not do: sync across devices, back up to a server, export t
 
 ## Privacy
 
-There is no account, no email signup, and no server-side storage of your reference list — references live in your browser's local storage. Standard web logging (IP address, browser type, referring URL) and ad-network cookies from Google AdSense apply across the site like any other ad-supported web property. The full details — what is collected, how long it is retained, and your rights — are documented on the [privacy page](/privacy).
+There is no account, no email signup, and no server-side storage of your reference list — references live in your browser's local storage. Standard web logging (IP address, browser type, referring URL) applies, and we use privacy-friendly, cookieless Cloudflare analytics; the site does not currently serve ads or use advertising cookies. The full details — what is collected, how long it is retained, and your rights — are documented on the [privacy page](/privacy).
 
 ## Browser and device support
 

--- a/src/content/guides/citation-generator-faq.mdx
+++ b/src/content/guides/citation-generator-faq.mdx
@@ -16,7 +16,7 @@ faq:
   - question: 'Can I save my citations?'
     answer: 'Yes. The [My References](/my-references) page stores every citation you generate, so you can come back to them later without re-entering the source data. References are saved locally in your browser — there is no account and no server-side storage of your reference list. If you switch browsers or clear your browser data, you will need to regenerate the references; an export feature is on the roadmap.'
   - question: 'Is the generator free? Do I need to sign up?'
-    answer: 'Yes, free. No account, no sign-up, no paywall. The site runs on minimal ad revenue, which is why ads appear on the citation-output pages. Premium features that other citation tools paywall — multiple styles, full source-type coverage, saved references — are free here because the underlying CSL project is open source and accuracy does not need to be locked behind a subscription.'
+    answer: 'Yes, free. No account, no sign-up, no paywall. Premium features that other citation tools paywall — multiple styles, full source-type coverage, saved references — are free here because the underlying CSL project is open source and accuracy does not need to be locked behind a subscription.'
 ogImage: '/images/banner.png'
 ---
 

--- a/src/content/index/advantages.ts
+++ b/src/content/index/advantages.ts
@@ -35,8 +35,8 @@ const advantages = [
     },
     {
         icon: NoSymbolIcon,
-        text: "Reduced and reasonable number of ads to ensure a smooth experience",
-        heading: "Minimal ads",
+        text: "A clean, distraction-free interface with no ads or invasive trackers",
+        heading: "No ads or clutter",
     },
 ];
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -31,22 +31,6 @@ const extraSchemas = [buildSoftwareApplication(), buildFaqPage(faqs)];
         </div>
         <CitationSearch includeDropdown includeManualCite client:load />
     </section>
-    <!-- <div class="ad-container">
-        <script
-            async
-            src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-3675571854758381"
-            crossorigin="anonymous"></script>
-        <ins
-            class="adsbygoogle"
-            style="display:block"
-            data-ad-client="ca-pub-3675571854758381"
-            data-ad-slot="9255203790"
-            data-ad-format="auto"
-            data-full-width-responsive="true"></ins>
-        <script>
-            (adsbygoogle = window.adsbygoogle || []).push({});
-        </script>
-    </div> -->
     <PageSegment title="MLA Citation Generator Features" background>
         <div class="advantage-card-container">
             {
@@ -596,45 +580,4 @@ text-decoration-thickness: 2px;
         border-radius: 14px;
         /* width: min-content; */
     }
-
-    .ad-container {
-        background-color: var(--color-background-2);
-        border-radius: 30px;
-        width: min-content;
-        margin: 4rem auto 0;
-        padding: 1.5rem;
-
-        overflow: hidden;
-        max-width: 100%;
-        width: min(50vw, 600px);
-        min-height: 100px;
-
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-    }
-    .ad {
-        width: 970px;
-        height: 250px;
-        background: url("https://via.placeholder.com/970x250") no-repeat center
-            center;
-    }
-    @media (max-width: 1000px) {
-        .ad-container {
-            margin: 4rem 1.5rem 0;
-            width: auto;
-        }
-        .ad {
-            width: 100%;
-        }
-    }
-    /* .ad-container::after {
-        content: "Advertisement";
-        line-height: 1;
-        color: var(--color-text-light);
-        margin-top: 9px;
-        display: block;
-        font-size: 15px;
-        text-align: center;
-    } */
 </style>

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -44,26 +44,24 @@ const description =
             reporting purposes.
         </p>
 
-        <h3>b. Data Collected by Third-Party Vendors</h3>
+        <h3>b. Analytics</h3>
         <p>
-            We use third-party vendors, including Google, to serve ads on our
-            Website. These vendors may use cookies (small text files placed on
-            your device) and similar tracking technologies (like web beacons) to
-            collect information about your activity on our Website and other
-            websites in order to provide you with targeted advertising based on
-            your interests.
+            We use privacy-friendly analytics provided by Cloudflare to
+            understand aggregate usage of the Website (for example, which pages
+            are visited and from which countries). This analytics is
+            cookieless and is not used to identify individual visitors.
         </p>
+
+        <h3>c. Advertising</h3>
         <p>
-            <b>Google Ads:</b> We use Google AdSense to display ads on our Website.
-            Google, as a third-party vendor, uses cookies to serve ads on our site.
-            Google's use of advertising cookies enables it and its partners to serve
-            ads to our users based on their visit to our site and/or other sites
-            on the Internet. Users may opt out of personalized advertising by visiting
-            <a href="https://adssettings.google.com/">Google's Ads Settings</a>.
-            You can learn more about how Google uses information from sites or
-            apps that use its services by reviewing Google's Privacy Policy at <a
-                href="https://policies.google.com/technologies/partner-sites"
-                >https://policies.google.com/technologies/partner-sites</a>
+            We do not currently display third-party advertising on the Website,
+            and we do not use advertising cookies. If we introduce advertising
+            in the future, we will update this Privacy Policy to describe the
+            vendors involved (such as Google AdSense), the data they collect,
+            and the choices available to you, including how to opt out of
+            personalized advertising through <a
+                href="https://adssettings.google.com/">Google's Ads Settings</a
+            >.
         </p>
 
         <h2>2. How We Use Your Information</h2>
@@ -79,10 +77,6 @@ const description =
             <li>
                 To monitor and analyze usage and trends to improve your
                 experience with the Website.
-            </li>
-            <li>
-                To enable third-party vendors, including Google, to serve ads
-                based on your prior visits to our Website or other websites.
             </li>
             <li>To respond to legal requests and prevent harm.</li>
         </ul>
@@ -102,8 +96,7 @@ const description =
                 advertising, analytics, data analysis, hosting services, and customer
                 service. These companies may have access to your usage data as necessary
                 to perform their functions but are not permitted to share or use
-                such information for any other purpose. As noted above, this includes
-                our use of Google AdSense to serve ads on our site.
+                such information for any other purpose.
             </li>
             <li>
                 <strong>Legal Requirements:</strong> We may disclose your information

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -10,7 +10,7 @@ const description =
     <article class="legal">
         <h1>Privacy Policy</h1>
 
-        <p><strong>Last Updated:</strong> January 18, 2025</p>
+        <p><strong>Last Updated:</strong> May 31, 2026</p>
 
         <p>
             MLA Generator ("we," "us," or "our") is committed to protecting your


### PR DESCRIPTION
## What

Removes Google AdSense from the site. The site currently serves **no** ads ("not yet"), so this also corrects copy that falsely claimed otherwise.

### Changes
- **`BaseHead.astro`** — removed the `adsbygoogle.js` loader `<script>` and the `google-adsense-account` meta. Cloudflare Insights beacon is preserved.
- **`index.astro`** — removed the commented-out AdSense `<ins>` block and the now-dead `.ad-container` / `.ad` CSS (incl. a `via.placeholder.com` reference).
- **`privacy.astro`** — split the advertising section into accurate **Analytics** (cookieless Cloudflare) + **Advertising** ("we do not currently display third-party advertising"; forward-looking language for if ads return). Removed present-tense "we use Google AdSense to display ads" assertions + the ad-vendor bullet/disclosure sentence. Bumped Last Updated.
- **`advantages.ts`** — the homepage "Minimal ads" feature card → truthful "No ads or clutter".
- **`citation-generator-faq.mdx`** — removed two ad claims (the "ad-network cookies" line and the "site runs on minimal ad revenue, which is why ads appear" line — the latter also fed the FAQPage structured data).

## Verification
- `npm test` → 377/377 pass.
- `npm run build` → clean; `dist/` grep confirms **zero** `adsbygoogle`/`pagead`/`googlesyndication`/`ca-pub` references.
- Pre-merge fresh-context correctness review run before opening this PR. It surfaced two leftover present-tense ad claims (the homepage feature card and the FAQ structured-data answer), both fixed in commit 2 of this PR.

## Non-blocking notes
- **`public/ads.txt` is intentionally retained** so advertising can be re-enabled later without reconfiguration. It's inert without the loader.
- Privacy §4 "Cookies" still uses conditional "may use" language (forward-looking); left as-is.
