### PR TITLE
Guide nav & hierarchy: fix lede link, add H2/H3 anchors + category hubs

### DIFF
--- a/src/components/astro/GuideCardGrid.astro
+++ b/src/components/astro/GuideCardGrid.astro
@@ -1,0 +1,62 @@
+---
+// Reusable grid of guide "cards". Used by the guides hub and the per-category
+// hub pages. Card styling is scoped here to `.guide-grid a` so it can never
+// leak onto inline prose links in the surrounding page (which was the bug that
+// turned an inline link into a padded card box).
+import type { CollectionEntry } from "astro:content";
+
+interface Props {
+    items: CollectionEntry<"guides">[];
+}
+
+const { items } = Astro.props;
+---
+
+<ul class="guide-grid">
+    {items.map((g) => (
+        <li>
+            <a href={`/guides/${g.slug}`}>
+                <span class="guide-title">{g.data.title}</span>
+                <span class="guide-desc">{g.data.description}</span>
+            </a>
+        </li>
+    ))}
+</ul>
+
+<style>
+    .guide-grid {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+        display: grid;
+        gap: 0.75rem;
+        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    }
+    .guide-grid a {
+        display: flex;
+        flex-direction: column;
+        gap: 0.25rem;
+        padding: 1rem 1.25rem;
+        border: 1px solid var(--color-border);
+        border-radius: 10px;
+        text-decoration: none;
+        color: var(--color-text-dark);
+        height: 100%;
+    }
+    .guide-grid a:hover,
+    .guide-grid a:focus-visible {
+        background-color: var(--color-background-2);
+        outline: none;
+    }
+    .guide-grid a:focus-visible {
+        outline: 2px solid var(--color-text-dark);
+        outline-offset: 2px;
+    }
+    .guide-title {
+        font-weight: 510;
+    }
+    .guide-desc {
+        font-size: 14px;
+        color: var(--color-text-light);
+    }
+</style>

--- a/src/components/astro/Heading.astro
+++ b/src/components/astro/Heading.astro
@@ -1,30 +1,58 @@
 ---
-const { id } = Astro.props;
+// Renders an MDX heading (h2 or h3) with a hover-revealed anchor link so
+// sections are deep-linkable. The anchor sits inline after the text (not
+// negative-offset absolute) so it never causes horizontal overflow on narrow
+// screens. `id` is supplied by Astro's auto-slug, matching the in-page nav.
 import { LinkIcon } from '@heroicons/react/24/outline';
+
+interface Props {
+    id?: string;
+    as?: 'h2' | 'h3';
+}
+
+const { id, as = 'h2' } = Astro.props;
+const Tag = as;
 ---
 
-<h2 id={id}>
-    <a href={`#${id}`}>
-        <LinkIcon className="icon"/>
-    </a>
+<Tag id={id} class="anchored-heading">
     <slot />
-</h2>
+    {id && (
+        <a class="heading-anchor" href={`#${id}`} aria-label="Link to this section">
+            <LinkIcon className="heading-anchor-icon" />
+        </a>
+    )}
+</Tag>
 
