### PR TITLE
Connect JSON-LD into a single @graph; add per-guide sitemap lastmod

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -25,8 +25,10 @@ const GUIDE_LASTMOD = (() => {
             const date = updated || published;
             if (date) map[`/guides/${file.replace(/\.mdx$/, '')}`] = new Date(`${date}T00:00:00.000Z`).toISOString();
         }
-    } catch {
-        // If the content dir can't be read, fall back to no lastmod rather than failing the build.
+    } catch (err) {
+        // Fall back to no lastmod rather than failing the build, but make the
+        // degradation visible so a future read failure isn't silent.
+        console.warn('[sitemap] could not read guide frontmatter for <lastmod>; sitemap will omit lastmod values.', err);
     }
     return map;
 })();

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,32 @@ import sitemap from '@astrojs/sitemap';
 import compress from "astro-compress";
 import react from '@astrojs/react';
 import mdx from '@astrojs/mdx';
+import { readFileSync, readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+// Build a map of /guides/<slug> -> last-significant-change date, read straight
+// from each guide's frontmatter (updatedDate, else pubDate). This feeds honest
+// per-guide <lastmod> values into the sitemap. Pages without a real change date
+// (the generator, legal pages) intentionally get no lastmod rather than a faked
+// build-time one.
+const GUIDE_LASTMOD = (() => {
+    const map = {};
+    try {
+        const dir = join(dirname(fileURLToPath(import.meta.url)), 'src/content/guides');
+        for (const file of readdirSync(dir)) {
+            if (!file.endsWith('.mdx')) continue;
+            const src = readFileSync(join(dir, file), 'utf8');
+            const updated = src.match(/^updatedDate:\s*['"]?(\d{4}-\d{2}-\d{2})/m)?.[1];
+            const published = src.match(/^pubDate:\s*['"]?(\d{4}-\d{2}-\d{2})/m)?.[1];
+            const date = updated || published;
+            if (date) map[`/guides/${file.replace(/\.mdx$/, '')}`] = new Date(`${date}T00:00:00.000Z`).toISOString();
+        }
+    } catch {
+        // If the content dir can't be read, fall back to no lastmod rather than failing the build.
+    }
+    return map;
+})();
 
 /**
  * Astro Config file for Cloudflare
@@ -47,6 +73,8 @@ export default defineConfig({
             serialize(item) {
                 const pathname = new URL(item.url).pathname.replace(/\/$/, '') || '/';
                 if (pathname.startsWith('/admin')) return undefined;
+                // Honest per-guide last-modified date from frontmatter, where we have one.
+                if (GUIDE_LASTMOD[pathname]) item.lastmod = GUIDE_LASTMOD[pathname];
                 // Tier priority to match the link-graph emphasis: the generator,
                 // the guides hub, and the seven cornerstone style guides outrank
                 // the long-tail how-to/concept guides (was a flat 0.9 for all guides

--- a/src/components/astro/BaseHead.astro
+++ b/src/components/astro/BaseHead.astro
@@ -2,7 +2,7 @@
 import "../../styles/global.css";
 import "../../styles/tailwind-output.css";
 import SchemaOrgJsonLd from "./SchemaOrgJsonLd.astro";
-import { buildOrganization, buildWebSite } from "../../lib/schema-org";
+import { buildOrganization, buildWebSite, buildGraph } from "../../lib/schema-org";
 
 interface Props {
     title: string;
@@ -30,8 +30,10 @@ const {
     extraSchemas = [],
 } = Astro.props;
 
-const baseSchemas = [buildOrganization(), buildWebSite()];
-const allSchemas = [...baseSchemas, ...extraSchemas];
+// One connected JSON-LD graph per page: the Organization + WebSite are the
+// shared root, and page-specific nodes (Article, BreadcrumbList, FAQPage, …)
+// reference them by @id instead of repeating the publisher on every node.
+const schemaGraph = buildGraph([buildOrganization(), buildWebSite(), ...extraSchemas]);
 ---
 
 <meta charset="utf-8" />
@@ -81,7 +83,7 @@ const allSchemas = [...baseSchemas, ...extraSchemas];
 
 <link rel="sitemap" href="/sitemap-index.xml" />
 
-<SchemaOrgJsonLd schemas={allSchemas} />
+<SchemaOrgJsonLd schemas={schemaGraph} />
 
 <script
     defer

--- a/src/lib/schema-org.ts
+++ b/src/lib/schema-org.ts
@@ -19,7 +19,9 @@ export function buildOrganization(): JsonLd {
     '@id': ORG_ID,
     name: ORG_NAME,
     url: ORG_URL,
-    logo: ORG_LOGO,
+    // ImageObject (not a bare URL) is the recommended publisher-logo form for
+    // Article rich results, which resolve the logo via this @id reference.
+    logo: { '@type': 'ImageObject', url: ORG_LOGO },
   };
 }
 

--- a/src/lib/schema-org.ts
+++ b/src/lib/schema-org.ts
@@ -3,12 +3,20 @@ export const ORG_URL = 'https://mlagenerator.com';
 export const ORG_LOGO = 'https://mlagenerator.com/images/logo.svg';
 export const DEFAULT_AUTHOR = 'MLA Generator Editorial Team';
 
+// Stable @id anchors. Every page emits its JSON-LD as a single @graph in which
+// the Organization and WebSite are described once and everything else
+// references them by @id, rather than re-describing the publisher on each node.
+export const ORG_ID = `${ORG_URL}/#organization`;
+export const WEBSITE_ID = `${ORG_URL}/#website`;
+export const SOFTWARE_ID = `${ORG_URL}/#software`;
+
 type JsonLd = Record<string, unknown> & { '@context'?: string; '@type': string };
 
 export function buildOrganization(): JsonLd {
   return {
     '@context': 'https://schema.org',
     '@type': 'Organization',
+    '@id': ORG_ID,
     name: ORG_NAME,
     url: ORG_URL,
     logo: ORG_LOGO,
@@ -19,8 +27,10 @@ export function buildWebSite(): JsonLd {
   return {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
+    '@id': WEBSITE_ID,
     name: ORG_NAME,
     url: ORG_URL,
+    publisher: { '@id': ORG_ID },
   };
 }
 
@@ -28,6 +38,7 @@ export function buildSoftwareApplication(): JsonLd {
   return {
     '@context': 'https://schema.org',
     '@type': 'SoftwareApplication',
+    '@id': SOFTWARE_ID,
     name: 'MLA Generator Citation Tool',
     url: ORG_URL,
     applicationCategory: 'EducationalApplication',
@@ -37,6 +48,7 @@ export function buildSoftwareApplication(): JsonLd {
       price: '0',
       priceCurrency: 'USD',
     },
+    publisher: { '@id': ORG_ID },
     description:
       'Free citation generator that creates accurate APA, MLA, Chicago, Harvard, Vancouver, IEEE, and AMA references from a URL, DOI, or ISBN.',
   };
@@ -64,11 +76,8 @@ export function buildArticle(input: ArticleInput): JsonLd {
     datePublished: input.datePublished.toISOString(),
     dateModified: (input.dateModified ?? input.datePublished).toISOString(),
     author: { '@type': 'Organization', name: input.author },
-    publisher: {
-      '@type': 'Organization',
-      name: ORG_NAME,
-      logo: { '@type': 'ImageObject', url: ORG_LOGO },
-    },
+    publisher: { '@id': ORG_ID },
+    isPartOf: { '@id': WEBSITE_ID },
     mainEntityOfPage: { '@type': 'WebPage', '@id': input.url },
     ...(input.keywords ? { keywords: input.keywords } : {}),
     ...(input.section ? { articleSection: input.section } : {}),
@@ -115,6 +124,22 @@ export function buildAboutPage(url: string): JsonLd {
     '@context': 'https://schema.org',
     '@type': 'AboutPage',
     url,
-    mainEntity: buildOrganization(),
+    mainEntity: { '@id': ORG_ID },
+  };
+}
+
+/**
+ * Combine independent JSON-LD nodes into a single connected `@graph` document.
+ * Each node's own `@context` is dropped (the graph carries one shared context),
+ * so nodes can keep returning a standalone-valid `@context` for direct use/tests
+ * while still composing cleanly here.
+ */
+export function buildGraph(nodes: JsonLd[]): { '@context': string; '@graph': object[] } {
+  return {
+    '@context': 'https://schema.org',
+    '@graph': nodes.map((node) => {
+      const { ['@context']: _ctx, ...rest } = node;
+      return rest;
+    }),
   };
 }

--- a/tests/lib/schema-org.test.ts
+++ b/tests/lib/schema-org.test.ts
@@ -23,7 +23,7 @@ describe('buildOrganization', () => {
     expect(org['@id']).toBe(ORG_ID);
     expect(org.name).toBe(ORG_NAME);
     expect(org.url).toBe(ORG_URL);
-    expect(org.logo).toBe(ORG_LOGO);
+    expect(org.logo).toEqual({ '@type': 'ImageObject', url: ORG_LOGO });
   });
 });
 

--- a/tests/lib/schema-org.test.ts
+++ b/tests/lib/schema-org.test.ts
@@ -7,16 +7,20 @@ import {
   buildBreadcrumbList,
   buildFaqPage,
   buildAboutPage,
+  buildGraph,
   ORG_NAME,
   ORG_URL,
   ORG_LOGO,
+  ORG_ID,
+  WEBSITE_ID,
 } from '../../src/lib/schema-org';
 
 describe('buildOrganization', () => {
-  it('returns an Organization with name, url, logo', () => {
+  it('returns an Organization with @id, name, url, logo', () => {
     const org = buildOrganization();
     expect(org['@context']).toBe('https://schema.org');
     expect(org['@type']).toBe('Organization');
+    expect(org['@id']).toBe(ORG_ID);
     expect(org.name).toBe(ORG_NAME);
     expect(org.url).toBe(ORG_URL);
     expect(org.logo).toBe(ORG_LOGO);
@@ -24,21 +28,24 @@ describe('buildOrganization', () => {
 });
 
 describe('buildWebSite', () => {
-  it('returns a WebSite anchored to the canonical site URL', () => {
+  it('returns a WebSite anchored to the canonical site URL, published by the org', () => {
     const site = buildWebSite();
     expect(site['@type']).toBe('WebSite');
+    expect(site['@id']).toBe(WEBSITE_ID);
     expect(site.name).toBe(ORG_NAME);
     expect(site.url).toBe(ORG_URL);
+    expect(site.publisher).toEqual({ '@id': ORG_ID });
   });
 });
 
 describe('buildSoftwareApplication', () => {
-  it('describes the free citation tool', () => {
+  it('describes the free citation tool and references the org as publisher', () => {
     const app = buildSoftwareApplication();
     expect(app['@type']).toBe('SoftwareApplication');
     expect(app.applicationCategory).toBe('EducationalApplication');
     expect(app.operatingSystem).toBe('Web');
     expect(app.offers.price).toBe('0');
+    expect(app.publisher).toEqual({ '@id': ORG_ID });
   });
 });
 
@@ -60,7 +67,8 @@ describe('buildArticle', () => {
     expect(a.datePublished).toBe('2026-01-01T00:00:00.000Z');
     expect(a.dateModified).toBe('2026-05-27T00:00:00.000Z');
     expect(a.author).toEqual({ '@type': 'Organization', name: 'MLA Generator Editorial Team' });
-    expect(a.publisher.name).toBe(ORG_NAME);
+    expect(a.publisher).toEqual({ '@id': ORG_ID });
+    expect(a.isPartOf).toEqual({ '@id': WEBSITE_ID });
     expect(a.mainEntityOfPage['@id']).toBe('https://mlagenerator.com/guides/apa');
     expect(a.keywords).toEqual(['apa', 'citations']);
     expect(a.articleSection).toBe('style-guide');
@@ -115,10 +123,42 @@ describe('buildFaqPage', () => {
 });
 
 describe('buildAboutPage', () => {
-  it('references the organization', () => {
+  it('references the organization by @id', () => {
     const a = buildAboutPage('https://mlagenerator.com/about');
     expect(a['@type']).toBe('AboutPage');
     expect(a.url).toBe('https://mlagenerator.com/about');
-    expect(a.mainEntity['@type']).toBe('Organization');
+    expect(a.mainEntity).toEqual({ '@id': ORG_ID });
+  });
+});
+
+describe('buildGraph', () => {
+  it('wraps nodes in a single @graph with one shared @context and strips per-node @context', () => {
+    const graph = buildGraph([buildOrganization(), buildWebSite()]);
+    expect(graph['@context']).toBe('https://schema.org');
+    expect(Array.isArray(graph['@graph'])).toBe(true);
+    expect(graph['@graph']).toHaveLength(2);
+    for (const node of graph['@graph']) {
+      expect((node as Record<string, unknown>)['@context']).toBeUndefined();
+    }
+    // Nodes keep their @id so cross-references (publisher, isPartOf) resolve.
+    const ids = (graph['@graph'] as Array<{ '@id'?: string }>).map((n) => n['@id']);
+    expect(ids).toContain(ORG_ID);
+    expect(ids).toContain(WEBSITE_ID);
+  });
+
+  it('connects an Article to the org and website by @id within the graph', () => {
+    const article = buildArticle({
+      title: 'T',
+      description: 'D',
+      url: 'https://mlagenerator.com/guides/x',
+      datePublished: new Date('2026-01-01'),
+      author: 'MLA Generator Editorial Team',
+      image: 'https://mlagenerator.com/images/banner.png',
+    });
+    const graph = buildGraph([buildOrganization(), buildWebSite(), article]);
+    const graphIds = (graph['@graph'] as Array<{ '@id'?: string }>).map((n) => n['@id']);
+    // The publisher/isPartOf @id references must point at nodes present in the graph.
+    expect(graphIds).toContain((article.publisher as { '@id': string })['@id']);
+    expect(graphIds).toContain((article.isPartOf as { '@id': string })['@id']);
   });
 });


### PR DESCRIPTION
## What

Two SEO/structured-data improvements (deferred items from the prior audit).

### 1. Connected JSON-LD `@graph`
Previously every page emitted several independent `application/ld+json` blocks, each repeating the publisher Organization. Now each page emits **one** connected `@graph`:
- `Organization` (`#organization`) and `WebSite` (`#website`) are described once with stable `@id`s.
- Page nodes reference them by `@id` instead of re-describing: `Article.publisher` / `SoftwareApplication.publisher` → `#organization`; `Article.isPartOf` → `#website`; `AboutPage.mainEntity` → `#organization`.
- `Organization.logo` is now an `ImageObject` (recommended publisher-logo form for Article rich results).
- New `buildGraph()` strips per-node `@context` and wraps in one shared context; `BaseHead` assembles `[org, website, …extraSchemas]`.

### 2. Honest per-guide sitemap `<lastmod>`
`astro.config.mjs` reads each guide's frontmatter at config-load and emits a `<lastmod>` (from `updatedDate`, else `pubDate`) for every `/guides/<slug>`. Pages with no real change date (generator, legal pages) get **no** `lastmod` rather than a faked build-time one.

## Verification
- `npm test` → 379/379 (incl. 2 new `buildGraph` tests; updated `@id`/`ImageObject` assertions).
- `npm run build` → clean. Verified in built `dist/`: each of the 24 guides emits exactly one valid connected `@graph` (publisher/isPartOf `@id`s resolve, no dangling/duplicate `@id`s, no nested `@context`, `</script>` escaping intact); `sitemap-0.xml` has 24 guide `<lastmod>` values matching frontmatter (e.g. apa `2026-05-27`) and 0 on the 6 non-guide pages.

## Review
Pre-merge: two independent fresh-context reviewers (JSON-LD validity; config/build safety) — **both safe-to-merge, zero blocking findings**. The two improvements above were their non-blocking suggestions, applied in commit 2.

## Notes / deliberately omitted
- `sameAs` and a sitelinks `SearchAction` were **not** added: there are no real social profiles in the repo to point `sameAs` at, and there is no search-results page for a `SearchAction` to target (the generator is a paste-a-URL flow). Adding either would be invalid/cargo-cult structured data. Happy to add `sameAs` if you supply official profile URLs.
- Publisher logo remains `logo.svg` (pre-existing); Google's publisher-logo guidance mildly prefers raster — tracked separately, not in this diff.
