### PR TITLE
Left-align the Citation Style dropdown label

### DIFF
--- a/src/styles/citation-search.module.css
+++ b/src/styles/citation-search.module.css
@@ -87,6 +87,13 @@
     color: var(--color-text-light);
 }
 
+/* Left-align the dropdown's "Citation Style" label, which otherwise inherits the
+   centered text-align of the homepage tool. Scoped to the dropdown so the
+   Website/Book input labels are unaffected. */
+.dropdown .inputLabel {
+    text-align: left;
+}
+
 .smallButton {
     font-size: 15px;
     font-weight: 440;


### PR DESCRIPTION
Small UI fix: the generator's "Citation Style" label inherited the centered text-align of the homepage tool. Adds `text-align: left` scoped to `.dropdown .inputLabel` so only that label changes (the Website/Book input labels share `.inputLabel` and are left untouched). Verified in compiled CSS: `_dropdown_… ._inputLabel_…{text-align:left}`. Build green, 387 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)