-<style>
-    h2 {
+<style is:global>
+    .anchored-heading {
         position: relative;
-        /* display: flex;
-        align-items: center; */
     }
-    .icon {
-        width: 20px;
-        margin-right: 8px;
-        position: absolute;
-        left: -28px;
-        top: 0;
-        bottom: 0;
-        transform: translateY(-50%);
-
-        display: none;
+    .heading-anchor {
+        display: inline-flex;
+        align-items: center;
+        margin-left: 0.4rem;
+        opacity: 0;
+        text-decoration: none;
+        color: var(--color-text-light);
+        transition: opacity 0.12s ease-in-out;
+        vertical-align: middle;
+    }
+    .heading-anchor:hover,
+    .heading-anchor:focus-visible {
+        color: var(--color-text-dark);
+    }
+    .anchored-heading:hover .heading-anchor,
+    .anchored-heading:focus-within .heading-anchor {
+        opacity: 1;
+    }
+    .heading-anchor-icon {
+        width: 18px;
+        height: 18px;
+    }
+    /* Touch devices have no hover — keep the anchor visible there. */
+    @media (hover: none) {
+        .heading-anchor {
+            opacity: 1;
+        }
     }
 </style>

--- a/src/components/astro/Heading3.astro
+++ b/src/components/astro/Heading3.astro
@@ -1,0 +1,9 @@
+---
+// Thin wrapper so MDX `h3` headings get the same anchor-link treatment as `h2`.
+// (MDX passes the heading's auto-slug `id` as a prop; we forward it.)
+import Heading from './Heading.astro';
+
+const { id } = Astro.props;
+---
+
+<Heading as="h3" id={id}><slot /></Heading>

--- a/src/layouts/guide.astro
+++ b/src/layouts/guide.astro
@@ -4,6 +4,7 @@ import Breadcrumbs from "../components/astro/Breadcrumbs.astro";
 import RelatedGuides from "../components/astro/RelatedGuides.astro";
 import GuideFaq from "../components/astro/GuideFaq.astro";
 import TryGenerator from "../components/astro/TryGenerator.astro";
+import { categoryByKey, categoryPath } from "../lib/guide-categories";
 
 interface Props {
     frontmatter: {
@@ -24,6 +25,7 @@ interface Props {
 const { frontmatter, headings, slug, extraSchemas } = Astro.props;
 const displayDate = frontmatter.updatedDate ?? frontmatter.pubDate;
 const dateLabel = frontmatter.updatedDate ? 'Updated' : 'Published';
+const category = categoryByKey(frontmatter.category);
 ---
 
 <Layout
@@ -58,6 +60,7 @@ const dateLabel = frontmatter.updatedDate ? 'Updated' : 'Published';
                 items={[
                     { name: 'Home', href: '/' },
                     { name: 'Guides', href: '/guides' },
+                    ...(category ? [{ name: category.label, href: categoryPath(category.key) }] : []),
                     { name: frontmatter.title, href: `/guides/${slug}`, current: true },
                 ]}
             />
@@ -253,6 +256,9 @@ const dateLabel = frontmatter.updatedDate ? 'Updated' : 'Published';
             target.scrollIntoView({
                 behavior: prefersReduced ? 'auto' : 'smooth',
             });
+            // Reflect the section in the URL so a clicked anchor is shareable,
+            // without adding a history entry on every jump.
+            history.replaceState(null, '', href);
         });
     });
 

--- a/src/layouts/guide.astro
+++ b/src/layouts/guide.astro
@@ -187,7 +187,10 @@ const category = categoryByKey(frontmatter.category);
         color: var(--color-text-light);
         text-align: left;
     }
-    #guide-content a {
+    /* Prose links only — exclude the hover-revealed heading anchor links, which
+       carry their own subtle styling (a higher-specificity #guide-content rule
+       would otherwise force them to dark + underlined). */
+    #guide-content a:not(.heading-anchor) {
         color: var(--color-text-dark);
         text-decoration: underline;
     }

