### PR TITLE
Widen landing-page body content to match the homepage (950px)

### DIFF
--- a/src/pages/ama-citation-generator.astro
+++ b/src/pages/ama-citation-generator.astro
@@ -151,7 +151,7 @@ const extraSchemas = [
     }
 
     .page-body {
-        max-width: 720px;
+        max-width: 950px;
         margin: 0 auto;
         padding: 3rem 1.5rem;
         color: var(--color-text-medium);

--- a/src/pages/apa-citation-generator.astro
+++ b/src/pages/apa-citation-generator.astro
@@ -149,7 +149,7 @@ const extraSchemas = [
         color: var(--color-text-light);
     }
     .apa-content {
-        max-width: 720px;
+        max-width: 950px;
         margin: 4rem auto 0;
         padding: 0 1.5rem;
         color: var(--color-text-medium);
@@ -180,7 +180,7 @@ const extraSchemas = [
         margin-top: 1.5rem;
     }
     .apa-faq {
-        max-width: 720px;
+        max-width: 950px;
         margin: 3.5rem auto;
         padding: 0 1.5rem;
     }

--- a/src/pages/chicago-citation-generator.astro
+++ b/src/pages/chicago-citation-generator.astro
@@ -157,7 +157,7 @@ const extraSchemas = [
 
     /* How-to-cite section */
     .cite-guide {
-        max-width: 720px;
+        max-width: 950px;
         margin: 0 auto;
         padding: min(calc(8vw + 2rem), 5rem) 1.5rem 3rem;
         color: var(--color-text-light);

--- a/src/pages/harvard-referencing-generator.astro
+++ b/src/pages/harvard-referencing-generator.astro
@@ -164,7 +164,7 @@ const extraSchemas = [
 
     /* How-to-cite article */
     .harvard-page {
-        max-width: 720px;
+        max-width: 950px;
         margin: 0 auto;
         padding: min(calc(10vw + 2rem), 6rem) 1.5rem 3rem;
         color: var(--color-text-light);
@@ -214,7 +214,7 @@ const extraSchemas = [
     .faq-container {
         display: grid;
         gap: 1rem;
-        max-width: calc(720px + var(--page-inline-padding) * 2);
+        max-width: calc(950px + var(--page-inline-padding) * 2);
         padding: 0 var(--page-inline-padding);
         margin: auto;
     }

--- a/src/pages/ieee-citation-generator.astro
+++ b/src/pages/ieee-citation-generator.astro
@@ -145,7 +145,7 @@ const extraSchemas = [
         color: var(--color-text-light);
     }
     .prose {
-        max-width: calc(720px + var(--page-inline-padding) * 2);
+        max-width: calc(950px + var(--page-inline-padding) * 2);
         padding: 0 var(--page-inline-padding);
         margin: auto;
         text-align: left;

--- a/src/pages/mla-citation-generator.astro
+++ b/src/pages/mla-citation-generator.astro
@@ -137,7 +137,7 @@ const extraSchemas = [
         color: var(--color-text-light);
     }
     .mla-content {
-        max-width: 720px;
+        max-width: 950px;
         margin: 4rem auto 0;
         padding: 0 1.5rem;
         color: var(--color-text-light);
@@ -172,7 +172,7 @@ const extraSchemas = [
     .faq-section .faq-container {
         display: grid;
         gap: 1rem;
-        max-width: calc(720px + var(--page-inline-padding) * 2);
+        max-width: calc(950px + var(--page-inline-padding) * 2);
         padding: 0 var(--page-inline-padding);
         margin: auto;
     }

--- a/src/pages/vancouver-citation-generator.astro
+++ b/src/pages/vancouver-citation-generator.astro
@@ -158,7 +158,7 @@ const extraSchemas = [
         color: var(--color-text-light);
     }
     .style-info {
-        max-width: 720px;
+        max-width: 950px;
         margin: 0 auto;
         padding: 4rem 1.5rem 1rem;
         color: var(--color-text-medium);


### PR DESCRIPTION
The per-style generator landing pages capped their prose ("How to cite in X") and FAQ blocks at 720px — narrower than the homepage body text (950px), and on a few pages even narrower than the page's own FAQ. Widened all those content/FAQ `max-width`s from 720px to 950px (keeping the compensated `calc(950px + var*2)` idiom and the 1.5rem mobile gutter). `#tool` and all else unchanged. Verified in built CSS (`.apa-content{max-width:950px…}`); build + 387 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)