### PR TITLE
Render guide FAQ answers as markdown

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "clsx": "^2.1.0",
         "github-slugger": "^2.0.0",
         "lucide-react": "^0.471.1",
+        "marked": "^18.0.4",
         "moment": "^2.30.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -7869,6 +7870,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "18.0.4",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.4.tgz",
+      "integrity": "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "clsx": "^2.1.0",
     "github-slugger": "^2.0.0",
     "lucide-react": "^0.471.1",
+    "marked": "^18.0.4",
     "moment": "^2.30.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/src/components/astro/GuideFaq.astro
+++ b/src/components/astro/GuideFaq.astro
@@ -2,6 +2,8 @@
 // src/components/astro/GuideFaq.astro
 // Renders visible FAQ markup as native <details>/<summary> elements
 // for accessibility + zero-JS expand/collapse.
+import { renderFaqAnswerHtml } from "../../lib/faq";
+
 interface FaqItem {
     question: string;
     answer: string;
@@ -21,7 +23,7 @@ const { items } = Astro.props;
             {items.map((item) => (
                 <details>
                     <summary>{item.question}</summary>
-                    <div class="faq-answer" set:html={item.answer} />
+                    <div class="faq-answer" set:html={renderFaqAnswerHtml(item.answer)} />
                 </details>
             ))}
         </div>

--- a/src/lib/faq.ts
+++ b/src/lib/faq.ts
@@ -1,0 +1,26 @@
+import { marked } from 'marked';
+
+// Guide FAQ answers (in each guide's frontmatter) are authored with inline
+// markdown — **bold**, `code`, *italic*, and [links](/guides/...). They are
+// shown via GuideFaq and also fed into FAQPage structured data.
+
+/**
+ * Render an answer's inline markdown to HTML for the visible <details> answer.
+ * (Answers are author-controlled frontmatter, so the HTML is trusted.)
+ */
+export function renderFaqAnswerHtml(answer: string): string {
+    return marked.parseInline(answer) as string;
+}
+
+/**
+ * Plain-text form for FAQPage structured data. Google's FAQ rich result only
+ * supports a limited set of HTML tags (no <code>), so strip the inline markdown
+ * markers to clean text rather than emit tags it would discard.
+ */
+export function faqAnswerText(answer: string): string {
+    return answer
+        .replace(/\[([^\]]+)\]\([^)]*\)/g, '$1') // [text](url) -> text
+        .replace(/\*\*([^*]+)\*\*/g, '$1') // **bold** -> bold
+        .replace(/\*([^*]+)\*/g, '$1') // *italic* -> italic
+        .replace(/`([^`]+)`/g, '$1'); // `code` -> code
+}

--- a/src/pages/guides/[...slug].astro
+++ b/src/pages/guides/[...slug].astro
@@ -11,6 +11,7 @@ import {
     buildFaqPage,
 } from "../../lib/schema-org";
 import { categoryByKey, categoryPath } from "../../lib/guide-categories";
+import { faqAnswerText } from "../../lib/faq";
 
 export async function getStaticPaths() {
     const entries = await getCollection("guides");
@@ -66,7 +67,12 @@ const breadcrumbSchema = buildBreadcrumbList([
 
 const extraSchemas: object[] = [articleSchema, breadcrumbSchema];
 if (entry.data.faq && entry.data.faq.length > 0) {
-    extraSchemas.push(buildFaqPage(entry.data.faq));
+    // Structured data gets plain-text answers (inline markdown stripped).
+    extraSchemas.push(
+        buildFaqPage(
+            entry.data.faq.map((f) => ({ question: f.question, answer: faqAnswerText(f.answer) })),
+        ),
+    );
 }
 ---
 

--- a/tests/lib/faq.test.ts
+++ b/tests/lib/faq.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { renderFaqAnswerHtml, faqAnswerText } from '../../src/lib/faq';
+
+describe('renderFaqAnswerHtml', () => {
+  it('renders inline markdown (bold, code, links) to HTML', () => {
+    const html = renderFaqAnswerHtml('A **bold** word, a `code` span, and a [link](/guides/apa).');
+    expect(html).toContain('<strong>bold</strong>');
+    expect(html).toContain('<code>code</code>');
+    expect(html).toContain('<a href="/guides/apa">link</a>');
+  });
+
+  it('does not wrap single-paragraph answers in a block element', () => {
+    expect(renderFaqAnswerHtml('plain text answer')).toBe('plain text answer');
+  });
+});
+
+describe('faqAnswerText', () => {
+  it('strips inline markdown to clean plain text for structured data', () => {
+    expect(
+      faqAnswerText('A **bold** word, a `code` span, and a [link](/guides/apa).'),
+    ).toBe('A bold word, a code span, and a link.');
+  });
+
+  it('leaves plain text untouched', () => {
+    expect(faqAnswerText('No markdown here.')).toBe('No markdown here.');
+  });
+});


### PR DESCRIPTION
## What
Fixes the discovered bug where guide **FAQ answers render markdown literally**.

Guide FAQ answers (in each guide's frontmatter) are authored with inline markdown — `**bold**`, `` `code` ``, `[links](/...)` — but `GuideFaq` injected them as raw HTML via `set:html`, so the markers showed literally (visible asterisks/backticks, broken links) while the article body (markdown-processed) rendered fine.

### Changes
- New `src/lib/faq.ts`:
  - `renderFaqAnswerHtml` → `marked.parseInline` for the visible `<details>` answer (bold/code/links render; no block `<p>` wrapping).
  - `faqAnswerText` → strips inline markdown to clean plain text for the **FAQPage structured data** (Google's FAQ rich result supports only a limited HTML tag set — no `<code>` — so plain text is safest there).
- `GuideFaq.astro` renders the answer HTML; `[...slug].astro` feeds stripped plain-text answers to `buildFaqPage`.
- `marked` added as a **build-time** dependency — guides are prerendered, so it never enters the Cloudflare worker bundle (verified: no `parseInline` anywhere in `dist`).

## Verification
- Built AMA guide: visible FAQ now renders `<strong>superscript Arabic numeral</strong>` and `<code>Chen MS</code>` (no literal `**`/backticks); the JSON-LD `acceptedAnswer.text` is clean plain text ("…prescribes a superscript Arabic numeral…").
- `npm test` → 388/388 (4 new `faq` tests).
- `marked` not present in `dist` (build-time only).
