### PR TITLE
Polish guide articles: superscript commas, table columns, CTA underline

### DIFF
--- a/src/components/astro/TryGenerator.astro
+++ b/src/components/astro/TryGenerator.astro
@@ -19,7 +19,7 @@ const {
 <aside class="try-generator" aria-labelledby="try-generator-heading">
     <h2 id="try-generator-heading">{heading}</h2>
     <p>{blurb}</p>
-    <a href="/" class="try-generator-cta">{cta} →</a>
+    <a href="/" class="try-generator-cta">{cta}</a>
 </aside>
 
 <style>
@@ -44,9 +44,10 @@ const {
         display: inline-block;
         font-weight: 510;
         color: var(--color-text-dark);
-        text-decoration: none;
+        /* Single underline only — no border-bottom (which, combined with the
+           inherited #guide-content underline, rendered as a double line). */
+        text-decoration: underline;
         padding: 0.5rem 0;
-        border-bottom: 1px solid currentColor;
     }
     .try-generator-cta:hover,
     .try-generator-cta:focus-visible {

--- a/src/content/guides/ama.mdx
+++ b/src/content/guides/ama.mdx
@@ -49,11 +49,11 @@ If the cited source supports only one clause of a longer sentence, place the num
 
 When a single claim cites several sources, list the numerals together in superscript. Consecutive numbers collapse to a range with a hyphen; non-consecutive numbers are separated by commas with no spaces.
 
-Consecutive: Three trials converge on this pattern.¹⁻³
+Consecutive: Three trials converge on this pattern.<sup>1-3</sup>
 
-Non-consecutive: Several reviews report the same effect.¹,⁴,⁷
+Non-consecutive: Several reviews report the same effect.<sup>1,4,7</sup>
 
-Mixed: A broader literature supports the finding.¹⁻³,⁷,⁹⁻¹¹
+Mixed: A broader literature supports the finding.<sup>1-3,7,9-11</sup>
 
 Some journal copy desks render the in-text numerals as parenthetical `(1)` instead of superscript — the Manual permits the parenthetical form when superscript is not available — but superscript is the *JAMA* default.
 

--- a/src/layouts/guide.astro
+++ b/src/layouts/guide.astro
@@ -170,12 +170,11 @@ const category = categoryByKey(frontmatter.category);
     #guide-content td {
         padding: 0.8rem 1rem;
         line-height: 1;
-        /* `anywhere` (unlike break-word) reduces the cell's min-content width,
-           so a table with long URLs can shrink to fit a phone instead of
-           forcing the whole table (and page) wider. Desktop has room, so
-           nothing breaks there; the table's own overflow-x is the backstop for
-           genuinely many-column tables. */
-        overflow-wrap: anywhere;
+        /* Keep natural column widths — cells inherit overflow-wrap:break-word
+           from #guide-content, which breaks long URLs but (unlike `anywhere`)
+           does NOT collapse a short label column to a single vertical letter.
+           A genuinely too-wide table scrolls horizontally via the table's own
+           overflow-x instead of squishing its columns. */
     }
     #guide-content td {
         padding-top: 0.6rem;


### PR DESCRIPTION
## What
Three article/mobile polish fixes you reported.

1. **Superscript commas (AMA guide).** The "Multiple sources in one citation" examples used Unicode superscript digits with **baseline** commas (`¹,⁴,⁷`), so the commas sat full-size next to the raised numerals. Those three body examples now use `<sup>1,4,7</sup>` / `<sup>1-3</sup>` / `<sup>1-3,7,9-11</sup>` so the whole token raises uniformly.
2. **Table columns regression (from the mobile-overflow PR).** `overflow-wrap: anywhere` on cells reduced their min-content so aggressively that a short label column ("Source type") collapsed to a single vertical letter. Removed it — cells now inherit `break-word`, keeping natural column widths; a genuinely too-wide table **scrolls horizontally** within its own box (no body widening), which is the intended behavior.
3. **"Open the generator" CTA.** It had a `border-bottom` **and** the inherited `#guide-content` underline (a double line) plus a `→` glyph. Removed the border-bottom and the arrow; it's now a single underlined text link.

## Verification
- `npm run build` clean. Built output confirms: AMA body renders `<sup>1,4,7</sup>` etc.; `overflow-wrap:anywhere` is gone from the guide CSS (cells inherit `break-word`); the CTA reads "Open the generator" with no arrow and no `border-bottom`.

## Discovered (NOT in this PR — flagging for a follow-up)
Guide **FAQ answers render markdown literally** — e.g. `**superscript Arabic numeral**` shows the asterisks — because `GuideFaq` uses `set:html` on raw frontmatter strings (the article body is markdown-processed, the FAQ is not). This affects every guide FAQ that uses `**bold**` or `[links]`. Worth its own fix (render the answers as markdown / sanitized HTML).
