### PR TITLE
FAQ: replace generic/over-claiming answers with accurate, product-grounded copy

### DIFF
--- a/src/content/index/faqs.ts
+++ b/src/content/index/faqs.ts
@@ -9,11 +9,11 @@ const faqs = [
     },
     {
         question: "How does MLA Generator work?",
-        answer: "<p>Paste a website's URL or a book's ISBN and choose your style. The tool fetches the page and reads the metadata publishers embed — or looks the ISBN up in book databases — then a structured citation engine formats the reference and the matching in-text citation. Every field stays editable, so you can correct or add anything the source didn't provide before you copy it. It works in all seven major styles, not just MLA.</p>",
+        answer: "<p>Paste a website's URL or a book's ISBN and choose your style. The tool fetches the page and reads the metadata publishers embed — or looks the ISBN up in book databases — then a structured citation engine formats the full reference. Every field stays editable, so you can correct or add anything the source didn't provide before you copy it. It works in all seven major styles, not just MLA.</p>",
     },
     {
         question: "What types of sources can your generator handle?",
-        answer: "<p>Automatically, from a link or ISBN: websites and books. For any other source type — journal articles, videos, images, reports, and more — you can enter the details by hand, and the <a href='/guides/'>citation guides</a> walk through exactly which fields each type needs in every style.</p>",
+        answer: "<p>Automatically, from a link or ISBN: websites and books. Journal articles can be added by hand in the editor. For other source types — videos, images, and more — our <a href='/guides/'>citation guides</a> show you exactly how to format each one in every style.</p>",
     },
     {
         question: "Is MLA Generator accurate?",

--- a/src/content/index/faqs.ts
+++ b/src/content/index/faqs.ts
@@ -1,37 +1,27 @@
 const faqs = [
     {
         question: "What is MLA format?",
-        answer: "<p>MLA (Modern Language Association) format is a widely used citation style within the humanities and liberal arts. It offers a standardized method for documenting sources you use in research papers. Following MLA format ensures your citations are clear, consistent, and easily understood by readers and educators.</p>",
+        answer: "<p>MLA (Modern Language Association) format is the citation style used across the humanities — literature, languages, and cultural studies. The current <a href='/guides/mla/'>MLA 9th edition</a> standardizes two things: brief in-text citations (an author's surname and a page number) and a full Works Cited list, so any reader can trace exactly where your information came from.</p>",
     },
     {
         question: "What elements are included in an MLA citation?",
-        answer: "<p>An MLA citation typically consists of the author's information, the title of the work you're referencing, publication details (publisher, date), and sometimes additional elements depending on the source type. For instance, you might need to include page numbers for books or website URLs for online sources.</p><p>If you're unsure about a specific source type, don't worry! Our comprehensive <a href='/guides/mla/'>MLA formatting guide</a> dives deeper into various citation formats and provides clear instructions to ensure you get it right every time.</p>",
+        answer: "<p>MLA 9 builds every Works Cited entry from the same nine core elements, used in a fixed order and only when they apply: author; title of source; title of container (the larger work it sits in); other contributors; version; number; publisher; publication date; and location (a page range, URL, or DOI). Our <a href='/guides/mla/'>MLA formatting guide</a> shows how each source type maps onto them, with a worked example for every one.</p>",
     },
     {
         question: "How does MLA Generator work?",
-        answer: "<p>Our MLA Generator is designed to simplify the process of creating citations in MLA format. It's a user-friendly tool that allows you to generate citations for a wide range of sources, including books, journal articles, and websites. Simply select the source type, fill in the required fields, and our MLA citation generator will do the rest!</p>",
+        answer: "<p>Paste a website's URL or a book's ISBN and choose your style. The tool fetches the page and reads the metadata publishers embed — or looks the ISBN up in book databases — then a structured citation engine formats the reference and the matching in-text citation. Every field stays editable, so you can correct or add anything the source didn't provide before you copy it. It works in all seven major styles, not just MLA.</p>",
     },
     {
         question: "What types of sources can your generator handle?",
-        answer: `
-            <p>Our MLA Generator can handle a wide range of source types, including:</p>
-            <ul>
-                <li>Books</li>
-                <li>Journal articles</li>
-                <li>Websites</li>
-                <li>eBooks</li>
-                <li>Videos</li>
-                <li>And more!</li>
-            </ul>
-        `,
+        answer: "<p>Automatically, from a link or ISBN: websites and books. For any other source type — journal articles, videos, images, reports, and more — you can enter the details by hand, and the <a href='/guides/'>citation guides</a> walk through exactly which fields each type needs in every style.</p>",
     },
     {
         question: "Is MLA Generator accurate?",
-        answer: "<p>Yes! Our MLA Generator is designed to produce accurate citations that comply with the latest MLA guidelines. We stay up-to-date with any changes to the MLA format to ensure our tool consistently delivers reliable results.</p>",
+        answer: "<p>The formatting is deterministic: punctuation, italics, and author order are applied by a structured citation engine against the published style manuals, not guessed. What still needs a human eye is the source data — automatically detected fields, especially the author and date on web pages, can be incomplete or wrong, so review them before you cite. Every guide on this site is written and reviewed against its style's current edition.</p>",
     },
     {
         question: "Is MLA Generator free to use?",
-        answer: "<p>Yes! Our MLA Generator is completely free to use. We believe that everyone should have access to the tools they need to succeed, which is why we offer our citation generator at no cost.</p><p>Whether you're a student, educator, or researcher, our MLA Generator is here to help you create accurate citations in a matter of seconds.</p>",
+        answer: "<p>Yes — completely free, with no account or sign-up. Every citation you generate is saved to your <a href='/my-references/'>My References</a> list in your browser's local storage, so it is still there when you come back. Clearing your browser data clears the list.</p>",
     },
 ];
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -162,8 +162,8 @@ const extraSchemas = [buildSoftwareApplication(), buildFaqPage(faqs)];
                     </li>
                     <li>Choose your citation style from the dropdown.</li>
                     <li>
-                        Generate: the tool retrieves what it can and formats both
-                        the reference and the in-text citation.
+                        Generate: the tool retrieves what it can and formats the
+                        full reference in your chosen style.
                     </li>
                     <li>
                         Review the fields — confirm the author and date, correct


### PR DESCRIPTION
## What & why

Follow-up to the homepage copy refresh (#55). The homepage FAQ (`src/content/index/faqs.ts`) was the same generic + mildly-over-claiming content the body essay had — "Is MLA Generator accurate? **Yes!**", "Simply select the source type…", and a source list ("Books, **Journal articles**, Websites, **eBooks**, **Videos**, And more!") that overstates what the widget auto-cites. These answers render as visible accordions **and** feed the `FAQPage` JSON-LD, so accuracy matters for both users and rich results.

## Changes (`src/content/index/faqs.ts`)

Kept the six questions (they target real searches — "what is MLA format", "is it free", etc.) and rewrote the answers to be specific, accurate, and consistent with the homepage body + the guides:

- **What is MLA format?** → MLA 9, humanities; in-text + Works Cited; links the MLA guide.
- **What elements…?** → MLA 9's nine core elements in fixed order (verified against `guides/mla.mdx`).
- **How does it work?** → paste a URL or ISBN → fetch page metadata / book-database lookup → deterministic citation engine → editable fields; all seven styles.
- **What types of sources…?** → **accurate**: websites + books automatically (URL/ISBN); journal articles, videos, etc. via **manual entry** (was: an auto-cite list that overstated the widget).
- **Is it accurate?** → **honest E-E-A-T**: formatting is deterministic (citeproc vs. the published manuals, not guessed); the *source data* needs your review (author/date on web pages); guides are edition-accurate. (Was: "Yes! …reliable results.")
- **Is it free?** → free, no account; references saved to `/my-references/` in browser localStorage.

Also touches **`src/pages/index.astro`** — see the review note below.

## Pre-merge verification (ultracode workflow)
A 5-agent adversarial workflow (accuracy-vs-code · schema/links/HTML · consistency · completeness → synthesis) verified the rewrite. Schema/links/HTML came back **clean** (FAQPage JSON-LD safe, all links slashed + resolving, HTML balanced). It caught **two real over-claims — now fixed** (both were emitted as structured data):
1. **In-text citation** — the tool only calls citeproc `makeBibliography()` (a reference), and produces no in-text citation anywhere in the code. Removed "and the matching in-text citation" from FAQ 3 **and** the identical claim in the homepage 4-step list (step 3, pre-existing from #55 — fixed here since it's the same false claim on the same page).
2. **Manual source types** — the editor exposes only Website/Book/Journal Article, so FAQ 4 no longer says videos/images/reports can be entered by hand (journal articles are hand-enterable; other types are covered by the guides).

Verified all other claims against code: MLA 9 nine core elements (vs `guides/mla.mdx`), fetch/ISBN-lookup/citeproc/editable pipeline, deterministic + no-AI, localStorage/no-account, 7 styles.

- Local `npm run build`/tests couldn't run (a Windows native-module crash in the fresh worktree) — **CI runs the authoritative `npm ci` + `npm test` on Linux**. Lightweight local checks passed: syntax valid, HTML balanced, all links slashed, `faqs.ts` shape unchanged (`faq.test.ts` tests the separate guide-markdown renderer, not this file).

## Deferred follow-up (pre-existing, flagged)
The homepage **meta description** (`index.astro:20`) and **`buildSoftwareApplication()`** schema still advertise citations "from a URL, DOI, or ISBN," but the automatic UI has no DOI input (Journal tab commented out). Left as-is here (the DOI *backend* exists, so it's defensible at the site level, and it's SEO-keyword/schema territory) — the clean resolution is **shipping the DOI/Journal tab**, which would make the claim fully true. Same item I flagged on #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
