### PR TITLE
Restore selection-based clipboard copy (fix lost paste formatting)

### DIFF
--- a/src/components/react/clipboard.ts
+++ b/src/components/react/clipboard.ts
@@ -1,17 +1,22 @@
-// Copy a citation to the clipboard preserving rich text (italics, the
-// Times-New-Roman / double-line-height styling that word processors honor on
-// paste). Uses the async Clipboard API with both `text/html` and `text/plain`
-// flavors, and falls back to the legacy execCommand selection method when the
-// async API or ClipboardItem is unavailable or rejects (e.g. permission denied,
-// document not focused, older browsers).
+// Copy a citation to the clipboard preserving rich text — italics AND the
+// Times-New-Roman / 12pt / double-line-height styling that word processors keep
+// on paste.
+//
+// IMPORTANT: the selection + execCommand('copy') path is the PRIMARY method. It
+// copies a *rendered, styled* DOM selection, so the browser serializes the
+// computed formatting onto the clipboard exactly the way Word / Google Docs
+// expect — this is the behavior that has always worked. A hand-built
+// `ClipboardItem` HTML fragment (the async Clipboard API) does NOT reliably
+// preserve that formatting across paste targets, so it is only a fallback for
+// the rare case where execCommand is unavailable or refused.
 
 const COPY_STYLE =
     'font-family:"Times New Roman",Times,serif;font-size:12pt;line-height:2;';
 
