### PR TITLE
Fix landing-page content width; polish /guides cards + nav

### DIFF
--- a/src/components/astro/GuideCardGrid.astro
+++ b/src/components/astro/GuideCardGrid.astro
@@ -29,7 +29,7 @@ const { items } = Astro.props;
         padding: 0;
         margin: 0;
         display: grid;
-        gap: 0.75rem;
+        gap: 1rem;
         /* min(280px, 100%) so a single column can shrink below 280px on very
            narrow phones instead of forcing the grid (and page) wider. */
         grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
@@ -37,17 +37,25 @@ const { items } = Astro.props;
     .guide-grid a {
         display: flex;
         flex-direction: column;
-        gap: 0.25rem;
-        padding: 1rem 1.25rem;
+        gap: 0.35rem;
+        padding: 1.25rem 1.4rem;
+        background-color: var(--color-background-1);
         border: 1px solid var(--color-border);
-        border-radius: 10px;
+        border-radius: 15px;
+        box-shadow: 0 1px 2px rgba(26, 26, 26, 0.04),
+            0 2px 8px rgba(26, 26, 26, 0.05);
         text-decoration: none;
         color: var(--color-text-dark);
         height: 100%;
+        transition: transform 0.18s ease, box-shadow 0.18s ease,
+            border-color 0.18s ease;
     }
     .guide-grid a:hover,
     .guide-grid a:focus-visible {
-        background-color: var(--color-background-2);
+        border-color: var(--color-border-2);
+        box-shadow: 0 2px 4px rgba(26, 26, 26, 0.06),
+            0 8px 20px rgba(26, 26, 26, 0.1);
+        transform: translateY(-2px);
         outline: none;
     }
     .guide-grid a:focus-visible {
@@ -55,10 +63,23 @@ const { items } = Astro.props;
         outline-offset: 2px;
     }
     .guide-title {
-        font-weight: 510;
+        font-size: 1.05rem;
+        font-weight: 560;
+        line-height: 1.35;
+        color: var(--color-text-dark);
     }
     .guide-desc {
         font-size: 14px;
+        line-height: 1.5;
         color: var(--color-text-light);
+    }
+    @media (prefers-reduced-motion: reduce) {
+        .guide-grid a {
+            transition: box-shadow 0.18s ease, border-color 0.18s ease;
+        }
+        .guide-grid a:hover,
+        .guide-grid a:focus-visible {
+            transform: none;
+        }
     }
 </style>

--- a/src/components/astro/Header.astro
+++ b/src/components/astro/Header.astro
@@ -20,10 +20,9 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
   </div>
   <nav aria-label="Primary" id="primary-nav">
     <ul id="menu-content">
-      <li><a href={`${site}`}>Citation Generator</a></li>
       <li><a href={`${site}my-references`}>My References</a></li>
       <li class="sub-menu-trigger">
-        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="guides-submenu">Citation Guides</button>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="guides-submenu">Citation Guides<svg class="nav-chevron" width="14" height="14" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path></svg></button>
         <ul class="sub-menu" id="guides-submenu" role="menu">
           <li role="none"><a role="menuitem" href={`${site}guides`}>All Guides</a></li>
           <li role="none"><a role="menuitem" href={`${site}guides/research-and-works-cited`}>Mastering Your Sources</a></li>
@@ -34,7 +33,7 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
         </ul>
       </li>
       <li class="sub-menu-trigger">
-        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="generators-submenu">Citation Generators</button>
+        <button type="button" aria-haspopup="true" aria-expanded="false" aria-controls="generators-submenu">Citation Generators<svg class="nav-chevron" width="14" height="14" viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"></path></svg></button>
         <ul class="sub-menu" id="generators-submenu" role="menu">
           <li role="none"><a role="menuitem" href={`${site}apa-citation-generator`}>APA Generator</a></li>
           <li role="none"><a role="menuitem" href={`${site}mla-citation-generator`}>MLA Generator</a></li>
@@ -267,6 +266,26 @@ import { Bars3Icon } from "@heroicons/react/24/outline";
     outline: 2px solid var(--color-text-dark);
     outline-offset: 2px;
     border-radius: 4px;
