### PR TITLE
Rewrite clipboard copy to the async Clipboard API (rich text preserved)

### DIFF
--- a/src/components/react/ReferenceItem.tsx
+++ b/src/components/react/ReferenceItem.tsx
@@ -2,10 +2,11 @@ import React, { memo, useEffect, useRef } from 'react';
 import EditReferenceDialogDrawer from './EditReferenceDialogDrawer';
 import { useFormattedCitation } from '../../lib/citations/useFormattedCitation';
 import type { StoredSource } from '../../lib/references/storage';
-import type { SupportedStyle, RichText } from '../../lib/citations/csl-types';
+import type { SupportedStyle } from '../../lib/citations/csl-types';
 import styles from '../../styles/references.module.css';
 import { Clipboard, Globe } from 'lucide-react';
-import { escapeHtml, richTextToHtml } from './richText';
+import { escapeHtml, richTextToHtml, richTextToPlain } from './richText';
+import { copyRichText } from './clipboard';
 
 interface Props {
     source: StoredSource;
@@ -16,22 +17,6 @@ interface Props {
     autoOpenEdit?: boolean;
 }
 
-function copyRichText(rt: RichText[]) {
-    const html = richTextToHtml(rt);
-    const div = document.createElement('div');
-    div.style.cssText = 'position:fixed;left:-9999px;font-family:"Times New Roman",Times,serif;font-size:12pt;line-height:2;';
-    div.innerHTML = html;
-    document.body.appendChild(div);
-    const range = document.createRange();
-    range.selectNodeContents(div);
-    const sel = window.getSelection();
-    sel?.removeAllRanges();
-    sel?.addRange(range);
-    document.execCommand('copy');
-    document.body.removeChild(div);
-    sel?.removeAllRanges();
-}
-
 function ReferenceItem({ source, checked, onToggle, citationFormat, setSources, autoOpenEdit }: Props) {
     const editButtonRef = useRef<HTMLButtonElement>(null);
     const { formatted, loading, error } = useFormattedCitation(source, citationFormat);
@@ -40,13 +25,15 @@ function ReferenceItem({ source, checked, onToggle, citationFormat, setSources, 
         if (autoOpenEdit && editButtonRef.current) editButtonRef.current.click();
     }, [source.uuid, autoOpenEdit]);
 
-    const handleCopy = (event: React.MouseEvent<HTMLButtonElement>) => {
+    const handleCopy = async (event: React.MouseEvent<HTMLButtonElement>) => {
         // Don't copy an empty/placeholder citation while it is still loading or
         // errored — that would wipe the clipboard while showing "Copied".
         if (loading || error || formatted.length === 0) return;
-        copyRichText(formatted);
+        // Capture the label span before awaiting: React resets the synthetic
+        // event's currentTarget once the handler returns.
         const targetSpan = event.currentTarget.querySelector('span');
-        if (!targetSpan) return;
+        const ok = await copyRichText(richTextToHtml(formatted), richTextToPlain(formatted));
+        if (!ok || !targetSpan) return;
         const current = targetSpan.textContent;
         targetSpan.textContent = 'Copied';
         setTimeout(() => { targetSpan.textContent = current; }, 1000);

--- a/src/components/react/References.tsx
+++ b/src/components/react/References.tsx
@@ -6,12 +6,13 @@ import CitationSearch from './CitationSearch';
 import ReferenceItem from './ReferenceItem';
 import { useReferences } from '../../lib/references/useReferences';
 import type { StoredSource } from '../../lib/references/storage';
-import type { SupportedStyle } from '../../lib/citations/csl-types';
+import type { SupportedStyle, RichText } from '../../lib/citations/csl-types';
 import { formatCitation } from '../../lib/citations/useFormattedCitation';
 import { Clipboard, Plus, Trash2 } from 'lucide-react';
 import { cn } from './utils';
 import { Button } from './Button';
-import { richTextToHtml } from './richText';
+import { richTextToHtml, richTextToPlain } from './richText';
+import { copyRichText } from './clipboard';
 
 function emptySource(): StoredSource {
     const id = crypto.randomUUID();
@@ -55,26 +56,19 @@ export default function References() {
         if (!items.length) return;
         // Reuses the same module-level cache as the per-item hook, so visible
         // items are zero-network.
-        const results = await Promise.all(items.map(async (s) => {
+        const rts = await Promise.all(items.map(async (s) => {
             try {
-                const rt = await formatCitation({ uuid: s.uuid, csl: s.csl }, citationFormat);
-                return richTextToHtml(rt);
+                return await formatCitation({ uuid: s.uuid, csl: s.csl }, citationFormat);
             } catch {
-                return '';
+                return null;
             }
         }));
-        const tempDiv = document.createElement('div');
-        tempDiv.style.cssText = 'position:fixed;left:-9999px;font-family:"Times New Roman",Times,serif;font-size:12pt;line-height:2;';
-        tempDiv.innerHTML = results.filter(Boolean).join('<br><br>');
-        document.body.appendChild(tempDiv);
-        const range = document.createRange();
-        range.selectNodeContents(tempDiv);
-        const sel = window.getSelection();
-        sel?.removeAllRanges();
-        sel?.addRange(range);
-        document.execCommand('copy');
-        document.body.removeChild(tempDiv);
-        sel?.removeAllRanges();
+        const valid = rts.filter((rt): rt is RichText[] => rt !== null && rt.length > 0);
+        if (!valid.length) return;
+        const html = valid.map(richTextToHtml).join('<br><br>');
+        const plain = valid.map(richTextToPlain).join('\n\n');
+        const ok = await copyRichText(html, plain);
+        if (!ok) return;
         const span = document.querySelector('[data-copy-selected] span');
         if (span) {
             const current = span.textContent;

--- a/src/components/react/clipboard.ts
+++ b/src/components/react/clipboard.ts
@@ -1,0 +1,67 @@
+// Copy a citation to the clipboard preserving rich text (italics, the
+// Times-New-Roman / double-line-height styling that word processors honor on
+// paste). Uses the async Clipboard API with both `text/html` and `text/plain`
+// flavors, and falls back to the legacy execCommand selection method when the
+// async API or ClipboardItem is unavailable or rejects (e.g. permission denied,
+// document not focused, older browsers).
+
+const COPY_STYLE =
+    'font-family:"Times New Roman",Times,serif;font-size:12pt;line-height:2;';
+
+// Legacy path: drop the HTML into an offscreen styled element, select it, and
+// run execCommand('copy'). This is what the app did before the async rewrite;
+// it carries the wrapper's inline styles onto the clipboard.
+function legacyCopyHtml(html: string): boolean {
+    if (typeof document === 'undefined') return false;
+    const div = document.createElement('div');
+    div.style.cssText = `position:fixed;left:-9999px;${COPY_STYLE}`;
+    div.innerHTML = html;
+    document.body.appendChild(div);
+
+    let ok = false;
+    try {
+        const range = document.createRange();
+        range.selectNodeContents(div);
+        const sel = window.getSelection();
+        sel?.removeAllRanges();
+        sel?.addRange(range);
+        ok = document.execCommand('copy');
+        sel?.removeAllRanges();
+    } catch {
+        ok = false;
+    }
+
+    document.body.removeChild(div);
+    return ok;
+}
+
+/**
+ * Copy rich text to the clipboard. `html` is the formatted markup (with `<i>`
+ * for titles, etc.); `plain` is the text-only fallback flavor.
+ * Returns true on success.
+ */
+export async function copyRichText(html: string, plain: string): Promise<boolean> {
+    const canUseAsync =
+        typeof navigator !== 'undefined' &&
+        !!navigator.clipboard &&
+        typeof navigator.clipboard.write === 'function' &&
+        typeof ClipboardItem !== 'undefined';
+
+    if (canUseAsync) {
+        try {
+            // Inline the formatting on a wrapper so pasted output keeps the
+            // citation's font/spacing the way the legacy selection copy did.
+            const styledHtml = `<div style="${COPY_STYLE}">${html}</div>`;
+            const item = new ClipboardItem({
+                'text/html': new Blob([styledHtml], { type: 'text/html' }),
+                'text/plain': new Blob([plain], { type: 'text/plain' }),
+            });
+            await navigator.clipboard.write([item]);
+            return true;
+        } catch {
+            // Fall through to the legacy path.
+        }
+    }
+
+    return legacyCopyHtml(html);
+}

--- a/src/components/react/richText.ts
+++ b/src/components/react/richText.ts
@@ -8,3 +8,9 @@ export function escapeHtml(s: string): string {
 export function richTextToHtml(rt: RichText[]): string {
     return rt.map((seg) => seg.italic ? `<i>${escapeHtml(seg.text)}</i>` : escapeHtml(seg.text)).join('');
 }
+
+// Plain-text rendering (formatting dropped) for the clipboard's text/plain
+// flavor, so pasting into a plain-text field yields readable text.
+export function richTextToPlain(rt: RichText[]): string {
+    return rt.map((seg) => seg.text).join('');
+}

--- a/tests/client/clipboard.test.ts
+++ b/tests/client/clipboard.test.ts
@@ -73,6 +73,20 @@ describe('copyRichText (legacy fallback)', () => {
 
         expect(ok).toBe(true);
         expect(exec).toHaveBeenCalledWith('copy');
+        // The offscreen element used for the selection copy must be cleaned up.
+        expect(document.querySelectorAll('div[style*="-9999px"]').length).toBe(0);
+    });
+
+    it('returns false when no async API is available and execCommand fails', async () => {
+        delete (navigator as any).clipboard;
+        delete (globalThis as any).ClipboardItem;
+        (document as any).execCommand = vi.fn().mockReturnValue(false);
+
+        const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
+
+        expect(ok).toBe(false);
+        // Still cleaned up even on failure.
+        expect(document.querySelectorAll('div[style*="-9999px"]').length).toBe(0);
     });
 
     it('falls back to execCommand when the async write rejects', async () => {

--- a/tests/client/clipboard.test.ts
+++ b/tests/client/clipboard.test.ts
@@ -1,0 +1,94 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { copyRichText } from '../../src/components/react/clipboard';
+import { richTextToHtml, richTextToPlain } from '../../src/components/react/richText';
+
+const RT = [
+    { text: 'Doe, Jane. ' },
+    { text: 'My Title', italic: true },
+    { text: '. Publisher, 2024.' },
+];
+
+const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+
+afterEach(() => {
+    // Restore globals mutated by individual tests.
+    if (clipboardDescriptor) {
+        Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
+    } else {
+        delete (navigator as any).clipboard;
+    }
+    delete (globalThis as any).ClipboardItem;
+    delete (document as any).execCommand;
+    vi.restoreAllMocks();
+});
+
+describe('richTextToPlain', () => {
+    it('joins segment text and drops italic formatting', () => {
+        expect(richTextToPlain(RT)).toBe('Doe, Jane. My Title. Publisher, 2024.');
+    });
+});
+
+describe('copyRichText (async Clipboard API)', () => {
+    it('writes both text/html (with italics + styled wrapper) and text/plain, and returns true', async () => {
+        let captured: any;
+        const writeMock = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { write: writeMock },
+            configurable: true,
+        });
+        (globalThis as any).ClipboardItem = class {
+            data: Record<string, Blob>;
+            constructor(data: Record<string, Blob>) {
+                this.data = data;
+                captured = data;
+            }
+        };
+
+        const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
+
+        expect(ok).toBe(true);
+        expect(writeMock).toHaveBeenCalledTimes(1);
+        const html = await captured['text/html'].text();
+        const plain = await captured['text/plain'].text();
+        // Rich text preserved: italic title + the inline wrapper styling.
+        expect(html).toContain('<i>My Title</i>');
+        expect(html).toContain('Times New Roman');
+        // Plain flavor is text-only.
+        expect(plain).toBe('Doe, Jane. My Title. Publisher, 2024.');
+        expect(plain).not.toContain('<i>');
+    });
+});
+
+describe('copyRichText (legacy fallback)', () => {
+    it('falls back to execCommand when the async API is unavailable', async () => {
+        // No navigator.clipboard / ClipboardItem available.
+        delete (navigator as any).clipboard;
+        delete (globalThis as any).ClipboardItem;
+        // jsdom does not implement execCommand; define it so the legacy path runs.
+        const exec = vi.fn().mockReturnValue(true);
+        (document as any).execCommand = exec;
+
+        const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
+
+        expect(ok).toBe(true);
+        expect(exec).toHaveBeenCalledWith('copy');
+    });
+
+    it('falls back to execCommand when the async write rejects', async () => {
+        Object.defineProperty(navigator, 'clipboard', {
+            value: { write: vi.fn().mockRejectedValue(new Error('denied')) },
+            configurable: true,
+        });
+        (globalThis as any).ClipboardItem = class {
+            constructor(_data: Record<string, Blob>) {}
+        };
+        const exec = vi.fn().mockReturnValue(true);
+        (document as any).execCommand = exec;
+
+        const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
+
+        expect(ok).toBe(true);
+        expect(exec).toHaveBeenCalledWith('copy');
+    });
+});


### PR DESCRIPTION
## What

Replaces the deprecated `document.execCommand('copy')` with the async Clipboard API for copying citations — **without losing rich-text formatting**.

### Changes
- New `clipboard.ts` `copyRichText(html, plain)` util: writes both a `text/html` flavor (with `<i>` italics + the Times-New-Roman / double-line-height wrapper, so pasting into Word/Docs keeps formatting) **and** a `text/plain` flavor via `navigator.clipboard.write` + `ClipboardItem`. Falls back to the legacy `execCommand` selection method when the async API/`ClipboardItem` is unavailable or rejects (permission denied, document not focused, older browsers). The legacy path is fully wrapped in try/catch and always cleans up its offscreen element.
- `richText.ts`: added `richTextToPlain()`.
- `ReferenceItem` (single copy) + `References` (copy-selected) now call the util. Multi-copy joins HTML with `<br><br>` and plain with `\n\n` (matching prior behavior); failed/empty citations are skipped, not copied blank.
- The single-citation handler captures the label span **before** awaiting (React resets the synthetic event's `currentTarget` after the handler returns).

## Verification
- `npm test` → 384/384 (5 new clipboard tests: async path asserts the `text/html` blob carries `<i>` + the wrapper and the `text/plain` blob is tag-free; plain serialization; both fallback triggers; `false`-return path; offscreen-element cleanup).
- `npm run build` → clean.

## Review
Pre-merge fresh-context review — **safe to merge, zero blocking findings**: rich-text fidelity preserved (and arguably more reliable, since styles are embedded in markup rather than serialized from a selected node), fallback sound, `currentTarget` captured before `await`, filtering correct, no dangling imports. The reviewer's two non-blocking test-coverage notes were addressed in commit 2.
