### PR TITLE
Fix mobile horizontal overflow on guide pages

### DIFF
--- a/src/components/astro/GuideCardGrid.astro
+++ b/src/components/astro/GuideCardGrid.astro
@@ -30,7 +30,9 @@ const { items } = Astro.props;
         margin: 0;
         display: grid;
         gap: 0.75rem;
-        grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+        /* min(280px, 100%) so a single column can shrink below 280px on very
+           narrow phones instead of forcing the grid (and page) wider. */
+        grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
     }
     .guide-grid a {
         display: flex;

--- a/src/layouts/guide.astro
+++ b/src/layouts/guide.astro
@@ -146,10 +146,15 @@ const category = categoryByKey(frontmatter.category);
         list-style: circle;
     }
     #guide-content table {
+        /* display:block + overflow-x:auto makes a too-wide table scroll inside
+           its own box on mobile instead of widening the page. (Cells also wrap
+           long URLs below, so most tables fit without scrolling.) */
+        display: block;
         width: 100%;
+        max-width: 100%;
+        overflow-x: auto;
         border-collapse: collapse;
         border-radius: 14px;
-        overflow: hidden;
         margin: 0.5rem 0;
         --border-radius: 8px;
     }
@@ -165,6 +170,12 @@ const category = categoryByKey(frontmatter.category);
     #guide-content td {
         padding: 0.8rem 1rem;
         line-height: 1;
+        /* `anywhere` (unlike break-word) reduces the cell's min-content width,
+           so a table with long URLs can shrink to fit a phone instead of
+           forcing the whole table (and page) wider. Desktop has room, so
+           nothing breaks there; the table's own overflow-x is the backstop for
+           genuinely many-column tables. */
+        overflow-wrap: anywhere;
     }
     #guide-content td {
         padding-top: 0.6rem;
@@ -233,6 +244,17 @@ const category = categoryByKey(frontmatter.category);
         display: flex;
         flex-direction: column;
         gap: 16px;
+        /* As a grid item, min-width defaults to auto, so a wide table or a long
+           unbreakable URL would expand the column past the viewport and force
+           the whole page to scroll horizontally on mobile. min-width:0 lets the
+           column shrink; overflow-wrap breaks long URLs instead of overflowing. */
+        min-width: 0;
+        overflow-wrap: break-word;
+    }
+    /* Code blocks scroll instead of pushing the page wide. */
+    #guide-content pre {
+        max-width: 100%;
+        overflow-x: auto;
     }
     @media (max-width: 1150px) {
         article {
@@ -240,6 +262,12 @@ const category = categoryByKey(frontmatter.category);
         }
         #guide-nav {
             position: static;
+        }
+    }
+    @media (max-width: 640px) {
+        article {
+            padding-left: 1.25rem;
+            padding-right: 1.25rem;
         }
     }
 </style>

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -84,6 +84,7 @@ const extraSchemas = [buildAboutPage(pageUrl)];
         padding: 4.5rem 2rem 3rem;
         color: var(--color-text-medium);
         line-height: 1.6;
+        overflow-wrap: break-word;
     }
     .about h1 {
         font-size: 2.2rem;

--- a/src/pages/privacy.astro
+++ b/src/pages/privacy.astro
@@ -170,6 +170,7 @@ const description =
         padding: 4rem 2rem 3rem;
         line-height: 1.65;
         color: var(--color-text-medium);
+        overflow-wrap: break-word;
     }
     .legal h1 { font-size: 2.2rem; color: var(--color-text-dark); margin: 0 0 1rem; }
     .legal h2 { font-size: 1.4rem; color: var(--color-text-dark); margin: 2rem 0 0.5rem; }

--- a/src/pages/terms.astro
+++ b/src/pages/terms.astro
@@ -166,6 +166,7 @@ const description =
         padding: 4rem 2rem 3rem;
         line-height: 1.65;
         color: var(--color-text-medium);
+        overflow-wrap: break-word;
     }
     .legal h1 { font-size: 2.2rem; color: var(--color-text-dark); margin: 0 0 1rem; }
     .legal h2 { font-size: 1.4rem; color: var(--color-text-dark); margin: 2rem 0 0.5rem; }


### PR DESCRIPTION
## The bug
On mobile, the long-form guide pages overflow horizontally — wide tables and long URLs run off the side of the screen, forcing you to zoom out and scroll sideways.

## Root cause
`#guide-content` is a CSS grid item (the `1fr` track) and a flex container. Grid/flex items default to `min-width: auto`, so they won't shrink below their widest child — a wide table or a long unbreakable URL (e.g. `https://www.youtube.com/watch?v=example`, in every row of the YouTube guide's table) expands the column past the viewport and forces the whole **page** to scroll.

## Fix (`guide.astro`)
- `#guide-content { min-width: 0 }` — the load-bearing fix: lets the column shrink to the viewport. Plus `overflow-wrap: break-word` for long URLs in prose/blockquotes.
- Tables → `display:block; width:100%; max-width:100%; overflow-x:auto` so a too-wide table scrolls **inside its own box** instead of widening the page (rounded corners preserved — `overflow-x:auto` reproduces the old `overflow:hidden` clipping). Cells get `overflow-wrap:anywhere` so long URLs break and most tables fit without scrolling at all.
- `pre` code blocks get an `overflow-x:auto` backstop; article side padding drops to 1.25rem under 640px.

## Also
- `GuideCardGrid`: `minmax(280px,1fr)` → `minmax(min(280px,100%),1fr)` so the guides hub + category cards don't overflow on ≤320px phones.
- `overflow-wrap:break-word` on the legal (privacy/terms) + about wrappers (defensive — they render external URLs).

## Verification
- `npm run build` clean; all rules confirmed in built CSS / prerendered HTML; no remaining unguarded `minmax(280px,…)`; guides contain no images/iframes, so tables + long URLs were the only overflow vectors.
- Pre-merge fresh-context CSS review — **safe to merge, zero blocking findings**: traced the 360px worst case (page no longer scrolls; contained table scroll is the acceptable outcome), confirmed **no desktop regression** (tables still fill the column; rounded corners intact), and found no other overflow vector on guide pages.

Note: I can't simulate your specific device here — please give it a quick check on your phone after deploy, but I'm confident it's resolved.