+  }
+  /* Dropdown indicator: points down when closed, rotates up when the menu is
+     open via hover (desktop), keyboard focus, or aria-expanded (click). */
+  .nav-chevron {
+    display: inline-block;
+    vertical-align: middle;
+    margin-left: 0.25rem;
+    color: var(--color-text-light);
+    transition: transform 0.2s ease;
+  }
+  .sub-menu-trigger:hover .nav-chevron,
+  .sub-menu-trigger:focus-within .nav-chevron,
+  .sub-menu-trigger button[aria-expanded="true"] .nav-chevron {
+    transform: rotate(180deg);
+    color: var(--color-text-dark);
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .nav-chevron {
+      transition: none;
+    }
   }
 </style>
 

--- a/src/content/guides/apa.mdx
+++ b/src/content/guides/apa.mdx
@@ -9,7 +9,7 @@ tags: ['APA', 'citations', 'references', 'APA 7th edition', 'research', 'writing
 relatedGuides: ['mla', 'chicago', 'harvard', 'how-to-cite-a-website', 'in-text-citations', 'mla-vs-apa']
 faq:
   - question: "What's the difference between APA 6 and APA 7?"
-    answer: 'APA 7 introduced singular "they" as an acceptable pronoun, dropped "Retrieved from" before most URLs, italicized issue numbers in references, expanded the author-list cutoff from 7 names to 20 before using an ellipsis, and added explicit guidance for citing software, datasets, and social media. The Publication Manual moved from the 6th edition to the 7th edition in October 2019.'
+    answer: 'APA 7 introduced singular "they" as an acceptable pronoun, dropped "Retrieved from" before most URLs, expanded the author-list cutoff from 7 names to 20 before using an ellipsis, and added explicit guidance for citing software, datasets, and social media. The Publication Manual moved from the 6th edition to the 7th edition in October 2019.'
   - question: 'Do I need page numbers in APA in-text citations?'
     answer: 'You need page numbers only when you are quoting directly. For paraphrasing, the author and year are sufficient, though APA encourages including a page or paragraph number when it helps the reader locate the passage. For sources without pages (such as websites), use paragraph numbers, section headings, or timestamps.'
   - question: 'How many authors before I use "et al." in APA 7?'
@@ -112,7 +112,7 @@ Entries are alphabetized by the first author's surname. The whole page is double
 
 The seventh edition of the *Publication Manual* (American Psychological Association, 2020) prefers DOIs over URLs when both exist. A DOI is a permanent identifier; a URL can rot. Format DOIs as full hyperlinks (`https://doi.org/10.1037/cogdev0000412`) rather than as the bare string. URLs appear without the *Retrieved from* prefix that APA 6 required, except for sources designed to change over time, such as a Wikipedia article or a live data dashboard.
 
-The trickiest format detail is capitalization. APA uses **sentence case** for article and chapter titles — only the first word, the first word after a colon, and proper nouns are capitalized. It uses **title case** for journal names, book titles when they appear as standalone works, and report titles. The rule is asymmetric and feels arbitrary, but it has a reason: the journal is a proper noun (one specific publication) while the article title is a description. Get the asymmetry wrong and the reference list looks amateur. The volume number is italicized along with the journal name; the issue number is in parentheses and not italicized. Page ranges use an en dash, not a hyphen.
+The trickiest format detail is capitalization. APA uses **sentence case** for article and chapter titles — only the first word, the first word after a colon, and proper nouns are capitalized. The same sentence case applies to the titles of standalone works such as books and reports, which are italicized but still capitalized this way. **Title case** is reserved for journal names. The rule is asymmetric and feels arbitrary, but it has a reason: the journal is a proper noun (one specific publication) while the article title is a description. Get the asymmetry wrong and the reference list looks amateur. The volume number is italicized along with the journal name; the issue number is in parentheses and not italicized. Page ranges use an en dash, not a hyphen.
 
 ## Source-type examples
 

--- a/src/content/guides/harvard.mdx
+++ b/src/content/guides/harvard.mdx
@@ -130,7 +130,7 @@ Entries are alphabetised by the first author's surname. Where there is no named 
 
 The author element inverts the first author's name as surname-then-initials, with periods after each initial and no spaces between them: `Chen, M.S.` — not `Chen, M. S.` or `Chen, MS`. Subsequent authors follow the same format, joined by *and* before the final author. The year follows the author block in parentheses: `Chen, M.S. (2021)`.
 
-Titles divide along two lines. Book and journal titles are *italicised* and use **sentence case** — only the first word and any proper nouns are capitalised. Article and chapter titles sit inside double quotation marks, also in sentence case. The asymmetry is consistent: the container (book or journal) is italicised; the thing inside the container is quoted. Page ranges use *p.* for a single page and *pp.* for a range, with an en dash between numbers (`pp. 87–104`, not `pp. 87-104`).
+Titles divide along two lines. Book titles are *italicised* and use **sentence case** — only the first word and any proper nouns are capitalised. Journal titles are *italicised* too but take **title case**, because the journal name is a proper noun naming a specific publication. Article and chapter titles sit inside double quotation marks, in sentence case. The asymmetry is consistent: the container (book or journal) is italicised; the thing inside the container is quoted. Page ranges use *p.* for a single page and *pp.* for a range, with an en dash between numbers (`pp. 87–104`, not `pp. 87-104`).
 
 For online sources, Cite Them Right (Pears and Shields, 2022) prefixes the URL with `Available at:` and follows it with `(Accessed: May 20, 2026)`. DOIs take the same prefix but no access date, because DOIs are stable identifiers.
 

--- a/src/pages/ama-citation-generator.astro
+++ b/src/pages/ama-citation-generator.astro
@@ -153,7 +153,7 @@ const extraSchemas = [
     .page-body {
         max-width: 720px;
         margin: 0 auto;
-        padding: 3rem var(--page-inline-padding);
+        padding: 3rem 1.5rem;
         color: var(--color-text-medium);
         line-height: 1.6;
         overflow-wrap: break-word;
@@ -204,9 +204,25 @@ const extraSchemas = [
         user-select: none;
         line-height: 1.3;
         color: var(--color-text-dark);
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        gap: 1rem;
     }
     .faq[open] summary {
         margin-bottom: 1rem;
+    }
+    .faq[open] summary::after {
+        content: url("/icons/close.svg");
+        transform: translate(0, 2px);
+    }
+    .faq summary::after {
+        content: url("/icons/open.svg");
+        display: flex;
+        align-items: center;
+        transform: translate(-1px, 2px);
+        width: 20px;
+        height: 20px;
     }
     .faq-content {
         color: var(--color-text-light);

--- a/src/pages/apa-citation-generator.astro
+++ b/src/pages/apa-citation-generator.astro
@@ -151,7 +151,7 @@ const extraSchemas = [
     .apa-content {
         max-width: 720px;
         margin: 4rem auto 0;
-        padding: 0 var(--page-inline-padding);
+        padding: 0 1.5rem;
         color: var(--color-text-medium);
         line-height: 1.6;
         overflow-wrap: break-word;
@@ -182,7 +182,7 @@ const extraSchemas = [
     .apa-faq {
         max-width: 720px;
         margin: 3.5rem auto;
-        padding: 0 var(--page-inline-padding);
+        padding: 0 1.5rem;
     }
     .apa-faq h2 {
         font-size: 1.6rem;

--- a/src/pages/chicago-citation-generator.astro
+++ b/src/pages/chicago-citation-generator.astro
@@ -159,7 +159,7 @@ const extraSchemas = [
     .cite-guide {
         max-width: 720px;
         margin: 0 auto;
-        padding: min(calc(8vw + 2rem), 5rem) var(--page-inline-padding) 3rem;
+        padding: min(calc(8vw + 2rem), 5rem) 1.5rem 3rem;
         color: var(--color-text-light);
         line-height: 1.6;
         overflow-wrap: break-word;

--- a/src/pages/guides/category/[category].astro
+++ b/src/pages/guides/category/[category].astro
@@ -55,7 +55,7 @@ const breadcrumbSchema = buildBreadcrumbList([
 
 <style>
     .category-hub {
-        max-width: 900px;
+        max-width: 1080px;
         margin: 0 auto;
         padding: 4.5rem 2rem 3rem;
         color: var(--color-text-medium);

--- a/src/pages/guides/index.astro
+++ b/src/pages/guides/index.astro
@@ -52,7 +52,7 @@ const grouped = GUIDE_CATEGORIES.map((cat) => ({
 
 <style>
     .guides-hub {
-        max-width: 900px;
+        max-width: 1080px;
         margin: 0 auto;
         padding: 4.5rem 2rem 3rem;
         color: var(--color-text-medium);

--- a/src/pages/harvard-referencing-generator.astro
+++ b/src/pages/harvard-referencing-generator.astro
@@ -166,7 +166,7 @@ const extraSchemas = [
     .harvard-page {
         max-width: 720px;
         margin: 0 auto;
-        padding: min(calc(10vw + 2rem), 6rem) var(--page-inline-padding) 3rem;
+        padding: min(calc(10vw + 2rem), 6rem) 1.5rem 3rem;
         color: var(--color-text-light);
         line-height: 1.6;
         overflow-wrap: break-word;

--- a/src/pages/mla-citation-generator.astro
+++ b/src/pages/mla-citation-generator.astro
@@ -139,7 +139,7 @@ const extraSchemas = [
     .mla-content {
         max-width: 720px;
         margin: 4rem auto 0;
-        padding: 0 var(--page-inline-padding);
+        padding: 0 1.5rem;
         color: var(--color-text-light);
         line-height: 1.6;
         overflow-wrap: break-word;

--- a/src/pages/vancouver-citation-generator.astro
+++ b/src/pages/vancouver-citation-generator.astro
@@ -160,7 +160,7 @@ const extraSchemas = [
     .style-info {
         max-width: 720px;
         margin: 0 auto;
-        padding: 4rem var(--page-inline-padding) 1rem;
+        padding: 4rem 1.5rem 1rem;
         color: var(--color-text-medium);
         line-height: 1.6;
         overflow-wrap: break-word;


### PR DESCRIPTION
Follow-up to #47 addressing a reported layout bug + requested polish.

## Bug fix
The per-style generator landing pages rendered the text after the generator in a smooshed ~340px column on desktop. Root cause: the `*-content`/`*-faq` blocks had **both** `max-width: 720px` **and** `padding: 0 var(--page-inline-padding)` — and `--page-inline-padding` is `13.2vw` on desktop with Tailwind's `box-sizing: border-box`, so the padding ate into the 720px. Changed those blocks to a fixed `0 1.5rem` gutter; `#tool` keeps the full-width var inset. Fixed apa/mla/chicago/harvard/vancouver/ama (ieee already used the compensated `calc(720px + var*2)` idiom). Confirmed in the built output: `.apa-content` now `padding: 0 1.5rem`, `#tool` unchanged.

## Requested polish
- **/guides cards** (`GuideCardGrid`): card surface + subtle box-shadow elevation, 15px radius, hover lift + focus-visible state, refined typography, reduced-motion guard. Used by the hub and category pages.
- **Wider /guides container**: hub + category-hub `900px → 1080px`.
- **Nav**: removed the redundant "Citation Generator" item (logo + "Create Citation" CTA already go there); added **rotating chevrons** to the two dropdown triggers (open/closed via hover, focus, and `aria-expanded`).
- **AMA** landing page: added the missing FAQ expand/collapse icon.

## Accuracy
Corrected `apa.mdx` (volume not issue italicized; book/report titles sentence case; removed a non-APA-7 claim from the FAQ) and reconciled `harvard.mdx` journal-title-case inconsistency.

## Verification
Build green · 387 tests pass · width fix confirmed in built CSS · all PR-#47 pages smoke-tested live (200). Note: I could not run a live visual browser check (Chrome extension offline) — a glance at a landing page + the /guides cards + the nav chevrons is worth it on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q4gTmdtwMqUdgbgf42mrg6