--- a/src/lib/guide-categories.ts
+++ b/src/lib/guide-categories.ts
@@ -1,0 +1,68 @@
+// Single source of truth for guide categories. Used by the guides hub
+// (src/pages/guides/index.astro), the per-category hub pages
+// (src/pages/guides/category/[category].astro), and the category tier in
+// guide breadcrumbs. Keep `key` in sync with the `category` enum in
+// src/content/config.ts.
+
+export type GuideCategoryKey =
+    | 'style-guide'
+    | 'how-to'
+    | 'concept'
+    | 'comparison'
+    | 'meta';
+
+export interface GuideCategory {
+    key: GuideCategoryKey;
+    /** Short label for headings, breadcrumbs, and nav. */
+    label: string;
+    /** One-line summary shown under the heading on the guides hub. */
+    blurb: string;
+    /** Longer description for the category hub page meta + intro. */
+    description: string;
+}
+
+export const GUIDE_CATEGORIES: GuideCategory[] = [
+    {
+        key: 'style-guide',
+        label: 'Style guides',
+        blurb: 'Complete reference for each major citation style.',
+        description:
+            'Edition-accurate reference guides for each major citation style — APA 7, MLA 9, Chicago 18, Harvard (Cite Them Right), Vancouver, IEEE, and AMA 11 — covering in-text citations, the reference list, and worked examples for every common source type.',
+    },
+    {
+        key: 'how-to',
+        label: 'How to cite',
+        blurb: 'Format common source types across every style.',
+        description:
+            'Step-by-step guides for citing specific source types — websites, books, journal articles, PDFs, interviews, and videos — formatted correctly in APA, MLA, Chicago, Harvard, Vancouver, IEEE, and AMA.',
+    },
+    {
+        key: 'concept',
+        label: 'Concepts',
+        blurb: 'Core citation concepts and how they apply.',
+        description:
+            'The core ideas behind citing sources well: in-text citations, hanging indents, annotated bibliographies, the difference between a works-cited list and a bibliography, and how to avoid plagiarism.',
+    },
+    {
+        key: 'comparison',
+        label: 'Comparisons',
+        blurb: 'Choosing the right style for your work.',
+        description:
+            'Side-by-side comparisons to help you choose between citation styles and switch cleanly from one to another, including which style to use for your field.',
+    },
+    {
+        key: 'meta',
+        label: 'Reference & FAQ',
+        blurb: 'Tool documentation and frequently asked questions.',
+        description:
+            'Documentation for the citation generator, a log of citation-style edition updates, and answers to frequently asked questions.',
+    },
+];
+
+export function categoryByKey(key: string): GuideCategory | undefined {
+    return GUIDE_CATEGORIES.find((c) => c.key === key);
+}
+
+export function categoryPath(key: string): string {
+    return `/guides/category/${key}`;
+}

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -3,12 +3,14 @@ import { getCollection } from "astro:content";
 import type { CollectionEntry } from "astro:content";
 import GuideLayout from "../../layouts/guide.astro";
 import Heading from "../../components/astro/Heading.astro";
+import Heading3 from "../../components/astro/Heading3.astro";
 import GithubSlugger from "github-slugger";
 import {
     buildArticle,
     buildBreadcrumbList,
     buildFaqPage,
 } from "../../lib/schema-org";
