### PR TITLE
Ship the DOI/Journal tab (+ reflect journal-article support in copy)

### DIFF
--- a/src/components/react/CitationSearch.tsx
+++ b/src/components/react/CitationSearch.tsx
@@ -35,7 +35,7 @@ const CitationSearch = forwardRef((props: { includeDropdown: Boolean, includeMan
     const tabPanels = [
         { label: "Website", placeholder: "Paste the website URL", name: "website" },
         { label: "Book", placeholder: "Enter an ISBN", name: "book" },
-        // { label: "Journal", placeholder: "Enter an ISBN", name: "journal" }
+        { label: "Journal", placeholder: "Enter a DOI", name: "journal" },
     ];
 
     return (

--- a/src/content/index/faqs.ts
+++ b/src/content/index/faqs.ts
@@ -9,11 +9,11 @@ const faqs = [
     },
     {
         question: "How does MLA Generator work?",
-        answer: "<p>Paste a website's URL or a book's ISBN and choose your style. The tool fetches the page and reads the metadata publishers embed — or looks the ISBN up in book databases — then a structured citation engine formats the full reference. Every field stays editable, so you can correct or add anything the source didn't provide before you copy it. It works in all seven major styles, not just MLA.</p>",
+        answer: "<p>Paste a website's URL, a book's ISBN, or a journal article's DOI and choose your style. The tool fetches the page and reads the metadata publishers embed — or looks an ISBN or DOI up in authority databases — then a structured citation engine formats the full reference. Every field stays editable, so you can correct or add anything the source didn't provide before you copy it. It works in all seven major styles, not just MLA.</p>",
     },
     {
         question: "What types of sources can your generator handle?",
-        answer: "<p>Automatically, from a link or ISBN: websites and books. Journal articles can be added by hand in the editor. For other source types — videos, images, and more — our <a href='/guides/'>citation guides</a> show you exactly how to format each one in every style.</p>",
+        answer: "<p>Automatically, from a URL, ISBN, or DOI: websites, books, and journal articles. For other source types — videos, images, and more — our <a href='/guides/'>citation guides</a> show you exactly how to format each one in every style.</p>",
     },
     {
         question: "Is MLA Generator accurate?",

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -101,8 +101,9 @@ const extraSchemas = [buildSoftwareApplication(), buildFaqPage(faqs)];
                     Most citation mistakes start with bad data, not bad
                     punctuation. Paste a link and the generator fetches the page
                     and reads the metadata publishers embed for exactly this
-                    purpose — author, title, site name, and date. An ISBN is
-                    looked up in book databases instead. Only then does a
+                    purpose — author, title, site name, and date. A book's ISBN
+                    or an article's DOI is matched to authority records instead.
+                    Only then does a
                     structured citation engine apply the punctuation, italics, and
                     author order your style requires. It never invents a field it
                     cannot find: missing details are left blank for you to fill,
@@ -112,10 +113,11 @@ const extraSchemas = [buildSoftwareApplication(), buildFaqPage(faqs)];
                 <h3 class="heading-3">What you can cite — and in which style</h3>
 
                 <p>
-                    The generator cites any website or book — paste a URL or an
-                    ISBN — and formats it in all seven major styles, each matched
-                    to its current edition. Which one you need usually comes from
-                    the assignment sheet or the discipline:
+                    The generator cites websites, books, and journal articles —
+                    from a URL, ISBN, or DOI — and formats them in all seven
+                    major styles, each matched to its current edition. Which one
+                    you need usually comes from the assignment sheet or the
+                    discipline:
                 </p>
 
                 <ul>
@@ -157,8 +159,9 @@ const extraSchemas = [buildSoftwareApplication(), buildFaqPage(faqs)];
 
                 <ol>
                     <li>
-                        Paste a website URL or a book's ISBN — or switch to
-                        manual entry for anything else.
+                        Paste a website URL, a book's ISBN, or a journal
+                        article's DOI — or switch to manual entry for anything
+                        else.
                     </li>
                     <li>Choose your citation style from the dropdown.</li>
                     <li>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -90,7 +90,7 @@ const extraSchemas = [buildSoftwareApplication(), buildFaqPage(faqs)];
                     publication date, a title copied in the wrong capitalization,
                     a URL saved without the article author, or a source entered
                     in APA when the assignment asked for MLA. MLA Generator is
-                    built around those details. Paste a URL or ISBN, pick
+                    built around those details. Paste a URL, ISBN, or DOI, pick
                     the style your paper requires, then review the editable
                     fields before you copy the finished reference.
                 </p>


### PR DESCRIPTION
## What & why

Surface the **DOI / journal-article** citation capability in the widget. The whole pipeline was already built and tested — only the UI tab was disabled. This is the clean resolution to the "cite from a DOI" claim that the meta description + `SoftwareApplication` schema have carried all along: instead of softening more copy, make the claim **true**.

## Changes (3 files, +14/−11)

- **`CitationSearch.tsx`** — enable the third tab: `{ label: "Journal", placeholder: "Enter a DOI", name: "journal" }` (was commented out, with a stale "Enter an ISBN" placeholder). Everything downstream already exists:
  - `SearchPanel` renders `name="journal"` → the form submits `?journal=<doi>` → `useReferences.ts:80-84` reads `journal`/`doi` → calls `/api/cite-journal?doi=` → `doi-detect.validateDoi` (accepts bare DOIs, `doi:` prefixes, and `doi.org` URLs) → Crossref→OpenAlex → `article-journal` CSL.
  - Tab CSS is flexbox (no 2-tab hardcoding); no test asserts the tab set.
- **`index.astro` + `faqs.ts`** — update the homepage + FAQ copy to accurately include journal articles: the tool now cites **websites, books, and journal articles — from a URL, ISBN, or DOI**. This makes the pre-existing meta-description + `SoftwareApplication` "from a URL, DOI, or ISBN" claim accurate (no over-claim anymore), without re-introducing the "in-text citation" error (still reference-only).

## Verification

- **Live backend, real DOI** (already deployed): `GET /api/cite-journal?doi=10.1038/171737a0` → full `article-journal` CSL:
  > Watson & Crick, "Molecular Structure of Nucleic Acids…", *Nature*, vol 171, iss 4356, pp 737–738, 1953. DOI URL input also returns 200.
- **Ultracode workflow** (UI-wiring · live end-to-end DOI+format · copy accuracy · edge/regression → synthesis): **verdict SHIP, zero blockers.** Its live-API sweep is the load-bearing evidence:
  - `/api/cite-journal` returned complete `article-journal` CSL (200) for every real Crossref DOI (nphys1170, PLoS ONE, Watson–Crick, Science, an APA-journal DOI); bare / URL-encoded / `doi.org` / `doi:` / UPPERCASE inputs all 200; garbage→400 `invalid_doi`, nonexistent→404, empty→400 — no 500s/crashes.
  - `POST /api/format` rendered the resulting journal CSL **correctly in all 7 styles** (correct container italics, author order, vol/issue/page, date, DOI), and degraded gracefully on missing fields.
  - Confirmed the wiring chain is intact and **no test asserts the tab set** (journal/DOI tests target the unchanged pipeline). Addressed its one nit (the intro now includes DOI for consistency).
- Local build/tests couldn't run (Windows native-module crash in the fresh worktree); **CI runs the authoritative `npm ci` + `npm test`** (includes `cite-journal.test.ts` + `useReferences.test.ts`). Post-deploy, I'll drive the actual tab in a real browser on production (paste a DOI → confirm a journal citation renders + formats).

## Notes (pre-existing, unchanged)
- Bad DOI → `cite-journal` 400 → `useReferences` logs and adds nothing (no user-facing error) — same behavior as a bad URL/ISBN today; not a regression.
- Hidden inactive tab inputs still submit, so a value typed in an earlier tab takes precedence (first non-empty wins in `useReferences`) — pre-existing for Website/Book; enabling Journal is consistent with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