-// Legacy path: drop the HTML into an offscreen styled element, select it, and
-// run execCommand('copy'). This is what the app did before the async rewrite;
-// it carries the wrapper's inline styles onto the clipboard.
-function legacyCopyHtml(html: string): boolean {
+// Primary path: drop the HTML into an offscreen styled element, select it, and
+// run execCommand('copy'). The selection carries the element's styling onto the
+// clipboard, which is what preserves font/size/line-height/italics on paste.
+function copyViaSelection(html: string): boolean {
     if (typeof document === 'undefined') return false;
     const div = document.createElement('div');
     div.style.cssText = `position:fixed;left:-9999px;${COPY_STYLE}`;
@@ -35,33 +40,36 @@ function legacyCopyHtml(html: string): boolean {
     return ok;
 }
 
-/**
- * Copy rich text to the clipboard. `html` is the formatted markup (with `<i>`
- * for titles, etc.); `plain` is the text-only fallback flavor.
- * Returns true on success.
- */
-export async function copyRichText(html: string, plain: string): Promise<boolean> {
+// Fallback only: the async Clipboard API. Writes both flavors, but a bare
+// fragment loses much of the formatting on paste — used only if the selection
+// copy fails (e.g. execCommand disabled by policy).
+async function copyViaAsyncApi(html: string, plain: string): Promise<boolean> {
     const canUseAsync =
         typeof navigator !== 'undefined' &&
         !!navigator.clipboard &&
         typeof navigator.clipboard.write === 'function' &&
         typeof ClipboardItem !== 'undefined';
-
-    if (canUseAsync) {
-        try {
-            // Inline the formatting on a wrapper so pasted output keeps the
-            // citation's font/spacing the way the legacy selection copy did.
-            const styledHtml = `<div style="${COPY_STYLE}">${html}</div>`;
-            const item = new ClipboardItem({
-                'text/html': new Blob([styledHtml], { type: 'text/html' }),
-                'text/plain': new Blob([plain], { type: 'text/plain' }),
-            });
-            await navigator.clipboard.write([item]);
-            return true;
-        } catch {
-            // Fall through to the legacy path.
-        }
+    if (!canUseAsync) return false;
+    try {
+        const styledHtml = `<div style="${COPY_STYLE}">${html}</div>`;
+        const item = new ClipboardItem({
+            'text/html': new Blob([styledHtml], { type: 'text/html' }),
+            'text/plain': new Blob([plain], { type: 'text/plain' }),
+        });
+        await navigator.clipboard.write([item]);
+        return true;
+    } catch {
+        return false;
     }
+}
 
-    return legacyCopyHtml(html);
+/**
+ * Copy rich text to the clipboard. `html` is the formatted markup (with `<i>`
+ * for titles); `plain` is the text-only fallback flavor. Returns true on
+ * success. Uses the selection + execCommand copy first (preserves formatting),
+ * falling back to the async Clipboard API only if that fails.
+ */
+export async function copyRichText(html: string, plain: string): Promise<boolean> {
+    if (copyViaSelection(html)) return true;
+    return copyViaAsyncApi(html, plain);
 }

--- a/tests/client/clipboard.test.ts
+++ b/tests/client/clipboard.test.ts
@@ -12,7 +12,6 @@ const RT = [
 const clipboardDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
 
 afterEach(() => {
-    // Restore globals mutated by individual tests.
     if (clipboardDescriptor) {
         Object.defineProperty(navigator, 'clipboard', clipboardDescriptor);
     } else {
@@ -29,14 +28,44 @@ describe('richTextToPlain', () => {
     });
 });
 
-describe('copyRichText (async Clipboard API)', () => {
-    it('writes both text/html (with italics + styled wrapper) and text/plain, and returns true', async () => {
-        let captured: any;
-        const writeMock = vi.fn().mockResolvedValue(undefined);
-        Object.defineProperty(navigator, 'clipboard', {
-            value: { write: writeMock },
-            configurable: true,
+describe('copyRichText — primary: selection + execCommand (preserves formatting)', () => {
+    it('copies a styled offscreen element (font + italics) via execCommand and does NOT use the async API', async () => {
+        let styleAtCopy = '';
+        let htmlAtCopy = '';
+        (document as any).execCommand = vi.fn((cmd: string) => {
+            if (cmd === 'copy') {
+                const el = document.querySelector('div[style*="-9999px"]') as HTMLElement | null;
+                styleAtCopy = el?.getAttribute('style') ?? '';
+                htmlAtCopy = el?.innerHTML ?? '';
+            }
+            return true;
         });
+        // Async API is available, but must NOT be used when the selection copy works.
+        const write = vi.fn();
+        Object.defineProperty(navigator, 'clipboard', { value: { write }, configurable: true });
+        (globalThis as any).ClipboardItem = class {
+            constructor(_data: unknown) {}
+        };
+
+        const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
+
+        expect(ok).toBe(true);
+        expect(document.execCommand).toHaveBeenCalledWith('copy');
+        expect(write).not.toHaveBeenCalled();
+        // The copied element carried the Times New Roman styling and the italic title.
+        expect(styleAtCopy).toContain('Times New Roman');
+        expect(htmlAtCopy).toContain('<i>My Title</i>');
+        // Offscreen element cleaned up afterward.
+        expect(document.querySelectorAll('div[style*="-9999px"]').length).toBe(0);
+    });
+});
+
+describe('copyRichText — fallback: async Clipboard API', () => {
+    it('falls back to navigator.clipboard.write (both flavors) when execCommand fails', async () => {
+        (document as any).execCommand = vi.fn().mockReturnValue(false);
+        let captured: Record<string, Blob> | undefined;
+        const write = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', { value: { write }, configurable: true });
         (globalThis as any).ClipboardItem = class {
             data: Record<string, Blob>;
             constructor(data: Record<string, Blob>) {
@@ -48,61 +77,21 @@ describe('copyRichText (async Clipboard API)', () => {
         const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
 
         expect(ok).toBe(true);
-        expect(writeMock).toHaveBeenCalledTimes(1);
-        const html = await captured['text/html'].text();
-        const plain = await captured['text/plain'].text();
-        // Rich text preserved: italic title + the inline wrapper styling.
+        expect(write).toHaveBeenCalledTimes(1);
+        const html = await captured!['text/html'].text();
+        const plain = await captured!['text/plain'].text();
         expect(html).toContain('<i>My Title</i>');
         expect(html).toContain('Times New Roman');
-        // Plain flavor is text-only.
         expect(plain).toBe('Doe, Jane. My Title. Publisher, 2024.');
-        expect(plain).not.toContain('<i>');
-    });
-});
-
-describe('copyRichText (legacy fallback)', () => {
-    it('falls back to execCommand when the async API is unavailable', async () => {
-        // No navigator.clipboard / ClipboardItem available.
-        delete (navigator as any).clipboard;
-        delete (globalThis as any).ClipboardItem;
-        // jsdom does not implement execCommand; define it so the legacy path runs.
-        const exec = vi.fn().mockReturnValue(true);
-        (document as any).execCommand = exec;
-
-        const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
-
-        expect(ok).toBe(true);
-        expect(exec).toHaveBeenCalledWith('copy');
-        // The offscreen element used for the selection copy must be cleaned up.
-        expect(document.querySelectorAll('div[style*="-9999px"]').length).toBe(0);
     });
 
-    it('returns false when no async API is available and execCommand fails', async () => {
-        delete (navigator as any).clipboard;
-        delete (globalThis as any).ClipboardItem;
+    it('returns false when execCommand fails and no async API is available', async () => {
         (document as any).execCommand = vi.fn().mockReturnValue(false);
+        delete (navigator as any).clipboard;
+        delete (globalThis as any).ClipboardItem;
 
         const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
 
         expect(ok).toBe(false);
-        // Still cleaned up even on failure.
-        expect(document.querySelectorAll('div[style*="-9999px"]').length).toBe(0);
-    });
-
-    it('falls back to execCommand when the async write rejects', async () => {
-        Object.defineProperty(navigator, 'clipboard', {
-            value: { write: vi.fn().mockRejectedValue(new Error('denied')) },
-            configurable: true,
-        });
-        (globalThis as any).ClipboardItem = class {
-            constructor(_data: Record<string, Blob>) {}
-        };
-        const exec = vi.fn().mockReturnValue(true);
-        (document as any).execCommand = exec;
-
-        const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
-
-        expect(ok).toBe(true);
-        expect(exec).toHaveBeenCalledWith('copy');
     });
 });

--- a/tests/client/clipboard.test.ts
+++ b/tests/client/clipboard.test.ts
@@ -93,5 +93,7 @@ describe('copyRichText — fallback: async Clipboard API', () => {
         const ok = await copyRichText(richTextToHtml(RT), richTextToPlain(RT));
 
         expect(ok).toBe(false);
+        // Offscreen element cleaned up even when the copy fails.
+        expect(document.querySelectorAll('div[style*="-9999px"]').length).toBe(0);
     });
 });


### PR DESCRIPTION
## The regression
After PR #41 (async Clipboard API rewrite), copying a citation no longer preserved font / size / line-height / spacing on paste into Word or Google Docs. **Root cause:** the async path hands the OS a hand-built `<div style="…">…</div>` HTML fragment, and those paste targets don't honor a container fragment's styling the way they honor a *serialized DOM selection*. The pre-#41 `execCommand` copy worked because it selected a rendered, styled element and let the browser serialize the computed formatting onto the clipboard.

## Fix
Make the selection + `execCommand('copy')` method the **primary** copy path again (restores the exact behavior that always worked); demote the async Clipboard API to a **fallback** used only if `execCommand` is unavailable/refused. Italics + Times New Roman / 12pt / double-line-height are preserved on paste again.

- `clipboard.ts`: `copyRichText` now tries `copyViaSelection` first, then `copyViaAsyncApi`.
- Tests updated: assert selection-copy is primary (and that the styled element with italics is the copy source, with the async API NOT used when it succeeds), and that async is the fallback when `execCommand` fails.

## Verification
- `npm test` → 387/387.
- `npm run build` clean.
- Paste fidelity itself is a paste-target behavior I can't exercise here — but this restores the identical method that worked before #41, so please confirm a copy/paste into your editor after deploy.