+import { categoryByKey, categoryPath } from "../../lib/guide-categories";
 
 export async function getStaticPaths() {
     const entries = await getCollection("guides");
@@ -51,9 +53,11 @@ const articleSchema = buildArticle({
     section: entry.data.category,
 });
 
+const category = categoryByKey(entry.data.category);
 const breadcrumbSchema = buildBreadcrumbList([
     { name: 'Home', url: `${site}/` },
     { name: 'Guides', url: `${site}/guides` },
+    ...(category ? [{ name: category.label, url: `${site}${categoryPath(category.key)}` }] : []),
     { name: entry.data.title, url: pageUrl },
 ]);
 
@@ -69,5 +73,5 @@ if (entry.data.faq && entry.data.faq.length > 0) {
     slug={entry.slug}
     extraSchemas={extraSchemas}
 >
-    <Content components={{ ...components, h2: Heading }} />
+    <Content components={{ ...components, h2: Heading, h3: Heading3 }} />
 </GuideLayout>

--- a/src/pages/guides/category/[category].astro
+++ b/src/pages/guides/category/[category].astro
@@ -1,0 +1,85 @@
+---
+import Layout from "../../../layouts/page.astro";
+import Breadcrumbs from "../../../components/astro/Breadcrumbs.astro";
+import GuideCardGrid from "../../../components/astro/GuideCardGrid.astro";
+import { buildBreadcrumbList } from "../../../lib/schema-org";
+import { GUIDE_CATEGORIES, categoryPath } from "../../../lib/guide-categories";
+import { getCollection } from "astro:content";
+
+export const prerender = true;
+
+export async function getStaticPaths() {
+    const all = await getCollection("guides");
+    const sortByTitle = (a: typeof all[number], b: typeof all[number]) =>
+        a.data.title.localeCompare(b.data.title);
+    return GUIDE_CATEGORIES.map((cat) => ({
+        params: { category: cat.key },
+        props: {
+            cat,
+            items: all.filter((g) => g.data.category === cat.key).sort(sortByTitle),
+        },
+    }));
+}
+
+const { cat, items } = Astro.props;
+
+const title = `${cat.label} — Citation Guides`;
+const description = cat.description;
+
+const breadcrumbSchema = buildBreadcrumbList([
+    { name: 'Home', url: new URL('/', Astro.site).href },
+    { name: 'Guides', url: new URL('/guides', Astro.site).href },
+    { name: cat.label, url: new URL(categoryPath(cat.key), Astro.site).href },
+]);
+---
+
+<Layout title={title} description={description} extraSchemas={[breadcrumbSchema]}>
+    <article class="category-hub">
+        <Breadcrumbs
+            items={[
+                { name: 'Home', href: '/' },
+                { name: 'Guides', href: '/guides' },
+                { name: cat.label, href: categoryPath(cat.key), current: true },
+            ]}
+        />
+        <header>
+            <h1>{cat.label}</h1>
+            <p class="lede">{cat.description}</p>
+        </header>
+
+        <GuideCardGrid items={items} />
+
+        <p class="back-link"><a href="/guides">← All citation guides</a></p>
+    </article>
+</Layout>
+
+<style>
+    .category-hub {
+        max-width: 900px;
+        margin: 0 auto;
+        padding: 4.5rem 2rem 3rem;
+        color: var(--color-text-medium);
+        line-height: 1.5;
+    }
+    .category-hub h1 {
+        font-size: 2.4rem;
+        color: var(--color-text-dark);
+        margin: 0 0 0.75rem;
+    }
+    .category-hub .lede {
+        font-size: 1.1rem;
+        margin-bottom: 2.5rem;
+        max-width: 60ch;
+    }
+    .category-hub .back-link {
+        margin-top: 2.5rem;
+    }
+    .category-hub .back-link a {
+        color: var(--color-text-light);
+        text-decoration: underline;
+    }
+    .category-hub .back-link a:hover,
+    .category-hub .back-link a:focus-visible {
+        color: var(--color-text-dark);
+    }
+</style>

--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -1,7 +1,9 @@
 ---
 import Layout from "../../layouts/page.astro";
 import Breadcrumbs from "../../components/astro/Breadcrumbs.astro";
+import GuideCardGrid from "../../components/astro/GuideCardGrid.astro";
 import { buildBreadcrumbList } from "../../lib/schema-org";
+import { GUIDE_CATEGORIES, categoryPath } from "../../lib/guide-categories";
 import { getCollection } from "astro:content";
 
 const title = "Citation Guides — APA, MLA, Chicago, Harvard, Vancouver, IEEE, AMA";
@@ -17,15 +19,7 @@ const all = await getCollection("guides");
 const sortByTitle = (a: typeof all[number], b: typeof all[number]) =>
     a.data.title.localeCompare(b.data.title);
 
-const categories: { key: string; label: string; blurb: string }[] = [
-    { key: 'style-guide', label: 'Style guides', blurb: 'Complete reference for each major citation style.' },
-    { key: 'how-to', label: 'How to cite', blurb: 'Format common source types across every style.' },
-    { key: 'concept', label: 'Concepts', blurb: 'Core citation concepts and how they apply.' },
-    { key: 'comparison', label: 'Comparisons', blurb: 'Choosing the right style for your work.' },
-    { key: 'meta', label: 'Reference & FAQ', blurb: 'Tool documentation and frequently asked questions.' },
-];
-
-const grouped = categories.map((cat) => ({
+const grouped = GUIDE_CATEGORIES.map((cat) => ({
     ...cat,
     items: all.filter((g) => g.data.category === cat.key).sort(sortByTitle),
 }));
@@ -46,18 +40,11 @@ const grouped = categories.map((cat) => ({
 
         {grouped.map((group) => group.items.length > 0 && (
             <section aria-labelledby={`cat-${group.key}`}>
-                <h2 id={`cat-${group.key}`}>{group.label}</h2>
+                <h2 id={`cat-${group.key}`}>
+                    <a href={categoryPath(group.key)}>{group.label}</a>
+                </h2>
                 <p class="cat-blurb">{group.blurb}</p>
-                <ul>
-                    {group.items.map((g) => (
-                        <li>
-                            <a href={`/guides/${g.slug}`}>
-                                <span class="guide-title">{g.data.title}</span>
-                                <span class="guide-desc">{g.data.description}</span>
-                            </a>
-                        </li>
-                    ))}
-                </ul>
+                <GuideCardGrid items={group.items} />
             </section>
         ))}
     </article>
@@ -81,6 +68,11 @@ const grouped = categories.map((cat) => ({
         margin-bottom: 3rem;
         max-width: 60ch;
     }
+    /* Inline prose link in the lede — a normal underlined text link, not a card. */
+    .guides-hub .lede a {
+        color: var(--color-text-dark);
+        text-decoration: underline;
+    }
     .guides-hub section {
         margin-bottom: 3rem;
     }
@@ -89,43 +81,16 @@ const grouped = categories.map((cat) => ({
         color: var(--color-text-dark);
         margin: 0 0 0.5rem;
     }
+    .guides-hub h2 a {
+        color: inherit;
+        text-decoration: none;
+    }
+    .guides-hub h2 a:hover,
+    .guides-hub h2 a:focus-visible {
+        text-decoration: underline;
+    }
     .cat-blurb {
         color: var(--color-text-light);
         margin-bottom: 1rem;
-    }
-    .guides-hub ul {
-        list-style: none;
-        padding: 0;
-        margin: 0;
-        display: grid;
-        gap: 0.75rem;
-        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    }
-    .guides-hub a {
-        display: flex;
-        flex-direction: column;
-        gap: 0.25rem;
-        padding: 1rem 1.25rem;
-        border: 1px solid var(--color-border);
-        border-radius: 10px;
-        text-decoration: none;
-        color: var(--color-text-dark);
-        height: 100%;
-    }
-    .guides-hub a:hover,
-    .guides-hub a:focus-visible {
-        background-color: var(--color-background-2);
-        outline: none;
-    }
-    .guides-hub a:focus-visible {
-        outline: 2px solid var(--color-text-dark);
-        outline-offset: 2px;
-    }
-    .guide-title {
-        font-weight: 510;
-    }
-    .guide-desc {
-        font-size: 14px;
-        color: var(--color-text-light);
     }
 </style>


### PR DESCRIPTION
## What

Guide navigation & hierarchy improvements (deferred audit items) + the reported lede-link bug.

### 1. Fix the guides-hub "citation generator" lede link (reported bug)
An over-broad `.guides-hub a` selector was styling **every** anchor in the hub as a padded outline card — including the inline "citation generator" link in the lede, which pushed its trailing period onto its own line. Card styling is now extracted into a reusable **`GuideCardGrid`** component scoped to `.guide-grid a`, so prose links render normally. The lede link is now a plain inline underlined link.

### 2. H2 + H3 anchor links
`Heading.astro` is now level-parametric and renders a **hover-revealed anchor link** on H2 and H3 headings (new `Heading3` wrapper maps MDX `h3`). Anchors are inline (no negative-offset absolute → no mobile horizontal overflow), icon has an `aria-label`, touch devices keep it visible, and clicking one updates the URL hash (`history.replaceState`) so sections are shareable. Fixed a specificity bug where the `#guide-content a` prose rule overrode the anchor styling (now `…a:not(.heading-anchor)`).

### 3. Category hub pages + category-tier breadcrumbs
New `/guides/category/<key>` hub pages (one per category) and a **category tier** in guide breadcrumbs — both the visible `Breadcrumbs` and the `BreadcrumbList` JSON-LD now read `Home > Guides > <Category> > <Guide>`. A new shared **`guide-categories`** module is the single source of truth for category metadata (reused by the hub, the category pages, and breadcrumbs). The hub's category headings now link to their category pages.

## Verification
- `npm run build` clean: 5 category pages + 24 guides prerender, **no route collision** (`dist/_routes.json` excludes both sets as static).
- `npm test` → 379/379.
- Runtime smoke (wrangler) confirms the server-rendered hub returns 200 and the old `.guides-hub a` card rule is gone; built CSS shows the lede link gets only the inline underline rule.

## Review
Pre-merge: two independent fresh-context reviewers (CSS/visual regression + the lede fix; routing/breadcrumb/anchor/link integrity) — **both safe-to-merge, zero blocking findings**. Card CSS confirmed moved byte-for-byte; breadcrumb visible/schema parity confirmed; category keys confirmed to match the content-config enum (no 404 tiers).

## Non-blocking notes
- `.anchored-heading { position: relative }` is now vestigial (harmless) since the anchor is inline; left in place.
- Scrollspy / in-page TOC still lists only H2 (intended); H3 anchors don't pollute the side nav.
