### PR TITLE
Citation reliability core: provenance + My References quality warnings (Phases 1-2; Browser/AI gated off)

### DIFF
--- a/docs/analytics.md
+++ b/docs/analytics.md
@@ -34,22 +34,25 @@ After the next deploy, every `/api/cite-website`, `/api/cite-book`, `/api/cite-j
 
 ## Excluding test traffic from analytics
 
-Any request that includes **either** of these signals skips analytics emission entirely — no row is written to the dataset, so the dashboard and SQL queries don't need to filter test traffic out:
+Any request that includes this signal skips analytics emission entirely — no row is written to the dataset, so the dashboard and SQL queries don't need to filter test traffic out:
 
 - HTTP header **`X-Mla-Test: 1`** (works for GET and POST)
-- Query param **`?nocache=1`** (reuses the existing cache-bypass convention)
 
-Use either for smoke tests, CI scripts, or any one-off curl probes against the production endpoints. Example:
+Use it for smoke tests, CI scripts, or any one-off curl probes against the production endpoints. Example:
 
 ```bash
-# Both of these are filtered from analytics
-curl 'https://mlagenerator.com/api/cite-website?url=https://en.wikipedia.org/wiki/Citation&nocache=1'
+curl 'https://mlagenerator.com/api/cite-website?url=https://en.wikipedia.org/wiki/Citation' \
+  -H 'X-Mla-Test: 1'
 curl 'https://mlagenerator.com/api/format' -X POST \
   -H 'X-Mla-Test: 1' -H 'content-type: application/json' \
   --data '{"csl":{"id":"u","type":"webpage","title":"smoke"},"style":"mla-9"}'
 ```
 
-Real user traffic never carries either signal, so this filter is operator-only.
+Real user traffic should never carry this header, so this filter is
+operator-only. Website cache bypasses and acquisition-mode overrides require the
+separate `CITATION_INTERNAL_DEBUG_TOKEN` flow documented in
+`docs/citation-reliability.md`; public query parameters do not control rendered
+acquisition or AI behavior.
 
 ## Querying
 

--- a/docs/citation-reliability.md
+++ b/docs/citation-reliability.md
@@ -1,0 +1,154 @@
+# Citation Reliability Runtime
+
+This project can run the AI-assisted citation reliability pipeline without
+rendering, but AI assist and rendered acquisition only activate when their
+server-side Cloudflare bindings are configured.
+
+The implementation intentionally follows the existing Pages-dashboard setup
+instead of adding a `wrangler.toml`; see `docs/analytics.md` for the same
+deployment rationale.
+
+## Cloudflare Bindings
+
+Add these under the Cloudflare Pages project settings:
+
+| Binding | Type | Purpose |
+| --- | --- | --- |
+| `AI` | Workers AI | Enables evidence-bounded missing-field extraction. This is the preferred default. |
+| `BROWSER_RENDERER` | Service binding | Optional. Calls the separate Browser Run Worker in `workers/browser-renderer`. |
+| `ANALYTICS` | Analytics Engine | Already supported; records acquisition and citation telemetry. |
+
+If `BROWSER_RENDERER` is absent, `/api/cite-website` still uses normal fetch and
+returns quality warnings that can ask the user to try the extension or manual
+entry. If `AI` is absent, citation generation and deterministic warnings still
+work.
+
+Cloudflare Pages currently exposes Service bindings in the dashboard list, but
+not a direct Browser Run binding. Use the included Worker instead:
+
+1. Deploy `workers/browser-renderer` as `mla-browser-renderer`.
+2. The Worker owns the direct Browser Run binding named `BROWSER`.
+3. Add a Pages Service binding named `BROWSER_RENDERER` pointing at
+   `mla-browser-renderer`.
+4. If the renderer Worker has a public route or workers.dev enabled, set the
+   same secret value as `RENDERER_SHARED_SECRET` on the Worker and
+   `BROWSER_RENDERER_TOKEN` on the Pages project.
+
+Browser Run `.quickAction()` requires a compatibility date of `2026-03-24` or
+newer in the deployed Worker. Local testing of Browser Run needs Workers remote
+mode; normal local Pages previews should be treated as fetch-only unless the
+service binding is explicitly available.
+
+The render stage is for ordinary JavaScript-rendered pages, not stealth bot
+evasion. It sets a clear MLA Generator user agent and reports blocked/partial
+states back to the user when a site denies automated access.
+
+## Optional AI Gateway
+
+Workers AI can be used directly through the `AI` binding. To route calls through
+AI Gateway instead, leave `AI` unset and configure:
+
+| Variable | Purpose |
+| --- | --- |
+| `AI_GATEWAY_CHAT_URL` | Full Gateway chat-completions URL. Example: `https://api.cloudflare.com/client/v4/accounts/<account>/ai/v1/chat/completions`. |
+| `AI_GATEWAY_TOKEN` | Cloudflare token or provider token required by the Gateway endpoint. |
+| `AI_GATEWAY_ID` | Optional `cf-aig-gateway-id` header value. |
+| `AI_GATEWAY_MODEL` | Model name sent in the Gateway payload, for example `openai/gpt-5.4-nano`. |
+
+`AI_CITATION_MODEL` overrides `AI_GATEWAY_MODEL` and the Workers AI default for
+the citation pipeline.
+
+## Runtime Behavior
+
+`/api/cite-website` is intentionally server-policy driven. Public clients can
+only submit a URL; they cannot force render, force fetch-only, force AI, or
+bypass cache.
+
+Server policy:
+
+- Fetch first.
+- Render only when concrete page signals indicate incomplete or blocked static
+  content and `BROWSER_RENDERER` is configured.
+- Run AI assist only when the `AI` binding or Gateway is available and the
+  extracted citation is missing useful fields.
+- Cache successful website citations under the current pipeline cache version.
+
+Environment controls:
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `CITATION_RENDERING_ENABLED` | enabled | Set to `0` to disable rendered acquisition without removing the binding. |
+| `CITATION_AI_ASSIST_ENABLED` | enabled | Set to `0` to disable AI missing-field assist. |
+| `CITATION_AI_CHECK_ENABLED` | disabled | Set to `1` to allow `/api/quality/check` to run AI sanity checks. |
+| `CITATION_INTERNAL_DEBUG_TOKEN` | unset | Optional secret for internal eval/debug overrides. |
+| `BROWSER_RENDERER_TOKEN` | unset | Optional shared secret sent to the renderer Worker. |
+
+When `CITATION_INTERNAL_DEBUG_TOKEN` is set, internal callers can send
+`x-mla-internal-token: <token>` to allow eval-only `acquisition` and `nocache`
+query overrides. Do not expose this token to browsers.
+
+Every successful response can include:
+
+- `_provenance`: field-level winning evidence, candidates, and conflicts.
+- `_quality`: conservative warnings and acquisition attempts.
+
+Old clients can ignore both fields. The React reference UI stores and displays
+them when present.
+
+## Manual Eval
+
+Run a preview server first, then:
+
+```bash
+npm run eval:citation-acquisition -- --base-url http://localhost:8788
+```
+
+Use a custom sample:
+
+```bash
+npm run eval:citation-acquisition -- --base-url https://preview.example.pages.dev --sample path/to/urls.json
+```
+
+To bypass cache or force an acquisition mode during an internal eval, provide
+the secret token:
+
+```bash
+npm run eval:citation-acquisition -- --base-url https://preview.example.pages.dev --internal-token <token>
+```
+
+The eval output includes success count, average latency, field counts, warning
+rate, render usage, AI usage, and per-URL acquisition states.
+
+## Repeatable Smoke Tests
+
+The citation smoke matrix lives in `tests/e2e/pipeline.test.ts`. It exercises
+the full local path from HTML to CSL extraction, conservative quality warnings,
+and formatted bibliography output in every supported style:
+
+- MLA 9
+- APA 7
+- Chicago 18 author-date
+- AMA 11
+- Cite Them Right 12th edition Harvard
+- IEEE
+- NLM/Vancouver
+
+The matrix includes real saved-page fixtures for scholarly articles, large
+author lists, news sites, government pages, blogs, Wikipedia, and bare HTML, plus
+synthetic edge cases for DOI-only early-view journal articles, conflicting news
+metadata, and corporate-author/no-date government pages.
+
+Style baselines checked during the smoke review:
+
+- MLA: `https://style.mla.org/works-cited/citations-by-format/`
+- APA: `https://apastyle.apa.org/instructional-aids/reference-examples.pdf`
+- Chicago: `https://www.chicagomanualofstyle.org/tools_citationguide.html`
+- AMA: `https://www.amamanualofstyle.com/view/10.1093/jama/9780190246556.001.0001/med-9780190246556-chapter-3-div1-50`
+- Cite Them Right Harvard: `https://university.open.ac.uk/library/referencing-and-plagiarism/quick-guide-to-harvard-referencing-cite-them-right`
+- IEEE: `https://journals.ieeeauthorcenter.ieee.org/your-role-in-article-production/ieee-editorial-style-manual/`
+- NLM/Vancouver: `https://www.nlm.nih.gov/bsd/uniform_requirements.html`
+
+For exact formatter regression coverage, run `tests/format/format.test.ts`.
+That corpus compares every source-type fixture against golden output in every
+supported style. The e2e smoke matrix complements it by proving extracted data
+keeps the required style-specific locators and author/title/source structure.

--- a/functions/api/cite-journal/handler.ts
+++ b/functions/api/cite-journal/handler.ts
@@ -29,10 +29,11 @@ export async function handleCiteJournal(
     writeEvent(analytics, 'error', { endpoint: 'cite_journal', code: 'invalid_doi' }, { count: 1 });
     return errorResponse(400, 'invalid_doi', 'Malformed DOI');
   }
+  if (!doi && rawUrl) doi = validateDoi(rawUrl);
 
   if (!doi) {
     writeEvent(analytics, 'error', { endpoint: 'cite_journal', code: 'invalid_doi' }, { count: 1 });
-    return errorResponse(400, 'invalid_doi', 'cite-journal currently requires a doi parameter; use cite-website for non-DOI articles');
+    return errorResponse(400, 'invalid_doi', 'cite-journal currently requires a DOI value or doi.org URL; use cite-website for non-DOI articles');
   }
 
   const cacheKey = `https://cache.mlagenerator/journal/${doi}`;

--- a/functions/api/cite-website/handler.ts
+++ b/functions/api/cite-website/handler.ts
@@ -2,18 +2,39 @@ import { runExtractionPipeline } from '../../lib/extract/pipeline';
 import { fetchHtml, FetchError } from '../../lib/extract/fetch';
 import { normalizeUrl } from '../../lib/extract/url-normalize';
 import { TTL } from '../../lib/cache';
-import type { ExtractEnvelope } from '../../lib/csl-types';
+import type { AcquisitionAttempt, AcquisitionSource, CSLDate, ExtractEnvelope } from '../../lib/csl-types';
 import { writeEvent, type AnalyticsBinding } from '../../lib/analytics';
+import { analyzeHtmlReadiness, extractReadableText, shouldTryRenderedAcquisition, type PageReadiness } from '../../lib/acquisition/page-readiness';
+import { renderHtmlWithBrowserRun, RenderError, type BrowserRunBinding } from '../../lib/acquisition/browser-run';
+import { mergePipelineResults, addEvidenceToResult, type MergedCitationEvidence } from '../../lib/provenance/merge';
+import { validateCitationQuality } from '../../lib/validation/citation-quality';
+import { runAiFieldAssist, type AiBinding } from '../../lib/ai/citation-assist';
+import type { PipelineResult } from '../../lib/extract/pipeline';
 
 export interface MinCache {
   get(key: string): Promise<Response | undefined>;
   put(key: string, response: Response, maxAgeSeconds: number): Promise<void>;
 }
 
+export interface CiteWebsiteDeps {
+  browser?: BrowserRunBinding;
+  ai?: AiBinding;
+  aiModel?: string;
+  acquisitionMode?: AcquisitionMode;
+  aiAssistEnabled?: boolean;
+  bypassCache?: boolean;
+  renderingEnabled?: boolean;
+}
+
+type AcquisitionMode = 'auto' | 'fetch' | 'render';
+const WEBSITE_CACHE_VERSION = 'citation-website-v2';
+
 export async function handleCiteWebsite(
   requestUrl: URL,
   cache: MinCache | null,
   analytics?: AnalyticsBinding,
+  now = new Date(),
+  deps: CiteWebsiteDeps = {},
 ): Promise<Response> {
   const raw = requestUrl.searchParams.get('url');
   if (!raw) {
@@ -31,13 +52,21 @@ export async function handleCiteWebsite(
   }
 
   const host = hostOf(target);
+  const mode = deps.acquisitionMode ?? 'auto';
+  const aiEnabled = deps.aiAssistEnabled !== false;
 
-  const bypassCache = requestUrl.searchParams.get('nocache') === '1';
-  if (cache && !bypassCache) {
-    const hit = await cache.get(target);
+  const bypassCache = deps.bypassCache === true;
+  const allowCache = mode !== 'render';
+  const cacheKey = cacheKeyFor(target);
+  if (cache && !bypassCache && allowCache) {
+    const hit = await cache.get(cacheKey);
     if (hit) {
       const body = await hit.json() as ExtractEnvelope;
       body._cached = true;
+      body._quality = body._quality ?? validateCitationQuality(body.csl, {
+        provenance: body._provenance,
+        acquisition: body._quality?.acquisition,
+      });
       writeEvent(analytics, 'cite_website',
         {
           signal_winner_title: body._signals?.title ?? '',
@@ -51,30 +80,154 @@ export async function handleCiteWebsite(
     }
   }
 
-  let html: string;
-  let finalUrl: string;
-  const fetchStart = Date.now();
-  try {
-    ({ html, finalUrl } = await fetchHtml(target));
-  } catch (err) {
-    if (err instanceof FetchError) {
-      writeEvent(analytics, 'error', { endpoint: 'cite_website', code: err.code }, { count: 1 });
-      return errorResponse(400, err.code, err.message, err.retryable);
-    }
-    writeEvent(analytics, 'error', { endpoint: 'cite_website', code: 'internal' }, { count: 1 });
-    return errorResponse(500, 'internal', String((err as Error).message), false);
-  }
-  const fetchMs = Date.now() - fetchStart;
+  const acquiredAt = now.toISOString();
+  const attempts: Partial<Record<AcquisitionSource, AcquisitionAttempt>> = {};
+  const results: PipelineResult[] = [];
+  let fetchedHtml = '';
+  let renderedHtml = '';
+  let fetchMs = 0;
+  let extractionMs = 0;
+  let finalUrl = target;
+  let fetchReadiness: PageReadiness | undefined;
 
-  const extractStart = Date.now();
-  const { csl, signals } = runExtractionPipeline(html, finalUrl);
-  const extractionMs = Date.now() - extractStart;
+  if (mode !== 'render') {
+    const fetchStart = Date.now();
+    try {
+      const fetched = await fetchHtml(target);
+      fetchedHtml = fetched.html;
+      finalUrl = fetched.finalUrl;
+      fetchMs = Date.now() - fetchStart;
+      const readiness = analyzeHtmlReadiness(fetchedHtml, finalUrl);
+      fetchReadiness = readiness;
+      const extractStart = Date.now();
+      const result = runExtractionPipeline(fetchedHtml, finalUrl, { acquisition: 'fetch', acquiredAt });
+      extractionMs += Date.now() - extractStart;
+      attempts.fetch = attemptFromReadiness('fetch', readiness, target, finalUrl, fetchMs, fetchedHtml, result);
+      results.push(result);
+    } catch (err) {
+      fetchMs = Date.now() - fetchStart;
+      if (err instanceof FetchError) {
+        attempts.fetch = {
+          source: 'fetch',
+          status: statusFromFetchError(err),
+          reason: err.message,
+          url: target,
+          durationMs: fetchMs,
+        };
+        writeEvent(analytics, 'error', { endpoint: 'cite_website', code: err.code }, { count: 1 });
+        if (!deps.browser || mode === 'fetch') {
+          return errorResponse(400, err.code, err.message, err.retryable);
+        }
+      } else {
+        attempts.fetch = {
+          source: 'fetch',
+          status: 'error',
+          reason: String((err as Error).message),
+          url: target,
+          durationMs: fetchMs,
+        };
+        writeEvent(analytics, 'error', { endpoint: 'cite_website', code: 'internal' }, { count: 1 });
+        if (!deps.browser || mode === 'fetch') {
+          return errorResponse(500, 'internal', String((err as Error).message), false);
+        }
+      }
+    }
+  }
+
+  const fetchResult = results[0];
+  const renderWanted = deps.renderingEnabled !== false && shouldRender(mode, fetchResult, attempts.fetch, fetchReadiness);
+  if (renderWanted) {
+    if (!deps.browser) {
+      attempts.render = {
+        source: 'render',
+        status: 'skipped',
+        reason: 'Browser Run binding is not configured.',
+        url: target,
+      };
+      if (!results.length) {
+        return errorResponse(400, 'render_unavailable', 'Browser rendering is not configured.', true);
+      }
+    } else {
+      const renderStart = Date.now();
+      try {
+        const rendered = await renderHtmlWithBrowserRun(deps.browser, target);
+        renderedHtml = rendered.html;
+        const readiness = analyzeHtmlReadiness(renderedHtml, target);
+        const extractStart = Date.now();
+        const result = runExtractionPipeline(renderedHtml, target, { acquisition: 'render', acquiredAt });
+        extractionMs += Date.now() - extractStart;
+        attempts.render = attemptFromReadiness(
+          'render',
+          readiness,
+          target,
+          target,
+          Date.now() - renderStart,
+          renderedHtml,
+          result,
+          rendered.browserMs,
+        );
+        results.push(result);
+      } catch (err) {
+        attempts.render = {
+          source: 'render',
+          status: err instanceof RenderError && err.code === 'render_timeout' ? 'timeout' : 'error',
+          reason: (err as Error).message,
+          url: target,
+          durationMs: Date.now() - renderStart,
+        };
+        if (!results.length) {
+          return errorResponse(400, err instanceof RenderError ? err.code : 'render_failed', (err as Error).message, true);
+        }
+      }
+    }
+  }
+
+  let merged = mergePipelineResults(results, finalUrl || target);
+  if (deps.ai && aiEnabled && shouldRunAiAssist(merged.csl, fetchedHtml, renderedHtml)) {
+    const aiStart = Date.now();
+    try {
+      const evidence = await runAiFieldAssist({
+        ai: deps.ai,
+        model: deps.aiModel,
+        csl: merged.csl,
+        fetchedText: extractReadableText(fetchedHtml),
+        renderedText: extractReadableText(renderedHtml),
+        url: finalUrl || target,
+        acquiredAt,
+      });
+      attempts.ai = {
+        source: 'ai',
+        status: evidence.length ? 'success' : 'partial',
+        reason: evidence.length ? 'AI suggested evidence-backed fields.' : 'AI returned no usable evidence-backed fields.',
+        url: target,
+        durationMs: Date.now() - aiStart,
+        fieldsFound: evidence.map((item) => String(item.field)),
+      };
+      if (evidence.length) merged = addEvidenceToResult(merged, evidence);
+    } catch (err) {
+      attempts.ai = {
+        source: 'ai',
+        status: 'error',
+        reason: (err as Error).message,
+        url: target,
+        durationMs: Date.now() - aiStart,
+      };
+    }
+  }
+
+  merged = withAccessDate(merged, now);
+  const quality = validateCitationQuality(merged.csl, {
+    provenance: merged.provenance,
+    acquisition: attempts,
+  });
 
   const envelope: ExtractEnvelope = {
     uuid: target,
-    type: 'webpage',
-    csl,
-    _signals: signals,
+    type: merged.csl.type,
+    csl: merged.csl,
+    _signals: merged.signals,
+    _provenance: merged.provenance,
+    _quality: quality,
     _cached: false,
   };
   const response = jsonResponse(envelope);
@@ -85,21 +238,22 @@ export async function handleCiteWebsite(
   // dashboard wants to see.
   writeEvent(analytics, 'cite_website',
     {
-      signal_winner_title: signals.title ?? '',
-      signal_winner_url: signals.URL ?? '',
+      signal_winner_title: merged.signals.title ?? '',
+      signal_winner_url: merged.signals.URL ?? '',
       host,
       url: target,
     },
     {
-      html_size_kb: Math.round(html.length / 1024),
+      html_size_kb: Math.round((fetchedHtml || renderedHtml).length / 1024),
       extraction_ms: extractionMs,
       cache_hit: 0,
       fetch_ms: fetchMs,
     },
   );
+  writeAcquisitionEvents(analytics, host, attempts);
 
-  if (cache && !bypassCache) {
-    await cache.put(target, response.clone(), TTL.WEBSITE);
+  if (cache && !bypassCache && allowCache) {
+    await cache.put(cacheKey, response.clone(), TTL.WEBSITE);
   }
   return response;
 }
@@ -114,9 +268,114 @@ function jsonResponse(body: unknown): Response {
   });
 }
 
+function dateFrom(date: Date): CSLDate {
+  return {
+    'date-parts': [[date.getUTCFullYear(), date.getUTCMonth() + 1, date.getUTCDate()]],
+  };
+}
+
 function errorResponse(status: number, code: string, message: string, retryable: boolean): Response {
   return new Response(JSON.stringify({ error: message, code, retryable }), {
     status,
     headers: { 'content-type': 'application/json' },
   });
+}
+
+export function acquisitionMode(value: string | null): AcquisitionMode {
+  return value === 'fetch' || value === 'render' || value === 'auto' ? value : 'auto';
+}
+
+function cacheKeyFor(target: string): string {
+  return `https://cache.mlagenerator.local/${WEBSITE_CACHE_VERSION}?url=${encodeURIComponent(target)}`;
+}
+
+function statusFromFetchError(err: FetchError): AcquisitionAttempt['status'] {
+  if (err.code === 'blocked') return 'blocked';
+  if (err.code === 'timeout') return 'timeout';
+  return err.retryable ? 'partial' : 'error';
+}
+
+function attemptFromReadiness(
+  source: AcquisitionSource,
+  readiness: PageReadiness,
+  url: string,
+  finalUrl: string,
+  durationMs: number,
+  html: string,
+  result: PipelineResult,
+  browserMs?: number,
+): AcquisitionAttempt {
+  const status = readiness.status === 'ready' ? 'success' : readiness.status;
+  return {
+    source,
+    status,
+    reason: readiness.reason,
+    url,
+    finalUrl,
+    durationMs,
+    htmlSizeKb: Math.round(html.length / 1024),
+    browserMs,
+    fieldsFound: Object.keys(result.signals),
+  };
+}
+
+function shouldRender(
+  mode: AcquisitionMode,
+  result: PipelineResult | undefined,
+  fetchAttempt: AcquisitionAttempt | undefined,
+  readiness: PageReadiness | undefined,
+): boolean {
+  if (mode === 'render') return true;
+  if (mode === 'fetch') return false;
+  if (!result) return fetchAttempt?.status === 'blocked' || fetchAttempt?.status === 'timeout' || fetchAttempt?.status === 'partial';
+  const fallbackReadiness: PageReadiness = {
+    status: fetchAttempt?.status === 'success' ? 'ready' : fetchAttempt?.status === 'blocked' ? 'blocked' : 'partial',
+    title: '',
+    textLength: 0,
+    metadataFieldCount: result.provenance ? Object.keys(result.provenance).length : 0,
+    articleLikeTextLength: 0,
+    scriptTextLength: 0,
+    blockerSignals: [],
+    stableSignals: [],
+    reason: fetchAttempt?.reason || '',
+  };
+  return shouldTryRenderedAcquisition(result.csl, readiness ?? fallbackReadiness);
+}
+
+function shouldRunAiAssist(csl: MergedCitationEvidence['csl'], fetchedHtml: string, renderedHtml: string): boolean {
+  if (!fetchedHtml && !renderedHtml) return false;
+  return !csl.title || !csl.author?.length || !csl.issued?.['date-parts']?.[0]?.[0] || !csl.publisher || !csl['container-title'];
+}
+
+function withAccessDate(result: MergedCitationEvidence, now: Date): MergedCitationEvidence {
+  return {
+    ...result,
+    csl: {
+      ...result.csl,
+      accessed: result.csl.accessed ?? dateFrom(now),
+    },
+  };
+}
+
+function writeAcquisitionEvents(
+  analytics: AnalyticsBinding | undefined,
+  host: string,
+  attempts: Partial<Record<AcquisitionSource, AcquisitionAttempt>>,
+): void {
+  for (const attempt of Object.values(attempts)) {
+    if (!attempt) continue;
+    writeEvent(analytics, 'cite_website_acquisition',
+      {
+        host,
+        source: attempt.source,
+        status: attempt.status,
+        reason: attempt.reason ?? '',
+      },
+      {
+        duration_ms: attempt.durationMs ?? 0,
+        html_size_kb: attempt.htmlSizeKb ?? 0,
+        browser_ms: attempt.browserMs ?? 0,
+      },
+    );
+  }
 }

--- a/functions/api/cite-website/index.ts
+++ b/functions/api/cite-website/index.ts
@@ -1,14 +1,49 @@
-import { handleCiteWebsite } from './handler';
+import { acquisitionMode, handleCiteWebsite } from './handler';
 import { defaultCacheStore } from '../../lib/cache';
 import type { AnalyticsBinding } from '../../lib/analytics';
 import { isTestRequest } from '../../lib/test-context';
+import { createBrowserRunBindingFromService, type BrowserRendererServiceBinding, type BrowserRunBinding } from '../../lib/acquisition/browser-run';
+import type { AiBinding } from '../../lib/ai/citation-assist';
+import { createAiGatewayBinding, type AiGatewayEnv } from '../../lib/ai/gateway';
 
-interface Env { ANALYTICS?: AnalyticsBinding }
+interface Env extends AiGatewayEnv {
+  ANALYTICS?: AnalyticsBinding;
+  BROWSER?: BrowserRunBinding;
+  BROWSER_RENDERER?: BrowserRendererServiceBinding;
+  AI?: AiBinding;
+  AI_CITATION_MODEL?: string;
+  AI_GATEWAY_MODEL?: string;
+  CITATION_INTERNAL_DEBUG_TOKEN?: string;
+  CITATION_RENDERING_ENABLED?: string;
+  CITATION_AI_ASSIST_ENABLED?: string;
+  BROWSER_RENDERER_TOKEN?: string;
+}
 
 export const onRequest: PagesFunction<Env> = async (context) => {
   const url = new URL(context.request.url);
-  // Test traffic (X-Mla-Test:1 or ?nocache=1) gets undefined binding so no
-  // data point lands in the dataset. Production dashboard stays clean.
+  // Test traffic gets undefined binding so no data point lands in the dataset.
+  // Production dashboard stays clean.
   const analytics = isTestRequest(context.request) ? undefined : context.env.ANALYTICS;
-  return handleCiteWebsite(url, defaultCacheStore(), analytics);
+  const ai = context.env.AI ?? createAiGatewayBinding(context.env);
+  const internalDebug = isInternalDebugRequest(context.request, context.env.CITATION_INTERNAL_DEBUG_TOKEN);
+  const browser = context.env.BROWSER ?? createBrowserRunBindingFromService(
+    context.env.BROWSER_RENDERER,
+    context.env.BROWSER_RENDERER_TOKEN,
+  );
+
+  return handleCiteWebsite(url, defaultCacheStore(), analytics, new Date(), {
+    browser,
+    ai,
+    aiModel: context.env.AI_CITATION_MODEL || context.env.AI_GATEWAY_MODEL,
+    acquisitionMode: internalDebug ? acquisitionMode(url.searchParams.get('acquisition')) : 'auto',
+    bypassCache: internalDebug && url.searchParams.get('nocache') === '1',
+    aiAssistEnabled: context.env.CITATION_AI_ASSIST_ENABLED === '1',
+    renderingEnabled: context.env.CITATION_RENDERING_ENABLED === '1',
+  });
 };
+
+function isInternalDebugRequest(request: Request, token: string | undefined): boolean {
+  if (!token) return false;
+  const provided = request.headers.get('x-mla-internal-token');
+  return typeof provided === 'string' && provided.length > 0 && provided === token;
+}

--- a/functions/api/format/handler.ts
+++ b/functions/api/format/handler.ts
@@ -2,7 +2,7 @@ import type { CSLItem, FormatRequest, FormatResponse, SupportedStyle } from '../
 import { formatCitation } from '../../lib/format/citeproc';
 import { writeEvent, type AnalyticsBinding } from '../../lib/analytics';
 
-const SUPPORTED: SupportedStyle[] = ['mla-9', 'apa-7', 'chicago-18', 'ama-11', 'harvard', 'ieee', 'vancouver'];
+export const SUPPORTED_STYLES: SupportedStyle[] = ['mla-9', 'apa-7', 'chicago-18', 'ama-11', 'harvard', 'ieee', 'vancouver'];
 
 export async function handleFormat(req: Request, analytics?: AnalyticsBinding): Promise<Response> {
   const start = Date.now();
@@ -21,9 +21,9 @@ export async function handleFormat(req: Request, analytics?: AnalyticsBinding): 
     writeEvent(analytics, 'error', { endpoint: 'format', code: 'bad_request' }, { count: 1 });
     return error(400, 'bad_request', 'Missing csl');
   }
-  if (!parsed.style || !SUPPORTED.includes(parsed.style)) {
+  if (!parsed.style || !SUPPORTED_STYLES.includes(parsed.style)) {
     writeEvent(analytics, 'error', { endpoint: 'format', code: 'bad_request' }, { count: 1 });
-    return error(400, 'bad_request', `Unsupported style. Allowed: ${SUPPORTED.join(', ')}`);
+    return error(400, 'bad_request', `Unsupported style. Allowed: ${SUPPORTED_STYLES.join(', ')}`);
   }
   try {
     const formatted = formatCitation(parsed.csl as CSLItem, parsed.style);

--- a/functions/api/quality/check/handler.ts
+++ b/functions/api/quality/check/handler.ts
@@ -1,0 +1,65 @@
+import type { CSLItem, ExtractQuality, FieldProvenance, SupportedStyle } from '../../../lib/csl-types';
+import { validateCitationQuality } from '../../../lib/validation/citation-quality';
+import { runAiCitationCheck } from '../../../lib/ai/citation-check';
+import type { AiBinding } from '../../../lib/ai/citation-assist';
+
+const SUPPORTED_STYLES: SupportedStyle[] = ['mla-9', 'apa-7', 'chicago-18', 'ama-11', 'harvard', 'ieee', 'vancouver'];
+
+export interface QualityCheckDeps {
+  ai?: AiBinding;
+  aiModel?: string;
+  aiCheckEnabled?: boolean;
+}
+
+interface QualityCheckRequest {
+  csl?: CSLItem;
+  style?: SupportedStyle;
+  provenance?: Partial<Record<keyof CSLItem, FieldProvenance>>;
+}
+
+export async function handleQualityCheck(request: Request, deps: QualityCheckDeps = {}): Promise<Response> {
+  let body: QualityCheckRequest;
+  try {
+    body = await request.json() as QualityCheckRequest;
+  } catch {
+    return json({ error: 'Invalid JSON', code: 'bad_request' }, 400);
+  }
+
+  if (!body.csl || typeof body.csl !== 'object') {
+    return json({ error: 'Missing csl', code: 'bad_request' }, 400);
+  }
+  const style = SUPPORTED_STYLES.includes(body.style as SupportedStyle) ? body.style as SupportedStyle : 'mla-9';
+  const base = validateCitationQuality(body.csl, {
+    style,
+    provenance: body.provenance,
+  });
+
+  let quality: ExtractQuality = base;
+  if (deps.aiCheckEnabled && deps.ai) {
+    try {
+      const aiWarnings = await runAiCitationCheck({
+        ai: deps.ai,
+        model: deps.aiModel,
+        csl: body.csl,
+        style,
+        existingWarnings: base.warnings,
+      });
+      quality = {
+        ...base,
+        warnings: [...base.warnings, ...aiWarnings],
+        score: Math.max(0, base.score - aiWarnings.length * 5),
+      };
+    } catch {
+      quality = base;
+    }
+  }
+
+  return json({ quality });
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}

--- a/functions/api/quality/check/index.ts
+++ b/functions/api/quality/check/index.ts
@@ -1,0 +1,19 @@
+import { handleQualityCheck } from './handler';
+import type { AiBinding } from '../../../lib/ai/citation-assist';
+import { createAiGatewayBinding, type AiGatewayEnv } from '../../../lib/ai/gateway';
+
+interface Env extends AiGatewayEnv {
+  AI?: AiBinding;
+  AI_CITATION_MODEL?: string;
+  AI_GATEWAY_MODEL?: string;
+  CITATION_AI_CHECK_ENABLED?: string;
+}
+
+export const onRequest: PagesFunction<Env> = async (context) => {
+  const ai = context.env.AI ?? createAiGatewayBinding(context.env);
+  return handleQualityCheck(context.request, {
+    ai,
+    aiModel: context.env.AI_CITATION_MODEL || context.env.AI_GATEWAY_MODEL,
+    aiCheckEnabled: context.env.CITATION_AI_CHECK_ENABLED === '1',
+  });
+};

--- a/functions/lib/acquisition/browser-run.ts
+++ b/functions/lib/acquisition/browser-run.ts
@@ -1,0 +1,111 @@
+const RENDER_TIMEOUT_MS = 12_000;
+const UA = 'Mozilla/5.0 (compatible; mlagenerator/1.0; +https://mlagenerator.com)';
+
+export interface BrowserRunBinding {
+  quickAction(action: string, body: Record<string, unknown>): Promise<Response | string | Record<string, unknown>>;
+}
+
+export interface BrowserRendererServiceBinding {
+  fetch(input: Request | string, init?: RequestInit): Promise<Response>;
+}
+
+export interface RenderedHtmlResult {
+  html: string;
+  browserMs?: number;
+}
+
+export class RenderError extends Error {
+  constructor(
+    message: string,
+    public readonly code: 'render_failed' | 'render_timeout' | 'render_empty',
+    public readonly retryable: boolean,
+  ) {
+    super(message);
+    this.name = 'RenderError';
+  }
+}
+
+export async function renderHtmlWithBrowserRun(
+  browser: BrowserRunBinding,
+  url: string,
+): Promise<RenderedHtmlResult> {
+  const started = Date.now();
+  try {
+    const response = await withTimeout(browser.quickAction('content', {
+      url,
+      userAgent: UA,
+      gotoOptions: { waitUntil: 'networkidle2' },
+      rejectResourceTypes: ['image', 'font', 'media'],
+    }), RENDER_TIMEOUT_MS);
+    const { html, browserMs } = await normalizeQuickActionResponse(response);
+    if (!html.trim()) throw new RenderError('Browser Run returned empty HTML', 'render_empty', true);
+    return { html, browserMs: browserMs ?? Date.now() - started };
+  } catch (err) {
+    if (err instanceof RenderError) throw err;
+    if ((err as any)?.name === 'AbortError') {
+      throw new RenderError('Browser Run timed out', 'render_timeout', true);
+    }
+    throw new RenderError(`Browser Run failed: ${(err as Error).message}`, 'render_failed', true);
+  }
+}
+
+export function createBrowserRunBindingFromService(
+  service: BrowserRendererServiceBinding | undefined,
+  token?: string,
+): BrowserRunBinding | undefined {
+  if (!service) return undefined;
+  return {
+    async quickAction(action, body) {
+      const headers: Record<string, string> = { 'content-type': 'application/json' };
+      if (token) headers['x-browser-renderer-token'] = token;
+      return service.fetch('https://browser-renderer.internal/', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ action, ...body }),
+      });
+    },
+  };
+}
+
+async function normalizeQuickActionResponse(response: Response | string | Record<string, unknown>): Promise<RenderedHtmlResult> {
+  if (typeof response === 'string') return { html: response };
+  if (response instanceof Response) {
+    const browserMsRaw = response.headers.get('X-Browser-Ms-Used') || response.headers.get('x-browser-ms-used');
+    const browserMs = browserMsRaw ? parseInt(browserMsRaw, 10) : undefined;
+    const text = await response.text();
+    return { html: htmlFromText(text), browserMs: Number.isFinite(browserMs) ? browserMs : undefined };
+  }
+  const html = htmlFromObject(response);
+  return { html };
+}
+
+function htmlFromText(text: string): string {
+  const trimmed = text.trim();
+  if (!trimmed.startsWith('{')) return text;
+  try {
+    return htmlFromObject(JSON.parse(trimmed));
+  } catch {
+    return text;
+  }
+}
+
+function htmlFromObject(value: Record<string, unknown>): string {
+  for (const key of ['result', 'content', 'html']) {
+    const candidate = value[key];
+    if (typeof candidate === 'string') return candidate;
+  }
+  const nested = value.result;
+  if (nested && typeof nested === 'object') return htmlFromObject(nested as Record<string, unknown>);
+  return JSON.stringify(value);
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  const ctrl = new AbortController();
+  const timeout = setTimeout(() => ctrl.abort(), timeoutMs);
+  return Promise.race([
+    promise,
+    new Promise<T>((_, reject) => {
+      ctrl.signal.addEventListener('abort', () => reject(new DOMException('Timed out', 'AbortError')), { once: true });
+    }),
+  ]).finally(() => clearTimeout(timeout));
+}

--- a/functions/lib/acquisition/page-readiness.ts
+++ b/functions/lib/acquisition/page-readiness.ts
@@ -1,0 +1,162 @@
+import * as cheerio from 'cheerio';
+import type { CSLItem } from '../csl-types';
+
+const BLOCKER_PATTERNS = [
+  /access denied/i,
+  /captcha/i,
+  /checking your browser/i,
+  /enable javascript/i,
+  /just a moment/i,
+  /unusual traffic/i,
+  /verify you are human/i,
+  /temporarily blocked/i,
+  /forbidden/i,
+];
+
+const GENERIC_TITLE_PATTERNS = [
+  /^loading/i,
+  /^just a moment/i,
+  /^access denied/i,
+  /^error/i,
+  /^403\b/i,
+  /^attention required/i,
+];
+
+export interface PageReadiness {
+  status: 'ready' | 'partial' | 'blocked' | 'timeout' | 'empty';
+  title: string;
+  canonicalUrl?: string;
+  textLength: number;
+  metadataFieldCount: number;
+  articleLikeTextLength: number;
+  scriptTextLength: number;
+  blockerSignals: string[];
+  stableSignals: string[];
+  reason: string;
+}
+
+export function analyzeHtmlReadiness(html: string, url: string): PageReadiness {
+  if (!html.trim()) {
+    return emptyReadiness('empty', 'No HTML was returned.');
+  }
+
+  const $ = cheerio.load(html);
+  const title = $('title').first().text().replace(/\s+/g, ' ').trim();
+  const canonicalUrl = $('link[rel="canonical" i]').first().attr('href')?.trim();
+  const metadataFieldCount = $('meta[content], script[type="application/ld+json"], [itemprop]').length;
+  const scriptTextLength = $('script').toArray().reduce((sum, el) => sum + ($(el).html() || '').length, 0);
+
+  const bodyForText = $('body').clone();
+  bodyForText.find('script, style, noscript, svg, nav, footer').remove();
+  const text = bodyForText.text().replace(/\s+/g, ' ').trim();
+  const textLength = text.length;
+  const articleLikeTextLength = $('article, main, [role="main"], [class*="article" i], [class*="story" i]')
+    .toArray()
+    .reduce((sum, el) => sum + $(el).text().replace(/\s+/g, ' ').trim().length, 0);
+  const combined = `${title}\n${text.slice(0, 5000)}`;
+  const blockerSignals = BLOCKER_PATTERNS
+    .filter((pattern) => pattern.test(combined))
+    .map((pattern) => pattern.source);
+
+  if (blockerSignals.length) {
+    return {
+      status: 'blocked',
+      title,
+      canonicalUrl: resolveUrl(canonicalUrl, url),
+      textLength,
+      metadataFieldCount,
+      articleLikeTextLength,
+      scriptTextLength,
+      blockerSignals,
+      stableSignals: [],
+      reason: 'The page content matched an automated-access blocker.',
+    };
+  }
+
+  const stableSignals: string[] = [];
+  if (title && !GENERIC_TITLE_PATTERNS.some((pattern) => pattern.test(title))) stableSignals.push('meaningful-title');
+  if (canonicalUrl) stableSignals.push('canonical-url');
+  if (metadataFieldCount >= 3) stableSignals.push('metadata');
+  if (textLength >= 600) stableSignals.push('body-text');
+  if (articleLikeTextLength >= 300) stableSignals.push('article-like-text');
+
+  if (!title && textLength < 100 && metadataFieldCount === 0) {
+    return {
+      status: 'empty',
+      title,
+      canonicalUrl: resolveUrl(canonicalUrl, url),
+      textLength,
+      metadataFieldCount,
+      articleLikeTextLength,
+      scriptTextLength,
+      blockerSignals,
+      stableSignals,
+      reason: 'The page had almost no readable content or metadata.',
+    };
+  }
+
+  if (stableSignals.includes('meaningful-title') && (metadataFieldCount >= 3 || textLength >= 600)) {
+    return {
+      status: 'ready',
+      title,
+      canonicalUrl: resolveUrl(canonicalUrl, url),
+      textLength,
+      metadataFieldCount,
+      articleLikeTextLength,
+      scriptTextLength,
+      blockerSignals,
+      stableSignals,
+      reason: 'The page had a meaningful title plus metadata or readable body text.',
+    };
+  }
+
+  return {
+    status: 'partial',
+    title,
+    canonicalUrl: resolveUrl(canonicalUrl, url),
+    textLength,
+    metadataFieldCount,
+    articleLikeTextLength,
+    scriptTextLength,
+    blockerSignals,
+    stableSignals,
+    reason: 'The page appeared incomplete or thin after static fetch.',
+  };
+}
+
+export function shouldTryRenderedAcquisition(csl: CSLItem, readiness: PageReadiness): boolean {
+  if (readiness.status === 'blocked' || readiness.status === 'empty' || readiness.status === 'partial') return true;
+  if (!csl.title || !csl.author?.length || !csl.issued?.['date-parts']?.[0]?.[0]) {
+    return readiness.scriptTextLength > readiness.textLength * 2 || readiness.textLength < 800;
+  }
+  return false;
+}
+
+export function extractReadableText(html: string, maxChars = 7000): string {
+  const $ = cheerio.load(html);
+  $('script, style, noscript, svg, nav, footer').remove();
+  return $('body').text().replace(/\s+/g, ' ').trim().slice(0, maxChars);
+}
+
+function emptyReadiness(status: PageReadiness['status'], reason: string): PageReadiness {
+  return {
+    status,
+    title: '',
+    textLength: 0,
+    metadataFieldCount: 0,
+    articleLikeTextLength: 0,
+    scriptTextLength: 0,
+    blockerSignals: [],
+    stableSignals: [],
+    reason,
+  };
+}
+
+function resolveUrl(value: string | undefined, base: string): string | undefined {
+  if (!value) return undefined;
+  try {
+    return new URL(value, base).href;
+  } catch {
+    return value;
+  }
+}

--- a/functions/lib/ai/citation-assist.ts
+++ b/functions/lib/ai/citation-assist.ts
@@ -1,0 +1,215 @@
+import type { CSLDate, CSLItem, FieldEvidence } from '../csl-types';
+import { parseAuthorList } from '../extract/author-parse';
+import { parseDate } from '../extract/date-parse';
+
+const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
+const MIN_CONFIDENCE = 0.7;
+
+export interface AiBinding {
+  run(model: string, input: Record<string, unknown>): Promise<unknown>;
+}
+
+export interface AiAssistInput {
+  ai: AiBinding;
+  model?: string;
+  csl: CSLItem;
+  fetchedText?: string;
+  renderedText?: string;
+  url: string;
+  acquiredAt?: string;
+}
+
+interface AiProposal {
+  field: keyof CSLItem;
+  value: unknown;
+  evidenceSnippet: string;
+  evidenceSource: 'fetched' | 'rendered' | 'pasted' | 'extension';
+  rationale?: string;
+  confidence: number;
+}
+
+const FIELD_SCHEMA = {
+  type: 'object',
+  properties: {
+    proposals: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          field: {
+            type: 'string',
+            enum: ['title', 'author', 'issued', 'publisher', 'container-title', 'URL', 'DOI', 'volume', 'issue', 'page', 'abstract'],
+          },
+          value: {},
+          evidenceSnippet: { type: 'string' },
+          evidenceSource: { type: 'string', enum: ['fetched', 'rendered', 'pasted', 'extension'] },
+          rationale: { type: 'string' },
+          confidence: { type: 'number' },
+        },
+        required: ['field', 'value', 'evidenceSnippet', 'evidenceSource', 'confidence'],
+      },
+    },
+  },
+  required: ['proposals'],
+};
+
+export async function runAiFieldAssist(input: AiAssistInput): Promise<FieldEvidence[]> {
+  const sourceText = combinedSourceText(input);
+  if (sourceText.length < 50) return [];
+
+  const response = await input.ai.run(input.model || DEFAULT_MODEL, {
+    messages: [
+      {
+        role: 'system',
+        content: [
+          'You extract citation fields only from provided source text.',
+          'Do not invent missing fields.',
+          'Return only fields with a direct evidenceSnippet copied from the provided text.',
+          'Do not format citations.',
+        ].join(' '),
+      },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          url: input.url,
+          existingCsl: input.csl,
+          missingFields: missingFields(input.csl),
+          fetchedText: input.fetchedText || '',
+          renderedText: input.renderedText || '',
+        }),
+      },
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: FIELD_SCHEMA,
+    },
+  });
+
+  return parseAiProposals(response)
+    .map((proposal) => evidenceFromProposal(proposal, input, sourceText))
+    .filter((item): item is FieldEvidence => !!item);
+}
+
+function parseAiProposals(response: unknown): AiProposal[] {
+  const parsed = parseModelJson(response);
+  const proposals = parsed?.proposals;
+  if (!Array.isArray(proposals)) return [];
+  return proposals.filter((item): item is AiProposal => {
+    if (!item || typeof item !== 'object') return false;
+    const proposal = item as AiProposal;
+    return typeof proposal.field === 'string'
+      && proposal.value !== undefined
+      && typeof proposal.evidenceSnippet === 'string'
+      && typeof proposal.evidenceSource === 'string'
+      && typeof proposal.confidence === 'number';
+  });
+}
+
+function parseModelJson(response: unknown): any {
+  if (!response) return null;
+  if (typeof response === 'string') return parseJson(response);
+  if (typeof response !== 'object') return null;
+  const obj = response as Record<string, any>;
+  for (const key of ['response', 'result', 'content', 'text']) {
+    if (typeof obj[key] === 'string') {
+      const parsed = parseJson(obj[key]);
+      if (parsed) return parsed;
+    }
+    if (obj[key] && typeof obj[key] === 'object') {
+      const parsed = parseModelJson(obj[key]);
+      if (parsed) return parsed;
+    }
+  }
+  if (Array.isArray(obj.choices)) {
+    for (const choice of obj.choices) {
+      const parsed = parseModelJson(choice?.message?.content ?? choice?.text);
+      if (parsed) return parsed;
+    }
+  }
+  if (Array.isArray(obj.proposals)) return obj;
+  return null;
+}
+
+function parseJson(value: string): any {
+  try {
+    return JSON.parse(value);
+  } catch {
+    const match = value.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function evidenceFromProposal(
+  proposal: AiProposal,
+  input: AiAssistInput,
+  sourceText: string,
+): FieldEvidence | null {
+  if (!Number.isFinite(proposal.confidence) || proposal.confidence < MIN_CONFIDENCE || proposal.confidence > 1) return null;
+  const snippet = normalizeText(proposal.evidenceSnippet);
+  if (!snippet || !normalizeText(sourceText).includes(snippet)) return null;
+  const normalizedValue = normalizeFieldValue(proposal.field, proposal.value);
+  if (normalizedValue === undefined) return null;
+  if ((input.csl as any)[proposal.field] !== undefined) return null;
+  return {
+    field: proposal.field,
+    normalizedValue,
+    rawValue: typeof proposal.value === 'string' ? proposal.value : JSON.stringify(proposal.value),
+    source: 'ai-extract',
+    acquisition: 'ai',
+    snippet: proposal.evidenceSnippet,
+    confidence: Math.min(0.82, proposal.confidence),
+    acquiredAt: input.acquiredAt,
+  };
+}
+
+function normalizeFieldValue(field: keyof CSLItem, value: unknown): unknown {
+  if (field === 'author') {
+    if (Array.isArray(value)) {
+      const parsed = value.flatMap((item) => parseAuthorList(String(item)));
+      return parsed.length ? parsed : undefined;
+    }
+    if (typeof value === 'string') {
+      const parsed = parseAuthorList(value);
+      return parsed.length ? parsed : undefined;
+    }
+    return undefined;
+  }
+  if (field === 'issued') {
+    if (typeof value === 'string') return dateFromString(value);
+    if (value && typeof value === 'object' && Array.isArray((value as CSLDate)['date-parts'])) return value;
+    return undefined;
+  }
+  if (typeof value === 'string' || typeof value === 'number') {
+    const text = String(value).replace(/\s+/g, ' ').trim();
+    return text || undefined;
+  }
+  return undefined;
+}
+
+function dateFromString(value: string): CSLDate | undefined {
+  const parsed = parseDate(value);
+  return parsed ? { 'date-parts': [parsed], raw: value } : undefined;
+}
+
+function missingFields(csl: CSLItem): string[] {
+  const out: string[] = [];
+  if (!csl.title) out.push('title');
+  if (!csl.author?.length) out.push('author');
+  if (!csl.issued?.['date-parts']?.[0]?.[0]) out.push('issued');
+  if (!csl.publisher) out.push('publisher');
+  if (!csl['container-title']) out.push('container-title');
+  return out;
+}
+
+function combinedSourceText(input: AiAssistInput): string {
+  return `${input.fetchedText || ''}\n${input.renderedText || ''}`.trim();
+}
+
+function normalizeText(value: string): string {
+  return value.replace(/\s+/g, ' ').trim().toLowerCase();
+}

--- a/functions/lib/ai/citation-check.ts
+++ b/functions/lib/ai/citation-check.ts
@@ -1,0 +1,124 @@
+import type { CitationQualityWarning, CSLItem, SupportedStyle } from '../csl-types';
+import type { AiBinding } from './citation-assist';
+
+const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
+
+export interface AiCitationCheckInput {
+  ai: AiBinding;
+  model?: string;
+  csl: CSLItem;
+  style: SupportedStyle;
+  existingWarnings: CitationQualityWarning[];
+}
+
+const CHECK_SCHEMA = {
+  type: 'object',
+  properties: {
+    warnings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          code: { type: 'string' },
+          field: { type: 'string' },
+          severity: { type: 'string', enum: ['info', 'review', 'warning'] },
+          message: { type: 'string' },
+        },
+        required: ['code', 'severity', 'message'],
+      },
+    },
+  },
+  required: ['warnings'],
+};
+
+export async function runAiCitationCheck(input: AiCitationCheckInput): Promise<CitationQualityWarning[]> {
+  const response = await input.ai.run(input.model || DEFAULT_MODEL, {
+    messages: [
+      {
+        role: 'system',
+        content: [
+          'You review citation metadata for internal consistency only.',
+          'Use only the provided CSL object and existing warnings.',
+          'Do not invent facts about the source.',
+          'Return additional review warnings only when a user should inspect a field.',
+        ].join(' '),
+      },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          style: input.style,
+          csl: input.csl,
+          existingWarnings: input.existingWarnings,
+        }),
+      },
+    ],
+    response_format: {
+      type: 'json_schema',
+      json_schema: CHECK_SCHEMA,
+    },
+  });
+  return parseWarnings(response);
+}
+
+function parseWarnings(response: unknown): CitationQualityWarning[] {
+  const parsed = parseModelJson(response);
+  const warnings = parsed?.warnings;
+  if (!Array.isArray(warnings)) return [];
+  return warnings
+    .map((warning): CitationQualityWarning | null => {
+      if (!warning || typeof warning !== 'object') return null;
+      const w = warning as Record<string, unknown>;
+      if (typeof w.code !== 'string' || typeof w.message !== 'string') return null;
+      const severity = w.severity === 'warning' || w.severity === 'review' || w.severity === 'info'
+        ? w.severity
+        : 'review';
+      return {
+        code: w.code.startsWith('ai_') ? w.code : `ai_${w.code}`,
+        field: typeof w.field === 'string' ? w.field as keyof CSLItem : undefined,
+        severity,
+        message: w.message,
+        action: 'review-field',
+      };
+    })
+    .filter((warning): warning is CitationQualityWarning => !!warning)
+    .slice(0, 3);
+}
+
+function parseModelJson(response: unknown): any {
+  if (!response) return null;
+  if (typeof response === 'string') return parseJson(response);
+  if (typeof response !== 'object') return null;
+  const obj = response as Record<string, any>;
+  for (const key of ['response', 'result', 'content', 'text']) {
+    if (typeof obj[key] === 'string') {
+      const parsed = parseJson(obj[key]);
+      if (parsed) return parsed;
+    }
+    if (obj[key] && typeof obj[key] === 'object') {
+      const parsed = parseModelJson(obj[key]);
+      if (parsed) return parsed;
+    }
+  }
+  if (Array.isArray(obj.choices)) {
+    for (const choice of obj.choices) {
+      const parsed = parseModelJson(choice?.message?.content ?? choice?.text);
+      if (parsed) return parsed;
+    }
+  }
+  if (Array.isArray(obj.warnings)) return obj;
+  return null;
+}
+
+function parseJson(value: string): any {
+  try {
+    return JSON.parse(value);
+  } catch {
+    const match = value.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/functions/lib/ai/gateway.ts
+++ b/functions/lib/ai/gateway.ts
@@ -1,0 +1,27 @@
+import type { AiBinding } from './citation-assist';
+
+export interface AiGatewayEnv {
+  AI_GATEWAY_CHAT_URL?: string;
+  AI_GATEWAY_TOKEN?: string;
+  AI_GATEWAY_ID?: string;
+}
+
+export function createAiGatewayBinding(env: AiGatewayEnv): AiBinding | undefined {
+  if (!env.AI_GATEWAY_CHAT_URL) return undefined;
+  return {
+    async run(model: string, input: Record<string, unknown>): Promise<unknown> {
+      const headers: Record<string, string> = {
+        'content-type': 'application/json',
+      };
+      if (env.AI_GATEWAY_TOKEN) headers.authorization = `Bearer ${env.AI_GATEWAY_TOKEN}`;
+      if (env.AI_GATEWAY_ID) headers['cf-aig-gateway-id'] = env.AI_GATEWAY_ID;
+      const res = await fetch(env.AI_GATEWAY_CHAT_URL!, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ ...input, model }),
+      });
+      if (!res.ok) throw new Error(`AI Gateway HTTP ${res.status}`);
+      return res.json();
+    },
+  };
+}

--- a/functions/lib/csl-types.ts
+++ b/functions/lib/csl-types.ts
@@ -49,11 +49,103 @@ export interface CSLItem {
   abstract?: string;
 }
 
+export type AcquisitionSource =
+  | 'fetch'
+  | 'render'
+  | 'ai'
+  | 'authority'
+  | 'extension'
+  | 'paste'
+  | 'input'
+  | 'user';
+
+export type EvidenceSource =
+  | 'input'
+  | 'jsonld'
+  | 'microdata'
+  | 'opengraph'
+  | 'twitter'
+  | 'meta'
+  | 'heuristic'
+  | 'fetch-html'
+  | 'rendered-html'
+  | 'browser-extension'
+  | 'pasted-text'
+  | 'crossref'
+  | 'openalex'
+  | 'openlibrary'
+  | 'google-books'
+  | 'ai-extract'
+  | 'user-edit';
+
+export interface FieldEvidence {
+  field: keyof CSLItem;
+  normalizedValue: unknown;
+  rawValue?: string;
+  source: EvidenceSource;
+  acquisition?: AcquisitionSource;
+  locator?: string;
+  snippet?: string;
+  confidence: number;
+  acquiredAt?: string;
+}
+
+export interface FieldProvenance {
+  winner?: FieldEvidence;
+  candidates: FieldEvidence[];
+  conflicts: FieldEvidence[];
+}
+
+export type AcquisitionStatus =
+  | 'success'
+  | 'partial'
+  | 'blocked'
+  | 'timeout'
+  | 'error'
+  | 'skipped';
+
+export interface AcquisitionAttempt {
+  source: AcquisitionSource;
+  status: AcquisitionStatus;
+  reason?: string;
+  url?: string;
+  finalUrl?: string;
+  durationMs?: number;
+  htmlSizeKb?: number;
+  browserMs?: number;
+  fieldsFound?: string[];
+}
+
+export interface CitationQualityWarning {
+  code: string;
+  field?: keyof CSLItem;
+  severity: 'info' | 'review' | 'warning' | 'error';
+  message: string;
+  action:
+    | 'none'
+    | 'review-field'
+    | 'choose-source-type'
+    | 'confirm-no-listed-author'
+    | 'try-rendered-page'
+    | 'use-extension'
+    | 'paste-text'
+    | 'enter-manually';
+  evidence?: FieldEvidence[];
+}
+
+export interface ExtractQuality {
+  score: number;
+  warnings: CitationQualityWarning[];
+  acquisition?: Partial<Record<AcquisitionSource, AcquisitionAttempt>>;
+}
+
 export interface ExtractEnvelope {
   uuid: string;
   type: CSLType;
   csl: CSLItem;
   _signals?: Record<string, string>;
+  _provenance?: Partial<Record<keyof CSLItem, FieldProvenance>>;
+  _quality?: ExtractQuality;
   _cached?: boolean;
 }
 

--- a/functions/lib/extract/author-parse.ts
+++ b/functions/lib/extract/author-parse.ts
@@ -8,7 +8,7 @@ import type { CSLName } from '../csl-types';
 // alternations (Foundation, Press, University, Institute, Society, Group,
 // Company, Department, Office, Agency, Bureau, Commission) don't include an
 // optional `.` of their own.
-const ORG_SUFFIXES = /\b(Inc\.?|LLC|Ltd\.?|Corp\.?|Corporation|Foundation|Press|University|Institute|Society|Group|Company|Co\.?|Department|Office|Agency|Bureau|Commission)[.\s]*$/i;
+const ORG_SUFFIXES = /\b(Inc\.?|LLC|Ltd\.?|Corp\.?|Corporation|Foundation|Press|University|Institute|Society|Group|Company|Co\.?|Department|Office|Agency|Bureau|Commission|Administration|Authority|Association|Council|Center|Centre|Laboratory|Lab|Labs|Ministry|Service|Services|News|Editorial Board|Editorial Team|Staff)[.\s]*$/i;
 const PARTICLES = new Set([
   'von', 'de', 'del', 'della', 'van', 'la', 'le', 'der', 'den', 'di', 'da', 'du', 'dos', 'des',
 ]);
@@ -19,6 +19,7 @@ export function parseAuthorName(input: string | CSLName | null | undefined): CSL
   if (typeof input === 'object') return input;
   const trimmed = input.trim();
   if (!trimmed) return null;
+  if (/^[A-Z][A-Z0-9&.-]{1,14}$/.test(trimmed)) return { literal: trimmed };
   if (ORG_SUFFIXES.test(trimmed)) return { literal: trimmed };
 
   if (trimmed.includes(',')) {
@@ -36,15 +37,80 @@ export function parseAuthorName(input: string | CSLName | null | undefined): CSL
   }
   const family = parts.pop();
   if (!family) return null;
-  let particle: string | undefined;
-  if (parts.length >= 1 && PARTICLES.has(parts[parts.length - 1].toLowerCase())) {
-    particle = parts.pop();
+  const particleParts: string[] = [];
+  while (parts.length >= 1 && PARTICLES.has(parts[parts.length - 1].toLowerCase())) {
+    particleParts.unshift(parts.pop() as string);
   }
   const given = parts.join(' ');
 
   const out: CSLName = { family };
   if (given) (out as any).given = given;
-  if (particle) (out as any)['non-dropping-particle'] = particle;
+  if (particleParts.length) (out as any)['non-dropping-particle'] = particleParts.join(' ');
   if (suffix) (out as any).suffix = suffix;
   return out;
+}
+
+export function parseAuthorList(input: string | null | undefined): CSLName[] {
+  if (!input) return [];
+  const cleaned = input
+    .replace(/\s+/g, ' ')
+    .replace(/^(by|written by|posted by|author:)\s+/i, '')
+    .replace(/\s+et\s+al\.?$/i, '')
+    .trim();
+  if (!cleaned) return [];
+
+  const segments = splitAuthorSegments(cleaned);
+  return segments
+    .map((segment) => parseAuthorName(segment))
+    .filter(Boolean) as CSLName[];
+}
+
+function splitAuthorSegments(input: string): string[] {
+  const semicolonParts = input.split(/\s*;\s*/).filter(Boolean);
+  if (semicolonParts.length > 1) {
+    return semicolonParts.flatMap(splitAuthorSegments);
+  }
+
+  const conjunctionParts = input.split(/\s+(?:and|&)\s+/i).filter(Boolean);
+  if (conjunctionParts.length > 1 && conjunctionParts.every(looksLikeAuthorUnit)) {
+    return conjunctionParts.flatMap(splitAuthorSegments);
+  }
+
+  return splitCommaSegments(input);
+}
+
+function splitCommaSegments(input: string): string[] {
+  const parts = input.split(/\s*,\s*/).filter(Boolean);
+  if (parts.length <= 1) return [input];
+
+  if (parts.length === 2) {
+    return looksLikeInvertedSingleName(parts[0], parts[1]) ? [input] : parts;
+  }
+
+  if (parts.length % 2 === 0) {
+    const pairs: string[] = [];
+    for (let i = 0; i < parts.length; i += 2) {
+      if (!looksLikeInvertedSingleName(parts[i], parts[i + 1])) return parts;
+      pairs.push(`${parts[i]}, ${parts[i + 1]}`);
+    }
+    return pairs;
+  }
+
+  return parts;
+}
+
+function looksLikeInvertedSingleName(left: string, right: string): boolean {
+  const leftWords = left.trim().split(/\s+/).filter(Boolean);
+  const rightWords = right.trim().split(/\s+/).filter(Boolean);
+  if (!leftWords.length || !rightWords.length) return false;
+  if (ORG_SUFFIXES.test(left) || ORG_SUFFIXES.test(right)) return false;
+  if (leftWords.length === 1 || rightWords.length === 1) return true;
+  return leftWords.slice(0, -1).every((word) => PARTICLES.has(word.toLowerCase()));
+}
+
+function looksLikeAuthorUnit(segment: string): boolean {
+  const parsed = parseAuthorName(segment);
+  if (!parsed) return false;
+  if ('literal' in parsed) return true;
+  return Boolean(parsed.given);
 }

--- a/functions/lib/extract/date-parse.ts
+++ b/functions/lib/extract/date-parse.ts
@@ -26,9 +26,9 @@ export function parseIsoDate(s: string | null | undefined): CSLDateParts | null 
   if (m[3]) {
     const month = parseInt(m[2], 10);
     const day = parseInt(m[3], 10);
-    // Reject impossible months/days (e.g. "2020-99-99") so we never emit a
-    // malformed CSL date that citeproc would render nonsensically.
-    if (month < 1 || month > 12 || day < 1 || day > 31) return null;
+    // Reject impossible dates (including month-specific limits and leap years)
+    // so we never emit malformed CSL that citeproc would render nonsensically.
+    if (!isValidYmd(y, month, day)) return null;
     return [y, month, day];
   }
   if (m[2]) {
@@ -41,18 +41,60 @@ export function parseIsoDate(s: string | null | undefined): CSLDateParts | null 
 
 export function parseFreeformDate(s: string | null | undefined): CSLDateParts | null {
   if (!s) return null;
-  const text = s.trim();
-  let m = text.match(/^([A-Za-z]+)\.?\s+(\d{1,2}),?\s+(\d{4})$/);
+  const text = s.trim().replace(/\b(\d{1,2})(st|nd|rd|th)\b/gi, '$1');
+  let m = text.match(/^(?:[A-Za-z]+,\s*)?([A-Za-z]+)\.?\s+(\d{1,2}),?\s+(\d{4})$/);
   if (m) {
     const month = MONTHS[m[1].toLowerCase()];
     const day = parseInt(m[2], 10);
-    if (month && day >= 1 && day <= 31) return [parseInt(m[3], 10), month, day];
+    const year = parseInt(m[3], 10);
+    if (month && isValidYmd(year, month, day)) return [year, month, day];
   }
-  m = text.match(/^(\d{1,2})\s+([A-Za-z]+)\.?\s+(\d{4})$/);
+  m = text.match(/^(?:[A-Za-z]+,\s*)?(\d{1,2})\s+([A-Za-z]+)\.?\s+(\d{4})/);
   if (m) {
     const month = MONTHS[m[2].toLowerCase()];
     const day = parseInt(m[1], 10);
-    if (month && day >= 1 && day <= 31) return [parseInt(m[3], 10), month, day];
+    const year = parseInt(m[3], 10);
+    if (month && isValidYmd(year, month, day)) return [year, month, day];
+  }
+  m = text.match(/^([A-Za-z]+)\.?\s+(\d{4})$/);
+  if (m) {
+    const month = MONTHS[m[1].toLowerCase()];
+    const year = parseInt(m[2], 10);
+    if (month && isValidYear(year)) return [year, month];
   }
   return null;
+}
+
+export function parseDate(s: string | null | undefined): CSLDateParts | null {
+  return parseIsoDate(s) || parseFreeformDate(s) || parseNumericDate(s);
+}
+
+function parseNumericDate(s: string | null | undefined): CSLDateParts | null {
+  if (!s) return null;
+  const text = s.trim();
+  const m = text.match(/^(\d{1,2})[./-](\d{1,2})[./-](\d{4})$/);
+  if (!m) return null;
+
+  const first = parseInt(m[1], 10);
+  const second = parseInt(m[2], 10);
+  const year = parseInt(m[3], 10);
+  if (!isValidYear(year)) return null;
+
+  // Numeric dates are locale-ambiguous. Parse only when one side disambiguates
+  // the order, e.g. 5/26/2026 (US) or 26/5/2026 (day-first).
+  if (first > 12 && second <= 12 && isValidYmd(year, second, first)) return [year, second, first];
+  if (second > 12 && first <= 12 && isValidYmd(year, first, second)) return [year, first, second];
+  return null;
+}
+
+function isValidYear(year: number): boolean {
+  return Number.isFinite(year) && year >= 1000 && year <= 9999;
+}
+
+function isValidYmd(year: number, month: number, day: number): boolean {
+  if (!isValidYear(year) || month < 1 || month > 12 || day < 1 || day > 31) return false;
+  const d = new Date(Date.UTC(year, month - 1, day));
+  return d.getUTCFullYear() === year
+    && d.getUTCMonth() === month - 1
+    && d.getUTCDate() === day;
 }

--- a/functions/lib/extract/merge.ts
+++ b/functions/lib/extract/merge.ts
@@ -1,4 +1,4 @@
-import type { CSLItem } from '../csl-types';
+import type { AcquisitionSource, CSLItem, EvidenceSource, FieldEvidence, FieldProvenance } from '../csl-types';
 
 export interface NamedSignal {
   name: string;
@@ -8,34 +8,93 @@ export interface NamedSignal {
 
 const MERGEABLE_FIELDS: Array<keyof CSLItem> = [
   'title', 'author', 'issued', 'publisher', 'container-title', 'URL', 'DOI',
-  'volume', 'issue', 'page', 'edition',
+  'volume', 'issue', 'page', 'edition', 'abstract',
 ];
+
+export const EXTRACT_MERGEABLE_FIELDS = MERGEABLE_FIELDS;
+
+interface MergeOptions {
+  acquisition?: AcquisitionSource;
+  acquiredAt?: string;
+}
 
 export function mergeSignals(signals: NamedSignal[]): {
   csl: Partial<CSLItem>;
   signals: Record<string, string>;
+  provenance: Partial<Record<keyof CSLItem, FieldProvenance>>;
+};
+export function mergeSignals(signals: NamedSignal[], options: MergeOptions = {}): {
+  csl: Partial<CSLItem>;
+  signals: Record<string, string>;
+  provenance: Partial<Record<keyof CSLItem, FieldProvenance>>;
 } {
   const csl: Partial<CSLItem> = {};
   const winners: Record<string, string> = {};
+  const provenance: Partial<Record<keyof CSLItem, FieldProvenance>> = {};
   for (const field of MERGEABLE_FIELDS) {
-    let bestConf = 0;
-    let bestVal: any;
-    let bestName: string | undefined;
+    const candidates: FieldEvidence[] = [];
     for (const s of signals) {
       const conf = s.confidence[field];
       // Guard the confidence contract: ignore NaN/Infinity/out-of-range scores so
       // a misbehaving signal can't hijack a field with a pathological value.
       if (typeof conf === 'number' && Number.isFinite(conf) && conf > 0 && conf <= 1
-        && s.fields[field] !== undefined && conf > bestConf) {
-        bestConf = conf;
-        bestVal = s.fields[field];
-        bestName = s.name;
+        && s.fields[field] !== undefined) {
+        candidates.push(evidenceFromSignal(field, s.name, s.fields[field], conf, options));
       }
     }
-    if (bestName) {
-      (csl as any)[field] = bestVal;
-      winners[field] = bestName;
+    if (candidates.length) {
+      const winner = candidates.reduce((best, next) => (
+        next.confidence > best.confidence ? next : best
+      ));
+      (csl as any)[field] = winner.normalizedValue;
+      winners[field] = winner.source;
+      provenance[field] = {
+        winner,
+        candidates,
+        conflicts: candidates.filter((candidate) => !sameEvidenceValue(candidate.normalizedValue, winner.normalizedValue)),
+      };
     }
   }
-  return { csl, signals: winners };
+  return { csl, signals: winners, provenance };
+}
+
+function evidenceFromSignal(
+  field: keyof CSLItem,
+  source: string,
+  value: unknown,
+  confidence: number,
+  options: MergeOptions,
+): FieldEvidence {
+  return {
+    field,
+    normalizedValue: value,
+    rawValue: evidenceRawValue(value),
+    source: source as EvidenceSource,
+    acquisition: options.acquisition,
+    confidence,
+    acquiredAt: options.acquiredAt,
+  };
+}
+
+function evidenceRawValue(value: unknown): string | undefined {
+  if (typeof value === 'string') return value;
+  if (value === undefined) return undefined;
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function sameEvidenceValue(a: unknown, b: unknown): boolean {
+  return stableEvidenceValue(a) === stableEvidenceValue(b);
+}
+
+function stableEvidenceValue(value: unknown): string {
+  if (value === undefined) return 'undefined';
+  if (value === null) return 'null';
+  if (typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(stableEvidenceValue).join(',')}]`;
+  const obj = value as Record<string, unknown>;
+  return `{${Object.keys(obj).sort().map((key) => `${JSON.stringify(key)}:${stableEvidenceValue(obj[key])}`).join(',')}}`;
 }

--- a/functions/lib/extract/pipeline.ts
+++ b/functions/lib/extract/pipeline.ts
@@ -1,5 +1,5 @@
 import * as cheerio from 'cheerio';
-import type { CSLItem } from '../csl-types';
+import type { AcquisitionSource, CSLItem, FieldEvidence, FieldProvenance } from '../csl-types';
 import { jsonldSignal } from './signals/jsonld';
 import { microdataSignal } from './signals/microdata';
 import { openGraphSignal } from './signals/opengraph';
@@ -20,18 +20,28 @@ const SIGNALS = [
 export interface PipelineResult {
   csl: CSLItem;
   signals: Record<string, string>;
+  provenance: Partial<Record<keyof CSLItem, FieldProvenance>>;
 }
 
-export function runExtractionPipeline(html: string, url: string): PipelineResult {
+export interface PipelineOptions {
+  acquisition?: AcquisitionSource;
+  acquiredAt?: string;
+}
+
+export function runExtractionPipeline(html: string, url: string, options: PipelineOptions = {}): PipelineResult {
   const $ = cheerio.load(html);
   const named = SIGNALS.map((s) => ({ name: s.name, ...s.fn($) }));
-  const { csl: merged, signals } = mergeSignals(named);
+  const { csl: merged, signals, provenance } = mergeSignals(named, options);
   const final: CSLItem = {
     id: url,
-    type: 'webpage',
+    type: inferType(merged),
     URL: url,
     ...merged,
   };
+  final.URL = resolveUrl(final.URL, url);
+  ensureInputUrlProvenance(provenance, final.URL, options);
+  dedupePublisherContainer(final);
+  if (!final.publisher) delete provenance.publisher;
 
   // Wikipedia quirk: JSON-LD `headline` is the article description, not the title
   // (e.g. <https://en.wikipedia.org/wiki/Citation> → "reference to a source").
@@ -42,10 +52,54 @@ export function runExtractionPipeline(html: string, url: string): PipelineResult
     if (heuristic?.fields.title) {
       final.title = heuristic.fields.title;
       signals.title = 'heuristic';
+      const candidate = provenance.title?.candidates.find((item) => item.source === 'heuristic');
+      if (candidate) {
+        provenance.title = {
+          winner: candidate,
+          candidates: provenance.title?.candidates ?? [candidate],
+          conflicts: (provenance.title?.candidates ?? []).filter((item) => item !== candidate),
+        };
+      }
     }
   }
 
-  return { csl: final, signals };
+  return { csl: final, signals, provenance };
+}
+
+function inferType(item: Partial<CSLItem>): CSLItem['type'] {
+  // A pasted URL can point at a journal article landing page. When the page
+  // exposes journal-style container metadata plus a scholarly locator, format
+  // it as an article-journal so CSL can render those details. DOI-only landing
+  // pages are common for early-online articles and should not fall back to a
+  // generic webpage.
+  if (item['container-title'] && (item.volume || item.issue || item.page || item.DOI)) {
+    return 'article-journal';
+  }
+  return 'webpage';
+}
+
+function resolveUrl(value: string | undefined, base: string): string {
+  if (!value) return base;
+  try {
+    const resolved = new URL(value, base);
+    return resolved.protocol === 'http:' || resolved.protocol === 'https:' ? resolved.href : base;
+  } catch {
+    return base;
+  }
+}
+
+function dedupePublisherContainer(item: CSLItem): void {
+  if (item.publisher && item['container-title']
+    && normalizeComparable(item.publisher) === normalizeComparable(item['container-title'])) {
+    delete item.publisher;
+  }
+}
+
+function normalizeComparable(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/^the\s+/, '')
+    .replace(/[^\p{L}\p{N}]+/gu, '');
 }
 
 function isWikipediaHost(url: string): boolean {
@@ -55,4 +109,29 @@ function isWikipediaHost(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+function ensureInputUrlProvenance(
+  provenance: Partial<Record<keyof CSLItem, FieldProvenance>>,
+  url: string,
+  options: PipelineOptions,
+): void {
+  if (provenance.URL?.winner) {
+    provenance.URL.winner.normalizedValue = url;
+    return;
+  }
+  const evidence: FieldEvidence = {
+    field: 'URL',
+    normalizedValue: url,
+    rawValue: url,
+    source: 'input',
+    acquisition: options.acquisition ?? 'input',
+    confidence: 1,
+    acquiredAt: options.acquiredAt,
+  };
+  provenance.URL = {
+    winner: evidence,
+    candidates: [evidence],
+    conflicts: [],
+  };
 }

--- a/functions/lib/extract/signals/heuristic.ts
+++ b/functions/lib/extract/signals/heuristic.ts
@@ -1,13 +1,14 @@
 import type { CheerioAPI } from 'cheerio';
 import type { CSLItem } from '../../csl-types';
-import { parseAuthorName } from '../author-parse';
-import { parseIsoDate } from '../date-parse';
+import { parseAuthorList } from '../author-parse';
+import { parseDate } from '../date-parse';
 import type { SignalResult } from './jsonld';
 
 const CONF_TITLE = 0.4;
 const CONF_AUTHOR_REL = 0.45;
 const CONF_AUTHOR_BYLINE = 0.35;
 const CONF_TIME = 0.45;
+const CONF_CANONICAL_URL = 0.7;
 
 const TITLE_SEP = /\s+[—\-–|]\s+/;
 
@@ -24,24 +25,37 @@ export function heuristicSignal($: CheerioAPI): SignalResult {
 
   const relAuthor = $('a[rel="author"], [rel="author"]').first().text().trim();
   if (relAuthor) {
-    const parsed = parseAuthorName(relAuthor);
-    if (parsed) { fields.author = [parsed]; confidence.author = CONF_AUTHOR_REL; }
+    const parsed = parseAuthorList(relAuthor);
+    if (parsed.length) { fields.author = parsed; confidence.author = CONF_AUTHOR_REL; }
   }
 
   if (!fields.author) {
-    const byline = $('.byline, .author, .article-author').first().text().trim();
+    const byline = $('.byline, .author, .article-author, [class*="byline" i], [class*="author" i], [data-testid*="byline" i], [data-testid*="author" i]').first().text().trim();
     if (byline) {
-      const cleaned = byline.replace(/^by\s+/i, '').trim();
-      const parsed = parseAuthorName(cleaned);
-      if (parsed) { fields.author = [parsed]; confidence.author = CONF_AUTHOR_BYLINE; }
+      const parsed = parseAuthorList(cleanBylineText(byline));
+      if (parsed.length) { fields.author = parsed; confidence.author = CONF_AUTHOR_BYLINE; }
     }
   }
 
   const timeEl = $('time[datetime]').first();
   if (timeEl.length) {
-    const dp = parseIsoDate(timeEl.attr('datetime') || '');
+    const dp = parseDate(timeEl.attr('datetime') || '') || parseDate(timeEl.text());
     if (dp) { fields.issued = { 'date-parts': [dp] }; confidence.issued = CONF_TIME; }
   }
 
+  const canonical = $('link[rel="canonical" i]').first().attr('href')?.trim();
+  if (canonical) {
+    fields.URL = canonical;
+    confidence.URL = CONF_CANONICAL_URL;
+  }
+
   return { fields, confidence };
+}
+
+function cleanBylineText(text: string): string {
+  return text
+    .replace(/\s+/g, ' ')
+    .replace(/\b(?:published|updated|posted|last updated|last reviewed|reviewed)\b.*$/i, '')
+    .replace(/\s+on\s+(?:\d{1,2}\s+[A-Za-z]+|[A-Za-z]+\s+\d{1,2}|\d{4}|\d{1,2}[/-]\d{1,2}[/-]\d{2,4}).*$/i, '')
+    .trim();
 }

--- a/functions/lib/extract/signals/jsonld.ts
+++ b/functions/lib/extract/signals/jsonld.ts
@@ -1,7 +1,8 @@
 import type { CheerioAPI } from 'cheerio';
 import type { CSLItem, CSLName } from '../../csl-types';
 import { parseAuthorName } from '../author-parse';
-import { parseIsoDate } from '../date-parse';
+import { parseDate } from '../date-parse';
+import { validateDoi } from '../../journal/doi-detect';
 
 export interface SignalResult {
   fields: Partial<CSLItem>;
@@ -33,17 +34,23 @@ export function decodeJsonLdEntities(text: string): string {
 const ARTICLE_TYPES = new Set([
   'Article', 'NewsArticle', 'BlogPosting', 'WebPage', 'ScholarlyArticle',
   'Report', 'TechArticle', 'AnalysisNewsArticle', 'OpinionNewsArticle',
-  'ReviewArticle', 'BackgroundNewsArticle',
+  'ReviewArticle', 'BackgroundNewsArticle', 'LiveBlogPosting',
+  'SocialMediaPosting', 'MedicalScholarlyArticle',
 ]);
 
-const NON_ARTICLE_CONTAINER_RE = /^(WebSite|Organization|Person|Corporation|BreadcrumbList|SiteNavigationElement)$/i;
+const NON_ARTICLE_CONTAINER_RE = /^(WebSite|Organization|NewsMediaOrganization|Person|Corporation|BreadcrumbList|SiteNavigationElement|CollectionPage|ProfilePage|SearchResultsPage|ImageObject|VideoObject)$/i;
 
 function isArticleish(type: string): boolean {
+  const types = typeNames(type);
   if (!type) return true; // unknown/missing — treat as article-ish, preserves prior behavior
-  if (ARTICLE_TYPES.has(type)) return true;
+  if (types.some((t) => ARTICLE_TYPES.has(t))) return true;
   // If it's an explicit non-article container, reject. Otherwise default to article-ish
   // (covers Schema.org subtypes we haven't enumerated).
-  return !NON_ARTICLE_CONTAINER_RE.test(type);
+  return !types.some((t) => NON_ARTICLE_CONTAINER_RE.test(t));
+}
+
+function typeNames(type: string): string[] {
+  return type.split(',').map((t) => t.trim()).filter(Boolean);
 }
 
 export function jsonldSignal($: CheerioAPI): SignalResult {
@@ -73,7 +80,7 @@ function walk(node: unknown, fields: Partial<CSLItem>, confidence: Partial<Recor
   const articleish = isArticleish(type);
 
   if (!fields.title) {
-    const isNonArticleContainer = NON_ARTICLE_CONTAINER_RE.test(type);
+    const isNonArticleContainer = !articleish;
     const t = n.headline || (isNonArticleContainer ? undefined : (n.name || n.title));
     if (typeof t === 'string' && t.trim()) {
       fields.title = t.trim();
@@ -94,14 +101,67 @@ function walk(node: unknown, fields: Partial<CSLItem>, confidence: Partial<Recor
     }
   }
 
+  if (!fields.author && n.creator) {
+    const arr = Array.isArray(n.creator) ? n.creator : [n.creator];
+    const authors: CSLName[] = [];
+    for (const a of arr) {
+      const parsed = nodeToAuthor(a);
+      if (parsed) authors.push(parsed);
+    }
+    if (authors.length) {
+      fields.author = authors;
+      confidence.author = CONF;
+    }
+  }
+
   if (!fields.issued) {
-    const d = n.datePublished || n.dateCreated;
+    const d = n.datePublished || n.dateCreated || n.dateModified;
     if (typeof d === 'string') {
-      const dp = parseIsoDate(d);
+      const dp = parseDate(d);
       if (dp) {
         fields.issued = { 'date-parts': [dp] };
         confidence.issued = CONF;
       }
+    }
+  }
+
+  if (!fields.DOI && articleish) {
+    const doi = doiFromJsonLdValues(n.doi, n.identifier, n.sameAs);
+    if (doi) {
+      fields.DOI = doi;
+      confidence.DOI = CONF;
+    }
+  }
+
+  if (!fields.volume && articleish) {
+    const volume = firstString(n.volumeNumber, n.volume, n.isPartOf?.volumeNumber, n.isPartOf?.isPartOf?.volumeNumber);
+    if (volume) {
+      fields.volume = volume;
+      confidence.volume = CONF;
+    }
+  }
+
+  if (!fields.issue && articleish) {
+    const issue = firstString(n.issueNumber, n.issue, n.isPartOf?.issueNumber);
+    if (issue) {
+      fields.issue = issue;
+      confidence.issue = CONF;
+    }
+  }
+
+  if (!fields.page && articleish) {
+    const page = firstString(n.pagination) || pageRange(n.pageStart, n.pageEnd);
+    if (page) {
+      fields.page = page;
+      confidence.page = CONF;
+    }
+  }
+
+  if (!fields.abstract && articleish) {
+    const abstract = firstString(n.abstract);
+    if (abstract) {
+      fields.abstract = abstract;
+      confidence.abstract = CONF;
     }
   }
 
@@ -113,11 +173,26 @@ function walk(node: unknown, fields: Partial<CSLItem>, confidence: Partial<Recor
     }
   }
 
+  if (!fields['container-title'] && articleish && n.isPartOf) {
+    const name = typeof n.isPartOf === 'string' ? n.isPartOf : n.isPartOf?.name;
+    if (typeof name === 'string' && name.trim()) {
+      fields['container-title'] = name.trim();
+      confidence['container-title'] = CONF;
+    }
+  }
+
   // Only accept URL from article-typed nodes — many @graph constructions put an
   // Organization or WebSite first whose `url` points at the site root, not the
   // article being cited.
-  if (!fields.URL && typeof n.url === 'string' && articleish) {
-    fields.URL = n.url;
+  const nodeUrl = typeof n.url === 'string'
+    ? n.url
+    : typeof n.mainEntityOfPage === 'string'
+      ? n.mainEntityOfPage
+      : typeof n.mainEntityOfPage?.['@id'] === 'string'
+        ? n.mainEntityOfPage['@id']
+        : undefined;
+  if (!fields.URL && nodeUrl && articleish) {
+    fields.URL = nodeUrl;
     confidence.URL = CONF;
   }
 
@@ -125,12 +200,61 @@ function walk(node: unknown, fields: Partial<CSLItem>, confidence: Partial<Recor
   if (n.mainEntity) walk(n.mainEntity, fields, confidence);
 }
 
+function firstString(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    if (typeof value === 'string' || typeof value === 'number') {
+      const s = String(value).replace(/\s+/g, ' ').trim();
+      if (s) return s;
+    }
+  }
+  return undefined;
+}
+
+function pageRange(start: unknown, end: unknown): string | undefined {
+  const first = firstString(start);
+  if (!first) return undefined;
+  const last = firstString(end);
+  return last ? `${first}-${last}` : first;
+}
+
+function doiFromJsonLdValues(...values: unknown[]): string | null {
+  for (const value of flattenIdentifierValues(values)) {
+    const direct = validateDoi(value);
+    if (direct) return direct;
+    const match = value.match(/\b10\.\d{4,9}\/[^\s"'#?]+/i);
+    const fromMatch = match ? validateDoi(match[0]) : null;
+    if (fromMatch) return fromMatch;
+  }
+  return null;
+}
+
+function flattenIdentifierValues(values: unknown[]): string[] {
+  const out: string[] = [];
+  const visit = (value: unknown) => {
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item);
+      return;
+    }
+    if (typeof value === 'string' || typeof value === 'number') {
+      const s = String(value).trim();
+      if (s) out.push(s);
+      return;
+    }
+    if (!value || typeof value !== 'object') return;
+    const obj = value as Record<string, any>;
+    for (const key of ['value', 'name', '@id', 'url']) visit(obj[key]);
+  };
+  for (const value of values) visit(value);
+  return out;
+}
+
 function nodeToAuthor(a: unknown): CSLName | null {
   if (typeof a === 'string') return parseAuthorName(a);
   if (!a || typeof a !== 'object') return null;
   const obj = a as Record<string, any>;
   const type = String(obj['@type'] || '');
-  if (type === 'Organization' || type === 'Corporation') {
+  const types = typeNames(type);
+  if (types.includes('Organization') || types.includes('Corporation')) {
     return obj.name ? { literal: String(obj.name) } : null;
   }
   if (obj.familyName || obj.givenName) {

--- a/functions/lib/extract/signals/meta.ts
+++ b/functions/lib/extract/signals/meta.ts
@@ -1,7 +1,8 @@
 import type { CheerioAPI } from 'cheerio';
-import type { CSLItem, CSLName } from '../../csl-types';
-import { parseAuthorName } from '../author-parse';
-import { parseIsoDate } from '../date-parse';
+import type { CSLItem } from '../../csl-types';
+import { parseAuthorList } from '../author-parse';
+import { parseDate } from '../date-parse';
+import { validateDoi } from '../../journal/doi-detect';
 import type { SignalResult } from './jsonld';
 
 const CONF_META = 0.55;
@@ -11,6 +12,14 @@ const CONF_DC_DATE = 0.7;
 function meta($: CheerioAPI, sel: string): string | null {
   const v = $(sel).attr('content');
   return v ? v.trim() || null : null;
+}
+
+function firstMeta($: CheerioAPI, selectors: string[]): string | null {
+  for (const sel of selectors) {
+    const value = meta($, sel);
+    if (value) return value;
+  }
+  return null;
 }
 
 // Returns the `content` of every meta tag matching `sel` (trimmed, non-empty).
@@ -26,20 +35,51 @@ function metaAll($: CheerioAPI, sel: string): string[] {
   return out;
 }
 
+function cleanText(value: string | null): string | null {
+  if (!value) return null;
+  return value.replace(/\s+/g, ' ').trim() || null;
+}
+
+function setTextField(
+  fields: Partial<CSLItem>,
+  confidence: SignalResult['confidence'],
+  field: keyof CSLItem,
+  value: string | null,
+  score = CONF_CITATION,
+): void {
+  const cleaned = cleanText(value);
+  if (cleaned) {
+    (fields as any)[field] = cleaned;
+    confidence[field] = score;
+  }
+}
+
+function normalizeDoi(raw: string): string | null {
+  const direct = validateDoi(raw);
+  if (direct) return direct;
+  const match = raw.match(/\b10\.\d{4,9}\/[^\s"'#?]+/i);
+  return match ? validateDoi(match[0]) : null;
+}
+
 export function metaSignal($: CheerioAPI): SignalResult {
   const fields: Partial<CSLItem> = {};
   const confidence: SignalResult['confidence'] = {};
 
-  const author = meta($, 'meta[name="author" i]');
-  if (author) {
-    const split = author.split(/[,;]/).map((s) => parseAuthorName(s.trim())).filter(Boolean) as CSLName[];
-    if (split.length) { fields.author = split; confidence.author = CONF_META; }
-  }
-
-  const publisher = meta($, 'meta[name="publisher" i]');
+  const publisher = firstMeta($, [
+    'meta[name="citation_publisher" i]',
+    'meta[name="DC.publisher" i]',
+    'meta[name="dcterms.publisher" i]',
+    'meta[name="publisher" i]',
+  ]);
   if (publisher) { fields.publisher = publisher; confidence.publisher = CONF_META; }
 
-  const cTitle = meta($, 'meta[name="citation_title" i]');
+  const cTitle = firstMeta($, [
+    'meta[name="citation_title" i]',
+    'meta[name="DC.title" i]',
+    'meta[name="dcterms.title" i]',
+    'meta[name="parsely-title" i]',
+    'meta[name="sailthru.title" i]',
+  ]);
   if (cTitle) { fields.title = cTitle; confidence.title = CONF_CITATION; }
 
   // NOTE: cheerio's `i` flag already makes attribute-value matching
@@ -50,26 +90,107 @@ export function metaSignal($: CheerioAPI): SignalResult {
     ...metaAll($, 'meta[name="citation_author" i]'),
     ...metaAll($, 'meta[name="DC.creator" i]'),
   ];
-  if (cAuthors.length && !fields.author) {
-    const parsed = cAuthors.map((s) => parseAuthorName(s)).filter(Boolean) as CSLName[];
+  if (cAuthors.length) {
+    const parsed = cAuthors.flatMap((s) => parseAuthorList(s));
     if (parsed.length) {
       fields.author = parsed;
       confidence.author = CONF_CITATION;
     }
   }
 
+  if (!fields.author) {
+    const author = meta($, 'meta[name="author" i]');
+    if (author) {
+      const split = parseAuthorList(author);
+      if (split.length) { fields.author = split; confidence.author = CONF_META; }
+    }
+  }
+
   const dateRaw =
-    meta($, 'meta[name="citation_publication_date" i]') ||
-    meta($, 'meta[name="DC.date" i]') ||
-    meta($, 'meta[name="dc.date" i]') ||
-    meta($, 'meta[name="DC.date.issued" i]');
+    firstMeta($, [
+      'meta[name="citation_publication_date" i]',
+      'meta[name="citation_date" i]',
+      'meta[name="citation_online_date" i]',
+      'meta[name="DC.date" i]',
+      'meta[name="DC.date.issued" i]',
+      'meta[name="dcterms.created" i]',
+      'meta[name="dcterms.issued" i]',
+      'meta[name="date" i]',
+      'meta[name="pubdate" i]',
+      'meta[name="publishdate" i]',
+      'meta[name="parsely-pub-date" i]',
+      'meta[name="sailthru.date" i]',
+      'meta[property="article:published_time" i]',
+    ]);
   if (dateRaw) {
-    const dp = parseIsoDate(dateRaw);
+    const dp = parseDate(dateRaw);
     if (dp) { fields.issued = { 'date-parts': [dp] }; confidence.issued = CONF_DC_DATE; }
   }
 
-  const journal = meta($, 'meta[name="citation_journal_title" i]');
+  const journal = firstMeta($, [
+    'meta[name="citation_journal_title" i]',
+    'meta[name="citation_conference_title" i]',
+    'meta[name="citation_inbook_title" i]',
+  ]);
   if (journal) { fields['container-title'] = journal; confidence['container-title'] = CONF_CITATION; }
+  if (!fields['container-title']) {
+    const siteName = firstMeta($, [
+      'meta[name="application-name" i]',
+      'meta[name="apple-mobile-web-app-title" i]',
+    ]);
+    if (siteName) { fields['container-title'] = siteName; confidence['container-title'] = CONF_META; }
+  }
+
+  const doi = firstMeta($, [
+    'meta[name="citation_doi" i]',
+    'meta[name="doi" i]',
+    'meta[name="DC.identifier" i]',
+    'meta[name="dcterms.identifier" i]',
+    'meta[name="prism.doi" i]',
+  ]);
+  if (doi) {
+    const normalized = normalizeDoi(doi);
+    if (normalized) {
+      fields.DOI = normalized;
+      confidence.DOI = CONF_CITATION;
+    }
+  }
+
+  setTextField(fields, confidence, 'volume', firstMeta($, [
+    'meta[name="citation_volume" i]',
+    'meta[name="prism.volume" i]',
+  ]));
+
+  setTextField(fields, confidence, 'issue', firstMeta($, [
+    'meta[name="citation_issue" i]',
+    'meta[name="prism.number" i]',
+    'meta[name="prism.issueIdentifier" i]',
+  ]));
+
+  const pages = firstMeta($, [
+    'meta[name="citation_pages" i]',
+    'meta[name="prism.pageRange" i]',
+  ]);
+  if (pages) {
+    setTextField(fields, confidence, 'page', pages);
+  } else {
+    const firstPage = firstMeta($, [
+      'meta[name="citation_firstpage" i]',
+      'meta[name="prism.startingPage" i]',
+    ]);
+    const lastPage = firstMeta($, [
+      'meta[name="citation_lastpage" i]',
+      'meta[name="prism.endingPage" i]',
+    ]);
+    if (firstPage && lastPage) setTextField(fields, confidence, 'page', `${firstPage}-${lastPage}`);
+    else setTextField(fields, confidence, 'page', firstPage);
+  }
+
+  setTextField(fields, confidence, 'abstract', firstMeta($, [
+    'meta[name="citation_abstract" i]',
+    'meta[name="dc.description.abstract" i]',
+    'meta[name="dcterms.abstract" i]',
+  ]));
 
   return { fields, confidence };
 }

--- a/functions/lib/extract/signals/microdata.ts
+++ b/functions/lib/extract/signals/microdata.ts
@@ -1,7 +1,8 @@
 import type { CheerioAPI } from 'cheerio';
 import type { CSLItem } from '../../csl-types';
-import { parseAuthorName } from '../author-parse';
-import { parseIsoDate } from '../date-parse';
+import { parseAuthorList } from '../author-parse';
+import { parseDate } from '../date-parse';
+import { validateDoi } from '../../journal/doi-detect';
 import type { SignalResult } from './jsonld';
 
 const CONF = 0.85;
@@ -9,7 +10,36 @@ const CONF = 0.85;
 function readValue($: CheerioAPI, sel: string): string | null {
   const el = $(sel).first();
   if (!el.length) return null;
-  return (el.attr('content') || el.attr('datetime') || el.text() || '').trim() || null;
+  return (el.attr('content') || el.attr('datetime') || el.attr('href') || el.text() || '').trim() || null;
+}
+
+function readValues($: CheerioAPI, sel: string): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  $(sel).each((_, el) => {
+    const v = ($(el).attr('content') || $(el).attr('datetime') || $(el).attr('href') || $(el).text() || '').replace(/\s+/g, ' ').trim();
+    if (v && !seen.has(v)) {
+      seen.add(v);
+      out.push(v);
+    }
+  });
+  return out;
+}
+
+function firstDoi(values: string[]): string | null {
+  for (const value of values) {
+    const direct = validateDoi(value);
+    if (direct) return direct;
+    const match = value.match(/\b10\.\d{4,9}\/[^\s"'#?]+/i);
+    const doi = match ? validateDoi(match[0]) : null;
+    if (doi) return doi;
+  }
+  return null;
+}
+
+function pageRange(start: string | null, end: string | null): string | null {
+  if (!start) return null;
+  return end ? `${start}-${end}` : start;
 }
 
 export function microdataSignal($: CheerioAPI): SignalResult {
@@ -19,20 +49,42 @@ export function microdataSignal($: CheerioAPI): SignalResult {
   const title = readValue($, '[itemprop="headline"]') || readValue($, '[itemprop="name"]');
   if (title) { fields.title = title; confidence.title = CONF; }
 
-  const authorText = readValue($, '[itemprop="author"]');
-  if (authorText) {
-    const parsed = parseAuthorName(authorText);
-    if (parsed) { fields.author = [parsed]; confidence.author = CONF; }
+  const authorValues = readValues($, '[itemprop="author"] [itemprop="name"], [itemprop="author"]');
+  if (authorValues.length) {
+    const parsed = authorValues.flatMap((author) => parseAuthorList(author));
+    if (parsed.length) { fields.author = parsed; confidence.author = CONF; }
   }
 
-  const datePublished = readValue($, '[itemprop="datePublished"]');
+  const datePublished =
+    readValue($, '[itemprop="datePublished"]') ||
+    readValue($, '[itemprop="dateCreated"]') ||
+    readValue($, '[itemprop="dateModified"]');
   if (datePublished) {
-    const dp = parseIsoDate(datePublished);
+    const dp = parseDate(datePublished);
     if (dp) { fields.issued = { 'date-parts': [dp] }; confidence.issued = CONF; }
   }
 
   const publisher = readValue($, '[itemprop="publisher"] [itemprop="name"]') || readValue($, '[itemprop="publisher"]');
   if (publisher) { fields.publisher = publisher; confidence.publisher = CONF; }
+
+  const container = readValue($, '[itemprop="isPartOf"] [itemprop="name"]');
+  if (container) { fields['container-title'] = container; confidence['container-title'] = CONF; }
+
+  const doi = firstDoi(readValues($, '[itemprop="identifier"], [itemprop="sameAs"]'));
+  if (doi) { fields.DOI = doi; confidence.DOI = CONF; }
+
+  const volume = readValue($, '[itemprop="volumeNumber"], [itemprop="volume"]');
+  if (volume) { fields.volume = volume; confidence.volume = CONF; }
+
+  const issue = readValue($, '[itemprop="issueNumber"], [itemprop="issue"]');
+  if (issue) { fields.issue = issue; confidence.issue = CONF; }
+
+  const page = readValue($, '[itemprop="pagination"]') ||
+    pageRange(readValue($, '[itemprop="pageStart"]'), readValue($, '[itemprop="pageEnd"]'));
+  if (page) { fields.page = page; confidence.page = CONF; }
+
+  const abstract = readValue($, '[itemprop="abstract"]');
+  if (abstract) { fields.abstract = abstract; confidence.abstract = CONF; }
 
   return { fields, confidence };
 }

--- a/functions/lib/extract/signals/opengraph.ts
+++ b/functions/lib/extract/signals/opengraph.ts
@@ -1,15 +1,24 @@
 import type { CheerioAPI } from 'cheerio';
 import type { CSLItem } from '../../csl-types';
-import { parseAuthorName } from '../author-parse';
-import { parseIsoDate } from '../date-parse';
+import { parseAuthorList } from '../author-parse';
+import { parseDate } from '../date-parse';
 import type { SignalResult } from './jsonld';
 
 const CONF = 0.75;
 const AUTHOR_CONF = 0.6;
 
 function meta($: CheerioAPI, prop: string): string | null {
-  const v = $(`meta[property="${prop}"]`).attr('content');
+  const v = $(`meta[property="${prop}" i], meta[name="${prop}" i]`).attr('content');
   return v ? v.trim() || null : null;
+}
+
+function metaAll($: CheerioAPI, prop: string): string[] {
+  const out: string[] = [];
+  $(`meta[property="${prop}" i], meta[name="${prop}" i]`).each((_, el) => {
+    const v = $(el).attr('content');
+    if (v && v.trim()) out.push(v.trim());
+  });
+  return out;
 }
 
 export function openGraphSignal($: CheerioAPI): SignalResult {
@@ -25,16 +34,18 @@ export function openGraphSignal($: CheerioAPI): SignalResult {
   const url = meta($, 'og:url');
   if (url) { fields.URL = url; confidence.URL = CONF; }
 
-  const pub = meta($, 'article:published_time');
+  const pub = meta($, 'article:published_time') || meta($, 'article:modified_time') || meta($, 'og:updated_time');
   if (pub) {
-    const dp = parseIsoDate(pub);
+    const dp = parseDate(pub);
     if (dp) { fields.issued = { 'date-parts': [dp] }; confidence.issued = CONF; }
   }
 
-  const author = meta($, 'article:author');
-  if (author && !/^https?:\/\//i.test(author)) {
-    const parsed = parseAuthorName(author);
-    if (parsed) { fields.author = [parsed]; confidence.author = AUTHOR_CONF; }
+  const authors = metaAll($, 'article:author')
+    .filter((author) => !/^https?:\/\//i.test(author))
+    .flatMap((author) => parseAuthorList(author));
+  if (authors.length) {
+    fields.author = authors;
+    confidence.author = AUTHOR_CONF;
   }
 
   return { fields, confidence };

--- a/functions/lib/extract/signals/twitter.ts
+++ b/functions/lib/extract/signals/twitter.ts
@@ -5,7 +5,7 @@ import type { SignalResult } from './jsonld';
 const CONF = 0.55;
 
 function meta($: CheerioAPI, name: string): string | null {
-  const v = $(`meta[name="twitter:${name}"]`).attr('content');
+  const v = $(`meta[name="twitter:${name}" i], meta[property="twitter:${name}" i]`).attr('content');
   return v ? v.trim() || null : null;
 }
 

--- a/functions/lib/journal/doi-detect.ts
+++ b/functions/lib/journal/doi-detect.ts
@@ -1,13 +1,66 @@
 import type { CheerioAPI } from 'cheerio';
 
-const DOI_RE = /\b(10\.\d{4,9}\/[-._;()/:A-Z0-9]+)/i;
+const DOI_RE = /\b(10\.\d{4,9}\/[^\s"'#?]+)/i;
+const DOI_EXACT_RE = /^(10\.\d{4,9}\/[^\s"'#?]+)$/i;
+
+function stripPairedWrappers(value: string): string {
+  let s = value.trim();
+  const pairs: Array<[string, string]> = [
+    ['<', '>'],
+    ['(', ')'],
+    ['[', ']'],
+    ['{', '}'],
+    ['"', '"'],
+    ["'", "'"],
+    ['“', '”'],
+    ['‘', '’'],
+  ];
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [open, close] of pairs) {
+      if (s.startsWith(open) && s.endsWith(close)) {
+        s = s.slice(open.length, -close.length).trim();
+        changed = true;
+      }
+    }
+  }
+  return s;
+}
+
+function stripUnmatchedTrailing(value: string, open: string, close: string): string {
+  let s = value;
+  while (s.endsWith(close)) {
+    let balance = 0;
+    for (const ch of s) {
+      if (ch === open) balance += 1;
+      else if (ch === close) balance -= 1;
+    }
+    if (balance >= 0) break;
+    s = s.slice(0, -1).trim();
+  }
+  return s;
+}
+
+function normalizeDoiCandidate(input: string): string {
+  let s = stripPairedWrappers(input);
+  s = s.replace(/[.,;:]+$/g, '');
+  s = stripPairedWrappers(s);
+  s = s.replace(/^https?:\/\/(dx\.)?doi\.org\//i, '');
+  s = s.replace(/^doi:\s*/i, '');
+  s = s.replace(/[?#].*$/, '');
+  s = stripPairedWrappers(s);
+  s = s.replace(/[.,;:]+$/g, '');
+  s = stripUnmatchedTrailing(s, '(', ')');
+  s = stripUnmatchedTrailing(s, '[', ']');
+  s = stripUnmatchedTrailing(s, '{', '}');
+  return s;
+}
 
 export function validateDoi(input: string | null | undefined): string | null {
   if (!input) return null;
-  let s = String(input).trim();
-  s = s.replace(/^https?:\/\/(dx\.)?doi\.org\//i, '');
-  s = s.replace(/^doi:\s*/i, '');
-  const m = s.match(/^(10\.\d{4,9}\/[-._;()/:A-Z0-9]+)$/i);
+  const s = normalizeDoiCandidate(String(input));
+  const m = s.match(DOI_EXACT_RE);
   return m ? m[1] : null;
 }
 

--- a/functions/lib/journal/normalize.ts
+++ b/functions/lib/journal/normalize.ts
@@ -33,12 +33,12 @@ export function normalizeCrossref(work: CrossrefWork): CSLItem {
 }
 
 export function normalizeOpenAlex(work: OpenAlexWork): CSLItem {
-  const doi = validateDoi(work.doi) || '';
+  const doi = validateDoi(work.doi) || validateDoi(work.primary_location?.id) || '';
   const csl: CSLItem = {
     id: doi,
     type: 'article-journal',
   };
-  if (work.title) csl.title = work.title;
+  if (work.title || work.display_name) csl.title = work.title || work.display_name;
   if (work.authorships?.length) {
     const a: CSLName[] = [];
     for (const aa of work.authorships) {
@@ -49,14 +49,25 @@ export function normalizeOpenAlex(work: OpenAlexWork): CSLItem {
     }
     if (a.length) csl.author = a;
   }
-  if (work.host_venue?.display_name) csl['container-title'] = work.host_venue.display_name;
+  const containerTitle =
+    work.host_venue?.display_name ||
+    work.primary_location?.source?.display_name ||
+    work.primary_location?.raw_source_name ||
+    undefined;
+  if (containerTitle) csl['container-title'] = containerTitle;
   if (work.publication_date) {
     const dp = parseIsoDate(work.publication_date);
     if (dp) csl.issued = { 'date-parts': [dp] };
+  } else if (work.publication_year) {
+    csl.issued = { 'date-parts': [[work.publication_year]] };
   }
   if (doi) csl.DOI = doi;
-  if (work.volume) csl.volume = work.volume;
-  if (work.issue) csl.issue = work.issue;
-  if (work.first_page) csl.page = work.last_page ? `${work.first_page}-${work.last_page}` : work.first_page;
+  const volume = work.volume || work.biblio?.volume || undefined;
+  const issue = work.issue || work.biblio?.issue || undefined;
+  const firstPage = work.first_page || work.biblio?.first_page || undefined;
+  const lastPage = work.last_page || work.biblio?.last_page || undefined;
+  if (volume) csl.volume = volume;
+  if (issue) csl.issue = issue;
+  if (firstPage) csl.page = lastPage ? `${firstPage}-${lastPage}` : firstPage;
   return csl;
 }

--- a/functions/lib/journal/openalex.ts
+++ b/functions/lib/journal/openalex.ts
@@ -1,8 +1,21 @@
 export interface OpenAlexWork {
+  display_name?: string;
   title?: string;
   authorships?: Array<{ author?: { display_name?: string } }>;
   host_venue?: { display_name?: string };
+  primary_location?: {
+    id?: string;
+    raw_source_name?: string | null;
+    source?: { display_name?: string | null } | null;
+  };
+  biblio?: {
+    volume?: string | null;
+    issue?: string | null;
+    first_page?: string | null;
+    last_page?: string | null;
+  };
   publication_date?: string;
+  publication_year?: number;
   doi?: string;
   volume?: string;
   issue?: string;

--- a/functions/lib/provenance/merge.ts
+++ b/functions/lib/provenance/merge.ts
@@ -1,0 +1,120 @@
+import type { CSLItem, CSLType, FieldEvidence, FieldProvenance } from '../csl-types';
+import type { PipelineResult } from '../extract/pipeline';
+import { EXTRACT_MERGEABLE_FIELDS, sameEvidenceValue } from '../extract/merge';
+
+const FIELD_ORDER = EXTRACT_MERGEABLE_FIELDS;
+
+export interface MergedCitationEvidence {
+  csl: CSLItem;
+  signals: Record<string, string>;
+  provenance: Partial<Record<keyof CSLItem, FieldProvenance>>;
+}
+
+export function mergePipelineResults(results: PipelineResult[], fallbackUrl: string): MergedCitationEvidence {
+  const provenance: Partial<Record<keyof CSLItem, FieldProvenance>> = {};
+  const signals: Record<string, string> = {};
+
+  for (const field of FIELD_ORDER) {
+    const candidates = results.flatMap((result) => result.provenance[field]?.candidates ?? []);
+    if (!candidates.length) continue;
+    const winner = chooseWinner(candidates);
+    provenance[field] = {
+      winner,
+      candidates,
+      conflicts: candidates.filter((candidate) => !sameEvidenceValue(candidate.normalizedValue, winner.normalizedValue)),
+    };
+    signals[field] = winner.source;
+  }
+
+  const merged: CSLItem = {
+    id: fallbackUrl,
+    type: chooseType(results),
+    URL: fallbackUrl,
+  };
+  for (const field of FIELD_ORDER) {
+    const winner = provenance[field]?.winner;
+    if (winner) (merged as any)[field] = winner.normalizedValue;
+  }
+  merged.URL = typeof merged.URL === 'string' && merged.URL ? merged.URL : fallbackUrl;
+  dedupePublisherContainer(merged, provenance);
+
+  return { csl: merged, signals, provenance };
+}
+
+export function addEvidenceToResult(
+  base: MergedCitationEvidence,
+  evidence: FieldEvidence[],
+): MergedCitationEvidence {
+  const result: PipelineResult = {
+    csl: base.csl,
+    signals: base.signals,
+    provenance: base.provenance,
+  };
+  const synthetic: PipelineResult = {
+    csl: base.csl,
+    signals: {},
+    provenance: {},
+  };
+  for (const item of evidence) {
+    synthetic.provenance[item.field] = {
+      winner: item,
+      candidates: [item],
+      conflicts: [],
+    };
+  }
+  return mergePipelineResults([result, synthetic], base.csl.URL || base.csl.id);
+}
+
+function chooseWinner(candidates: FieldEvidence[]): FieldEvidence {
+  return candidates.reduce((best, next) => {
+    if (next.confidence > best.confidence) return next;
+    if (next.confidence < best.confidence) return best;
+    return sourceRank(next) > sourceRank(best) ? next : best;
+  });
+}
+
+function sourceRank(evidence: FieldEvidence): number {
+  switch (evidence.source) {
+    case 'user-edit': return 100;
+    case 'crossref':
+    case 'openalex':
+    case 'openlibrary':
+    case 'google-books': return 90;
+    case 'browser-extension': return 80;
+    case 'jsonld':
+    case 'microdata':
+    case 'meta': return 70;
+    case 'opengraph': return 60;
+    case 'heuristic': return 50;
+    case 'ai-extract': return 40;
+    case 'twitter': return 30;
+    case 'input': return 20;
+    default: return 10;
+  }
+}
+
+function chooseType(results: PipelineResult[]): CSLType {
+  if (results.some((result) => result.csl.type === 'article-journal')) return 'article-journal';
+  if (results.some((result) => result.csl.type === 'article-newspaper')) return 'article-newspaper';
+  if (results.some((result) => result.csl.type === 'article-magazine')) return 'article-magazine';
+  if (results.some((result) => result.csl.type === 'book')) return 'book';
+  return 'webpage';
+}
+
+function dedupePublisherContainer(
+  item: CSLItem,
+  provenance: Partial<Record<keyof CSLItem, FieldProvenance>>,
+): void {
+  if (item.publisher && item['container-title']
+    && normalizeComparable(item.publisher) === normalizeComparable(item['container-title'])) {
+    delete item.publisher;
+    delete provenance.publisher;
+  }
+}
+
+function normalizeComparable(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/^the\s+/, '')
+    .replace(/[^\p{L}\p{N}]+/gu, '');
+}

--- a/functions/lib/test-context.ts
+++ b/functions/lib/test-context.ts
@@ -1,9 +1,8 @@
 /**
  * Detect whether an incoming API request is opting out of analytics
- * emission. Two signals, either is sufficient:
+ * emission.
  *
  *   - Header `X-Mla-Test: 1` — works for any method (incl. POST /api/format)
- *   - Query `?nocache=1`     — reuses the existing cache-bypass convention
  *
  * Handlers consult this once at the request boundary and pass `undefined`
  * for the analytics binding when it returns true. The writeEvent function
@@ -17,10 +16,5 @@
  */
 export function isTestRequest(req: Request): boolean {
   if (req.headers.get('x-mla-test') === '1') return true;
-  try {
-    if (new URL(req.url).searchParams.get('nocache') === '1') return true;
-  } catch {
-    /* malformed URL — treat as non-test */
-  }
   return false;
 }

--- a/functions/lib/validation/citation-quality.ts
+++ b/functions/lib/validation/citation-quality.ts
@@ -1,0 +1,189 @@
+import type {
+  AcquisitionAttempt,
+  AcquisitionSource,
+  CitationQualityWarning,
+  CSLItem,
+  FieldEvidence,
+  FieldProvenance,
+  SupportedStyle,
+  ExtractQuality,
+} from '../csl-types';
+
+export interface ValidateCitationOptions {
+  style?: SupportedStyle;
+  provenance?: Partial<Record<keyof CSLItem, FieldProvenance>>;
+  acquisition?: Partial<Record<AcquisitionSource, AcquisitionAttempt>>;
+}
+
+export function validateCitationQuality(csl: CSLItem, options: ValidateCitationOptions = {}): ExtractQuality {
+  const warnings: CitationQualityWarning[] = [];
+  const provenance = options.provenance ?? {};
+
+  if (!hasText(csl.title)) {
+    warnings.push({
+      code: 'title_missing',
+      field: 'title',
+      severity: 'error',
+      message: 'No title was found. A citation usually needs a source title before it is ready to use.',
+      action: 'review-field',
+    });
+  }
+
+  if (!hasAuthors(csl)) {
+    warnings.push({
+      code: 'author_not_found',
+      field: 'author',
+      severity: 'review',
+      message: 'No author was found. If this source lists a person or organization, add it. If the page has no listed author, this may be correct.',
+      action: 'confirm-no-listed-author',
+    });
+  }
+
+  if (!hasIssuedDate(csl)) {
+    warnings.push({
+      code: 'date_not_found',
+      field: 'issued',
+      severity: 'review',
+      message: 'No publication date was found. Review the source for a posted or updated date; otherwise the citation will use the style\'s no-date fallback.',
+      action: 'review-field',
+    });
+  }
+
+  if (csl.type === 'webpage' && !hasText(csl.URL)) {
+    warnings.push({
+      code: 'url_missing',
+      field: 'URL',
+      severity: 'error',
+      message: 'No URL was found for this web source. Add the source URL before using the citation.',
+      action: 'review-field',
+    });
+  }
+
+  if (csl.type === 'article-journal') {
+    if (!hasText(csl['container-title'])) {
+      warnings.push({
+        code: 'journal_title_missing',
+        field: 'container-title',
+        severity: 'warning',
+        message: 'No journal name was found. Journal articles usually need the journal title for an accurate citation.',
+        action: 'review-field',
+      });
+    }
+    if (!hasText(csl.volume)) {
+      warnings.push({
+        code: 'journal_volume_missing',
+        field: 'volume',
+        severity: 'review',
+        message: 'No volume number was found. Add it if the article page or DOI record lists one.',
+        action: 'review-field',
+      });
+    }
+    if (!hasText(csl.page) && !hasText(csl.DOI) && !hasText(csl.URL)) {
+      warnings.push({
+        code: 'journal_locator_missing',
+        field: 'page',
+        severity: 'warning',
+        message: 'No page range, DOI, or URL was found. Add at least one stable locator if the source provides it.',
+        action: 'review-field',
+      });
+    }
+  }
+
+  for (const [field, item] of Object.entries(provenance) as Array<[keyof CSLItem, FieldProvenance]>) {
+    if (item.conflicts.length > 0) {
+      warnings.push({
+        code: `${String(field)}_conflict`,
+        field,
+        severity: field === 'DOI' ? 'warning' : 'review',
+        message: conflictMessage(field),
+        action: 'review-field',
+        evidence: compactEvidence([item.winner, ...item.conflicts]),
+      });
+    }
+  }
+
+  for (const attempt of Object.values(options.acquisition ?? {})) {
+    if (!attempt) continue;
+    if (attempt.status === 'blocked') {
+      warnings.push({
+        code: `${attempt.source}_blocked`,
+        severity: 'warning',
+        message: 'This site blocked automated access. Use the browser extension, paste page text, or enter the citation details manually.',
+        action: 'use-extension',
+      });
+    } else if (attempt.status === 'partial') {
+      warnings.push({
+        code: `${attempt.source}_partial`,
+        severity: 'review',
+        message: 'The page appeared to load only partially. Review the citation fields before using the result.',
+        action: attempt.source === 'fetch' ? 'try-rendered-page' : 'review-field',
+      });
+    }
+  }
+
+  return {
+    score: scoreWarnings(warnings),
+    warnings: dedupeWarnings(warnings),
+    acquisition: options.acquisition,
+  };
+}
+
+function hasText(value: unknown): boolean {
+  return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasAuthors(csl: CSLItem): boolean {
+  return Array.isArray(csl.author) && csl.author.some((name) => {
+    if ('literal' in name) return hasText(name.literal);
+    return hasText(name.family) || hasText(name.given);
+  });
+}
+
+function hasIssuedDate(csl: CSLItem): boolean {
+  return !!csl.issued?.['date-parts']?.[0]?.[0] || hasText(csl.issued?.literal) || hasText(csl.issued?.raw);
+}
+
+function conflictMessage(field: keyof CSLItem): string {
+  if (field === 'issued') return 'We found more than one publication date. Review the date field before using this citation.';
+  if (field === 'author') return 'We found conflicting author information. Review the author field before using this citation.';
+  if (field === 'DOI') return 'We found conflicting DOI information. Review the DOI before using this citation.';
+  return `We found conflicting ${String(field)} information. Review this field before using the citation.`;
+}
+
+function compactEvidence(items: Array<FieldEvidence | undefined>): FieldEvidence[] {
+  return items
+    .filter((item): item is FieldEvidence => !!item)
+    .slice(0, 4)
+    .map((item) => ({
+      field: item.field,
+      normalizedValue: item.normalizedValue,
+      rawValue: item.rawValue,
+      source: item.source,
+      acquisition: item.acquisition,
+      confidence: item.confidence,
+      snippet: item.snippet,
+      locator: item.locator,
+    }));
+}
+
+function scoreWarnings(warnings: CitationQualityWarning[]): number {
+  const penalty = warnings.reduce((sum, warning) => {
+    if (warning.severity === 'error') return sum + 35;
+    if (warning.severity === 'warning') return sum + 20;
+    if (warning.severity === 'review') return sum + 10;
+    return sum + 3;
+  }, 0);
+  return Math.max(0, 100 - penalty);
+}
+
+function dedupeWarnings(warnings: CitationQualityWarning[]): CitationQualityWarning[] {
+  const seen = new Set<string>();
+  const out: CitationQualityWarning[] = [];
+  for (const warning of warnings) {
+    const key = `${warning.code}:${String(warning.field ?? '')}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(warning);
+  }
+  return out;
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "build-tailwind": "tailwindcss -i ./src/styles/tailwind.css -o ./src/styles/tailwind-output.css",
     "test": "vitest run",
     "test:watch": "vitest",
+    "eval:citation-acquisition": "node scripts/eval-citation-acquisition.mjs",
     "indexnow:dry-run": "node scripts/submit-indexnow.mjs --dry-run",
     "indexnow:submit": "node scripts/submit-indexnow.mjs"
   },

--- a/scripts/eval-citation-acquisition.mjs
+++ b/scripts/eval-citation-acquisition.mjs
@@ -1,0 +1,78 @@
+import { readFileSync } from 'node:fs';
+
+const args = new Map();
+for (let i = 2; i < process.argv.length; i += 1) {
+  const arg = process.argv[i];
+  if (!arg.startsWith('--')) continue;
+  const key = arg.slice(2);
+  const next = process.argv[i + 1];
+  if (next && !next.startsWith('--')) {
+    args.set(key, next);
+    i += 1;
+  } else {
+    args.set(key, '1');
+  }
+}
+
+const baseUrl = args.get('base-url') || 'http://localhost:8788';
+const samplePath = args.get('sample') || 'tests/evals/citation-acquisition-urls.json';
+const internalToken = args.get('internal-token') || process.env.CITATION_INTERNAL_DEBUG_TOKEN || '';
+const sample = JSON.parse(readFileSync(samplePath, 'utf8'));
+const entries = sample.map((item) => typeof item === 'string' ? { url: item } : item);
+
+const results = [];
+for (const entry of entries) {
+  const started = Date.now();
+  const endpoint = new URL('/api/cite-website', baseUrl);
+  endpoint.searchParams.set('url', entry.url);
+  const headers = { 'x-mla-test': '1' };
+  if (internalToken) {
+    headers['x-mla-internal-token'] = internalToken;
+    endpoint.searchParams.set('nocache', '1');
+    if (entry.acquisition) endpoint.searchParams.set('acquisition', entry.acquisition);
+  }
+  try {
+    const res = await fetch(endpoint, { headers });
+    const body = await res.json().catch(() => ({}));
+    results.push({
+      url: entry.url,
+      ok: res.ok,
+      status: res.status,
+      durationMs: Date.now() - started,
+      fields: Object.keys(body.csl || {}).filter((key) => body.csl[key] !== undefined),
+      warnings: body._quality?.warnings?.map((warning) => warning.code) ?? [],
+      acquisition: Object.fromEntries(Object.entries(body._quality?.acquisition || {}).map(([key, value]) => [key, value.status])),
+    });
+  } catch (err) {
+    results.push({
+      url: entry.url,
+      ok: false,
+      status: 0,
+      durationMs: Date.now() - started,
+      error: err.message,
+      fields: [],
+      warnings: [],
+      acquisition: {},
+    });
+  }
+}
+
+const summary = {
+  baseUrl,
+  samplePath,
+  total: results.length,
+  ok: results.filter((r) => r.ok).length,
+  avgDurationMs: average(results.map((r) => r.durationMs)),
+  avgFields: average(results.map((r) => r.fields.length)),
+  warningRate: average(results.map((r) => r.warnings.length > 0 ? 1 : 0)),
+  renderUsed: results.filter((r) => r.acquisition.render && r.acquisition.render !== 'skipped').length,
+  aiUsed: results.filter((r) => r.acquisition.ai && r.acquisition.ai !== 'skipped').length,
+  results,
+};
+
+console.log(JSON.stringify(summary, null, 2));
+
+function average(values) {
+  if (!values.length) return 0;
+  return Math.round((values.reduce((sum, value) => sum + value, 0) / values.length) * 100) / 100;
+}

--- a/src/components/react/EditCitationForm.tsx
+++ b/src/components/react/EditCitationForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useCallback, useEffect, useRef } from 'react';
 import type { StoredSource } from '../../lib/references/storage';
-import type { CSLItem } from '../../lib/citations/csl-types';
+import type { CitationQualityWarning, CSLItem } from '../../lib/citations/csl-types';
 import {
     Title,
     WebsiteName,
@@ -11,11 +11,20 @@ import {
     AccessDate,
     Edition,
     VolumeNumber,
+    IssueNumber,
+    PageRange,
     Publisher,
+    JournalName,
     DOI,
+    type FieldWarning,
 } from './EditCitationFormComponents';
 import { useDebounce } from '../../hooks/useDebounce';
 import SimpleDropdown from './SimpleDropdown';
+import {
+    isCitationWarningDismissed,
+    isDismissibleCitationWarning,
+    warningDismissalKey,
+} from '../../lib/references/warnings';
 
 interface CitationOption { label: string; value: CSLItem['type']; }
 
@@ -37,6 +46,15 @@ interface Props {
 
 export default function EditCitationForm({ source, setSources, currentRef }: Props) {
     const [local, setLocal] = useState<CSLItem>(source.csl);
+    const dismissWarning = useCallback((warningKey: string) => {
+        setSources((prev) => prev.map((item) => {
+            if (item.uuid !== source.uuid) return item;
+            const existing = item.dismissedWarningKeys ?? [];
+            if (existing.includes(warningKey)) return item;
+            return { ...item, dismissedWarningKeys: [...existing, warningKey] };
+        }));
+    }, [setSources, source.uuid]);
+    const fieldWarnings = warningMapFor(source.quality?.warnings ?? [], local, source.dismissedWarningKeys, dismissWarning);
 
     // Read the latest `local` via ref inside the debounced flush so the 500ms
     // timer always writes the most recent state, regardless of how many
@@ -81,33 +99,123 @@ export default function EditCitationForm({ source, setSources, currentRef }: Pro
                 />
             </div>
             <Line className="my-4" />
-            <Title value={local.title || ''} onChange={(v) => patch({ title: v })} isRequired />
+            <Title value={local.title || ''} onChange={(v) => patch({ title: v })} isRequired warning={fieldWarnings.title} />
             {local.type === 'webpage' && (
-                <WebsiteName value={local['container-title'] || ''} onChange={(v) => patch({ 'container-title': v })} />
+                <WebsiteName value={local['container-title'] || ''} onChange={(v) => patch({ 'container-title': v })} warning={fieldWarnings['container-title']} />
             )}
             <Line className="my-4" />
-            <Contributors authors={local.author ?? []} onChange={(next) => patch({ author: next })} />
+            <Contributors authors={local.author ?? []} onChange={(next) => patch({ author: next })} warning={fieldWarnings.author} />
             <Line className="my-4" />
-            <PublicationDate value={local.issued} onChange={(d) => patch({ issued: d })} isRecommended />
+            <PublicationDate value={local.issued} onChange={(d) => patch({ issued: d })} isRecommended warning={fieldWarnings.issued} />
             <AccessDate value={local.accessed} onChange={(d) => patch({ accessed: d })} />
             <Line className="my-4" />
             {(local.type === 'webpage' || local.type === 'book' || local.type === 'article-journal') && (
-                <UrlField value={local.URL || ''} onChange={(v) => patch({ URL: v })} isRecommended />
+                <UrlField value={local.URL || ''} onChange={(v) => patch({ URL: v })} isRecommended warning={fieldWarnings.URL} />
             )}
             {local.type === 'book' && (
                 <>
-                    <Edition value={local.edition || ''} onChange={(v) => patch({ edition: v })} />
-                    <VolumeNumber value={local.volume || ''} onChange={(v) => patch({ volume: v })} />
-                    <Publisher value={local.publisher || ''} onChange={(v) => patch({ publisher: v })} isRecommended />
-                    <DOI value={local.DOI || ''} onChange={(v) => patch({ DOI: v })} />
+                    <Edition value={local.edition || ''} onChange={(v) => patch({ edition: v })} warning={fieldWarnings.edition} />
+                    <VolumeNumber value={local.volume || ''} onChange={(v) => patch({ volume: v })} warning={fieldWarnings.volume} />
+                    <Publisher value={local.publisher || ''} onChange={(v) => patch({ publisher: v })} isRecommended warning={fieldWarnings.publisher} />
+                    <DOI value={local.DOI || ''} onChange={(v) => patch({ DOI: v })} warning={fieldWarnings.DOI} />
                 </>
             )}
             {local.type === 'article-journal' && (
                 <>
-                    <Publisher value={local['container-title'] || ''} onChange={(v) => patch({ 'container-title': v })} isRecommended />
-                    <DOI value={local.DOI || ''} onChange={(v) => patch({ DOI: v })} isRecommended />
+                    <JournalName value={local['container-title'] || ''} onChange={(v) => patch({ 'container-title': v })} isRecommended warning={fieldWarnings['container-title']} />
+                    <VolumeNumber value={local.volume || ''} onChange={(v) => patch({ volume: v })} isRecommended warning={fieldWarnings.volume} />
+                    <IssueNumber value={local.issue || ''} onChange={(v) => patch({ issue: v })} warning={fieldWarnings.issue} />
+                    <PageRange value={local.page || ''} onChange={(v) => patch({ page: v })} isRecommended warning={fieldWarnings.page} />
+                    <DOI value={local.DOI || ''} onChange={(v) => patch({ DOI: v })} isRecommended warning={fieldWarnings.DOI} />
                 </>
             )}
         </div>
     );
+}
+
+function warningMapFor(
+    warnings: CitationQualityWarning[],
+    csl: CSLItem,
+    dismissedWarningKeys: readonly string[] | undefined,
+    onDismissWarning: (warningKey: string) => void,
+): Partial<Record<keyof CSLItem, FieldWarning>> {
+    const out: Partial<Record<keyof CSLItem, FieldWarning>> = {};
+    for (const warning of warnings) {
+        if (isCitationWarningDismissed(warning, dismissedWarningKeys)) continue;
+        if (!warning.field || warningResolved(warning, csl)) continue;
+        const warningKey = warningDismissalKey(warning);
+        const dismissible = isDismissibleCitationWarning(warning);
+        const next = {
+            message: conciseWarningMessage(warning),
+            severity: warning.severity,
+            dismissible,
+            onDismiss: dismissible ? () => onDismissWarning(warningKey) : undefined,
+        };
+        const current = out[warning.field];
+        if (!current || severityRank(next.severity) > severityRank(current.severity)) {
+            out[warning.field] = next;
+        }
+    }
+    return out;
+}
+
+function conciseWarningMessage(warning: CitationQualityWarning): string {
+    switch (warning.code) {
+        case 'title_missing':
+            return 'Add the source title before using this citation.';
+        case 'author_not_found':
+            return 'Add the listed author or organization, if the source has one.';
+        case 'date_not_found':
+            return 'Add the published or updated date, if the source lists one.';
+        case 'url_missing':
+            return 'Add the source URL.';
+        case 'journal_title_missing':
+            return 'Add the journal name.';
+        case 'journal_volume_missing':
+            return 'Add the volume number if the source lists one.';
+        case 'journal_locator_missing':
+            return 'Add a page range, DOI, or URL if one is available.';
+        case 'issued_conflict':
+            return 'Multiple dates were found; confirm the date shown here.';
+        case 'author_conflict':
+            return 'Multiple author values were found; confirm this list.';
+        case 'DOI_conflict':
+            return 'Multiple DOIs were found; confirm this value.';
+        case 'title_conflict':
+            return 'Multiple titles were found; confirm this title.';
+        default:
+            if (warning.code.endsWith('_conflict')) return 'Conflicting source data was found; confirm this value.';
+            return warning.message;
+    }
+}
+
+function warningResolved(warning: CitationQualityWarning, csl: CSLItem): boolean {
+    if (!warning.code.includes('missing') && !warning.code.includes('not_found')) return false;
+    const field = warning.field;
+    if (warning.code === 'journal_locator_missing') {
+        return hasStringValue(csl.page) || hasStringValue(csl.DOI) || hasStringValue(csl.URL);
+    }
+    if (field === 'author') return hasAuthorValue(csl.author);
+    if (field === 'issued') return !!csl.issued?.['date-parts']?.[0]?.[0] || !!csl.issued?.literal || !!csl.issued?.raw;
+    const value = field ? csl[field] : undefined;
+    return hasStringValue(value);
+}
+
+function hasStringValue(value: unknown): boolean {
+    return typeof value === 'string' && value.trim().length > 0;
+}
+
+function hasAuthorValue(author: CSLItem['author']): boolean {
+    return Array.isArray(author) && author.some((name) => {
+        if ('literal' in name) return hasStringValue(name.literal);
+        return hasStringValue(name.family) || hasStringValue(name.given);
+    });
+}
+
+function severityRank(severity: FieldWarning['severity']): number {
+    if (severity === 'error') return 4;
+    if (severity === 'warning') return 3;
+    if (severity === 'review') return 2;
+    if (severity === 'info') return 1;
+    return 0;
 }

--- a/src/components/react/EditCitationFormComponents.tsx
+++ b/src/components/react/EditCitationFormComponents.tsx
@@ -2,17 +2,19 @@ import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Input } from "./Input";
 import { cn } from "./utils";
 import { Button } from "./Button";
-import { Building2, Calendar, ChevronDown, Trash2, UserRound } from "lucide-react";
+import { AlertTriangle, Building2, Calendar, ChevronDown, Trash2, UserRound, X } from "lucide-react";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "./Tabs";
 import type { CSLDate, CSLName } from "../../lib/citations/csl-types";
 import type { Option } from './Dropdown';
 import SimpleDropdown from './SimpleDropdown';
+import styles from '../../styles/references.module.css';
 
 interface TextComponentProps {
     value: string;
     onChange: (value: string) => void;
     isRequired?: boolean;
     isRecommended?: boolean;
+    warning?: FieldWarning;
 }
 
 interface DateComponentProps {
@@ -20,6 +22,14 @@ interface DateComponentProps {
     onChange: (value: CSLDate | undefined) => void;
     isRequired?: boolean;
     isRecommended?: boolean;
+    warning?: FieldWarning;
+}
+
+export interface FieldWarning {
+    message: string;
+    severity?: 'info' | 'review' | 'warning' | 'error';
+    dismissible?: boolean;
+    onDismiss?: () => void;
 }
 
 // Add months array at the top level
@@ -47,6 +57,7 @@ export const Line = ({ className }: { className?: string }) => <div className={c
 interface ContributorsProps {
     authors: CSLName[];
     onChange: (authors: CSLName[]) => void;
+    warning?: FieldWarning;
 }
 
 const isPerson = (n: CSLName): n is Exclude<CSLName, { literal: string }> => !('literal' in n);
@@ -54,7 +65,7 @@ const isPerson = (n: CSLName): n is Exclude<CSLName, { literal: string }> => !('
 /**
  * Contributors component — operates on CSL-JSON `author` arrays.
  */
-export const Contributors = ({ authors, onChange }: ContributorsProps) => {
+export const Contributors = ({ authors, onChange, warning }: ContributorsProps) => {
     // Stable per-row ids kept parallel to `authors`, used as React keys and to
     // track the expanded row. Index keys + an uncontrolled <details> meant that
     // deleting a middle contributor left the wrong row expanded showing another
@@ -171,6 +182,7 @@ export const Contributors = ({ authors, onChange }: ContributorsProps) => {
                         <span className="leading-none">Add Organization</span>
                     </Button>
                 </div>
+                <FieldWarningText warning={warning} />
             </div>
         </div>
     );
@@ -186,6 +198,42 @@ const LabelledInput = ({ label, value, onChange, recommended }: { label: string;
     </label>
 );
 
+const FieldWarningText = ({ warning }: { warning?: FieldWarning }) => {
+    if (!warning) return null;
+    const handleDismiss = (event: React.MouseEvent<HTMLButtonElement>) => {
+        event.preventDefault();
+        event.stopPropagation();
+        warning.onDismiss?.();
+    };
+    return (
+        <p
+            className={cn("m-0 flex items-center gap-1.5 text-xs leading-5", styles.fieldWarningText)}
+            data-severity={warning.severity || 'review'}
+        >
+            <AlertTriangle size={13} strokeWidth={1.7} className="shrink-0" aria-hidden="true" />
+            <span className={styles.fieldWarningMessage}>{warning.message}</span>
+            {warning.dismissible && warning.onDismiss && (
+                <button
+                    type="button"
+                    className={styles.fieldWarningDismiss}
+                    onClick={handleDismiss}
+                    aria-label={`Dismiss warning: ${warning.message}`}
+                    title="Dismiss warning"
+                >
+                    <X className={styles.fieldWarningDismissIcon} aria-hidden="true" />
+                </button>
+            )}
+        </p>
+    );
+};
+
+const FieldInputStack = ({ children, warning }: { children: React.ReactNode; warning?: FieldWarning }) => (
+    <div className="flex min-w-0 flex-col gap-1.5">
+        {children}
+        <FieldWarningText warning={warning} />
+    </div>
+);
+
 /**
  * Title component
  * @param value - The value to display
@@ -193,7 +241,7 @@ const LabelledInput = ({ label, value, onChange, recommended }: { label: string;
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const Title = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const Title = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -201,12 +249,14 @@ export const Title = ({ value, onChange, isRequired, isRecommended }: TextCompon
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="Title"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Title"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -218,7 +268,7 @@ export const Title = ({ value, onChange, isRequired, isRecommended }: TextCompon
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const Name = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const Name = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -226,12 +276,14 @@ export const Name = ({ value, onChange, isRequired, isRecommended }: TextCompone
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="Name"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Name"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -243,7 +295,7 @@ export const Name = ({ value, onChange, isRequired, isRecommended }: TextCompone
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const WebsiteName = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const WebsiteName = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -251,12 +303,14 @@ export const WebsiteName = ({ value, onChange, isRequired, isRecommended }: Text
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="Website Name"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Website Name"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -268,7 +322,7 @@ export const WebsiteName = ({ value, onChange, isRequired, isRecommended }: Text
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const Edition = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const Edition = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -276,12 +330,14 @@ export const Edition = ({ value, onChange, isRequired, isRecommended }: TextComp
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="e.g., 3"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="e.g., 3"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -293,7 +349,7 @@ export const Edition = ({ value, onChange, isRequired, isRecommended }: TextComp
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const VolumeNumber = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const VolumeNumber = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -301,12 +357,74 @@ export const VolumeNumber = ({ value, onChange, isRequired, isRecommended }: Tex
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="Volume number"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Volume number"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
+        </label>
+    )
+}
+
+export const IssueNumber = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
+    return (
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
+            <span className="flex flex-col leading-4 text-sm">
+                Issue Number
+                {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
+                {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
+            </span>
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Issue number"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
+        </label>
+    )
+}
+
+export const PageRange = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
+    return (
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
+            <span className="flex flex-col leading-4 text-sm">
+                Page Range
+                {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
+                {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
+            </span>
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Page range"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
+        </label>
+    )
+}
+
+export const JournalName = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
+    return (
+        <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
+            <span className="flex flex-col leading-4 text-sm">
+                Journal Name
+                {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
+                {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
+            </span>
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Journal name"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -318,7 +436,7 @@ export const VolumeNumber = ({ value, onChange, isRequired, isRecommended }: Tex
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const Publisher = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const Publisher = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -326,12 +444,14 @@ export const Publisher = ({ value, onChange, isRequired, isRecommended }: TextCo
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="Publisher"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Publisher"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -343,7 +463,7 @@ export const Publisher = ({ value, onChange, isRequired, isRecommended }: TextCo
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const Medium = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const Medium = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -351,12 +471,14 @@ export const Medium = ({ value, onChange, isRequired, isRecommended }: TextCompo
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="Medium"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Medium"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -368,7 +490,7 @@ export const Medium = ({ value, onChange, isRequired, isRecommended }: TextCompo
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const DOI = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const DOI = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -376,12 +498,14 @@ export const DOI = ({ value, onChange, isRequired, isRecommended }: TextComponen
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="DOI"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="DOI"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -393,7 +517,7 @@ export const DOI = ({ value, onChange, isRequired, isRecommended }: TextComponen
  * @param isRequired - Whether the field is required
  * @param isRecommended - Whether the field is recommended
  */
-export const URL = ({ value, onChange, isRequired, isRecommended }: TextComponentProps) => {
+export const URL = ({ value, onChange, isRequired, isRecommended, warning }: TextComponentProps) => {
     return (
         <label className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
             <span className="flex flex-col leading-4 text-sm">
@@ -401,12 +525,14 @@ export const URL = ({ value, onChange, isRequired, isRecommended }: TextComponen
                 {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
                 {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
             </span>
-            <Input
-                placeholder="Website URL"
-                type="text"
-                value={value}
-                onChange={(e) => onChange(e.target.value)}
-            />
+            <FieldInputStack warning={warning}>
+                <Input
+                    placeholder="Website URL"
+                    type="text"
+                    value={value}
+                    onChange={(e) => onChange(e.target.value)}
+                />
+            </FieldInputStack>
         </label>
     )
 }
@@ -547,27 +673,31 @@ const DateInput = ({ value, onChange, showSetToday }: {
 /**
  * Publication Date component — emits CSL-JSON `date-parts` shape.
  */
-export const PublicationDate = ({ value, onChange, isRequired, isRecommended }: DateComponentProps) => (
+export const PublicationDate = ({ value, onChange, isRequired, isRecommended, warning }: DateComponentProps) => (
     <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:items-center sm:gap-4">
         <span className="flex flex-col leading-4 text-sm">
             Publication Date
             {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
             {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
         </span>
-        <DateInput value={value} onChange={onChange} />
+        <FieldInputStack warning={warning}>
+            <DateInput value={value} onChange={onChange} />
+        </FieldInputStack>
     </div>
 );
 
 /**
  * Access Date component — emits CSL-JSON `date-parts` shape.
  */
-export const AccessDate = ({ value, onChange, isRequired, isRecommended }: DateComponentProps) => (
+export const AccessDate = ({ value, onChange, isRequired, isRecommended, warning }: DateComponentProps) => (
     <div className="flex flex-col gap-1 sm:grid sm:grid-cols-[130px_1fr] sm:gap-4">
         <span className="flex flex-col leading-4 text-sm h-9 justify-center">
             Access Date
             {isRequired && <span className="text-xs text-muted-foreground">Required</span>}
             {isRecommended && <span className="text-xs text-muted-foreground">Recommended</span>}
         </span>
-        <DateInput value={value} onChange={onChange} showSetToday />
+        <FieldInputStack warning={warning}>
+            <DateInput value={value} onChange={onChange} showSetToday />
+        </FieldInputStack>
     </div>
 );

--- a/src/components/react/ReferenceItem.tsx
+++ b/src/components/react/ReferenceItem.tsx
@@ -4,9 +4,10 @@ import { useFormattedCitation } from '../../lib/citations/useFormattedCitation';
 import type { StoredSource } from '../../lib/references/storage';
 import type { SupportedStyle } from '../../lib/citations/csl-types';
 import styles from '../../styles/references.module.css';
-import { Clipboard, Globe } from 'lucide-react';
+import { AlertTriangle, Clipboard, Globe } from 'lucide-react';
 import { escapeHtml, richTextToHtml, richTextToPlain } from './richText';
 import { copyRichText } from './clipboard';
+import { visibleCitationWarnings } from '../../lib/references/warnings';
 
 interface Props {
     source: StoredSource;
@@ -20,6 +21,13 @@ interface Props {
 function ReferenceItem({ source, checked, onToggle, citationFormat, setSources, autoOpenEdit }: Props) {
     const editButtonRef = useRef<HTMLButtonElement>(null);
     const { formatted, loading, error } = useFormattedCitation(source, citationFormat);
+    const visibleWarnings = visibleCitationWarnings(source.quality?.warnings, source.dismissedWarningKeys);
+    const fieldWarnings = visibleWarnings.filter((warning) => warning.field && warning.severity !== 'info');
+    const topFieldWarning = fieldWarnings[0];
+    const hasFieldWarnings = fieldWarnings.length > 0;
+    const warningLabel = topFieldWarning?.severity === 'error'
+        ? 'Citation is missing required information'
+        : 'Citation has fields to review';
 
     useEffect(() => {
         if (autoOpenEdit && editButtonRef.current) editButtonRef.current.click();
@@ -62,6 +70,17 @@ function ReferenceItem({ source, checked, onToggle, citationFormat, setSources, 
                                     : richTextToHtml(formatted),
                         }}
                     />
+                    {hasFieldWarnings && (
+                        <span
+                            className={styles.qualityIndicator}
+                            data-severity={topFieldWarning?.severity || 'review'}
+                            role="img"
+                            aria-label={warningLabel}
+                            title={warningLabel}
+                        >
+                            <AlertTriangle className={styles.qualityIcon} aria-hidden="true" />
+                        </span>
+                    )}
                 </div>
             </label>
             <div className={styles.citationSourceButtons}>

--- a/src/lib/citations/csl-types.ts
+++ b/src/lib/citations/csl-types.ts
@@ -49,11 +49,103 @@ export interface CSLItem {
   abstract?: string;
 }
 
+export type AcquisitionSource =
+  | 'fetch'
+  | 'render'
+  | 'ai'
+  | 'authority'
+  | 'extension'
+  | 'paste'
+  | 'input'
+  | 'user';
+
+export type EvidenceSource =
+  | 'input'
+  | 'jsonld'
+  | 'microdata'
+  | 'opengraph'
+  | 'twitter'
+  | 'meta'
+  | 'heuristic'
+  | 'fetch-html'
+  | 'rendered-html'
+  | 'browser-extension'
+  | 'pasted-text'
+  | 'crossref'
+  | 'openalex'
+  | 'openlibrary'
+  | 'google-books'
+  | 'ai-extract'
+  | 'user-edit';
+
+export interface FieldEvidence {
+  field: keyof CSLItem;
+  normalizedValue: unknown;
+  rawValue?: string;
+  source: EvidenceSource;
+  acquisition?: AcquisitionSource;
+  locator?: string;
+  snippet?: string;
+  confidence: number;
+  acquiredAt?: string;
+}
+
+export interface FieldProvenance {
+  winner?: FieldEvidence;
+  candidates: FieldEvidence[];
+  conflicts: FieldEvidence[];
+}
+
+export type AcquisitionStatus =
+  | 'success'
+  | 'partial'
+  | 'blocked'
+  | 'timeout'
+  | 'error'
+  | 'skipped';
+
+export interface AcquisitionAttempt {
+  source: AcquisitionSource;
+  status: AcquisitionStatus;
+  reason?: string;
+  url?: string;
+  finalUrl?: string;
+  durationMs?: number;
+  htmlSizeKb?: number;
+  browserMs?: number;
+  fieldsFound?: string[];
+}
+
+export interface CitationQualityWarning {
+  code: string;
+  field?: keyof CSLItem;
+  severity: 'info' | 'review' | 'warning' | 'error';
+  message: string;
+  action:
+    | 'none'
+    | 'review-field'
+    | 'choose-source-type'
+    | 'confirm-no-listed-author'
+    | 'try-rendered-page'
+    | 'use-extension'
+    | 'paste-text'
+    | 'enter-manually';
+  evidence?: FieldEvidence[];
+}
+
+export interface ExtractQuality {
+  score: number;
+  warnings: CitationQualityWarning[];
+  acquisition?: Partial<Record<AcquisitionSource, AcquisitionAttempt>>;
+}
+
 export interface ExtractEnvelope {
   uuid: string;
   type: CSLType;
   csl: CSLItem;
   _signals?: Record<string, string>;
+  _provenance?: Partial<Record<keyof CSLItem, FieldProvenance>>;
+  _quality?: ExtractQuality;
   _cached?: boolean;
 }
 

--- a/src/lib/references/inline-csl.ts
+++ b/src/lib/references/inline-csl.ts
@@ -1,0 +1,23 @@
+import type { StoredSource } from './storage';
+import { isStoredSource } from './storage';
+
+export const INLINE_CSL_PARAM = 'csl';
+
+export function decodeInlineCslParam(value: string | null): StoredSource | null {
+  if (!value) return null;
+  try {
+    const json = decodeBase64Url(value);
+    const parsed = JSON.parse(json);
+    return isStoredSource(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function decodeBase64Url(value: string): string {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padded = normalized.padEnd(normalized.length + ((4 - normalized.length % 4) % 4), '=');
+  const binary = atob(padded);
+  const bytes = Uint8Array.from(binary, (char) => char.charCodeAt(0));
+  return new TextDecoder().decode(bytes);
+}

--- a/src/lib/references/storage.ts
+++ b/src/lib/references/storage.ts
@@ -1,10 +1,13 @@
-import type { CSLItem } from '../citations/csl-types';
+import type { CSLItem, ExtractQuality, FieldProvenance } from '../citations/csl-types';
 
 export const STORAGE_KEY = 'sources_v2';
 
 export interface StoredSource {
   uuid: string;
   csl: CSLItem;
+  quality?: ExtractQuality;
+  provenance?: Partial<Record<keyof CSLItem, FieldProvenance>>;
+  dismissedWarningKeys?: string[];
 }
 
 export function loadSources(): StoredSource[] {
@@ -31,7 +34,7 @@ const VALID_CSL_TYPES = new Set([
   'webpage', 'book', 'article-journal', 'article-magazine', 'article-newspaper',
 ]);
 
-function isStoredSource(x: unknown): x is StoredSource {
+export function isStoredSource(x: unknown): x is StoredSource {
   if (!x || typeof x !== 'object') return false;
   const o = x as any;
   if (typeof o.uuid !== 'string') return false;
@@ -43,5 +46,9 @@ function isStoredSource(x: unknown): x is StoredSource {
   // over csl.author / csl.editor crash on corrupted localStorage data.
   if (csl.author !== undefined && !Array.isArray(csl.author)) return false;
   if (csl.editor !== undefined && !Array.isArray(csl.editor)) return false;
+  if (o.dismissedWarningKeys !== undefined
+    && (!Array.isArray(o.dismissedWarningKeys) || o.dismissedWarningKeys.some((key: unknown) => typeof key !== 'string'))) {
+    return false;
+  }
   return true;
 }

--- a/src/lib/references/useReferences.ts
+++ b/src/lib/references/useReferences.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { loadSources, saveSources, STORAGE_KEY, type StoredSource } from './storage';
-import type { CSLItem, SupportedStyle } from '../citations/csl-types';
+import { decodeInlineCslParam, INLINE_CSL_PARAM } from './inline-csl';
+import type { CSLItem, ExtractQuality, FieldProvenance, SupportedStyle } from '../citations/csl-types';
 
 export interface UseReferencesReturn {
   sources: StoredSource[];
@@ -25,6 +26,8 @@ interface ApiEnvelope {
   uuid: string;
   type: CSLItem['type'];
   csl: CSLItem;
+  _quality?: ExtractQuality;
+  _provenance?: Partial<Record<keyof CSLItem, FieldProvenance>>;
 }
 
 export function useReferences(): UseReferencesReturn {
@@ -41,7 +44,11 @@ export function useReferences(): UseReferencesReturn {
   const setSources = useCallback((next: StoredSource[] | ((prev: StoredSource[]) => StoredSource[])) => {
     setSourcesState((prev) => {
       const computed = typeof next === 'function' ? (next as any)(prev) : next;
-      saveSources(computed);
+      // Keep provenance in memory for this session, but never persist it: it is
+      // large (per-field candidate evidence), the client only reads `quality`
+      // for warnings, and saveSources silently drops the whole write on quota
+      // overflow — so a bulky provenance blob could cost the user saved sources.
+      saveSources(computed.map(stripProvenanceForStorage));
       return computed;
     });
   }, []);
@@ -73,7 +80,25 @@ export function useReferences(): UseReferencesReturn {
     const styleParam = params.get('citationStyle');
     if (isSupportedStyle(styleParam)) setCitationFormatState(styleParam);
 
-    setSourcesState(loadSources());
+    const existing = loadSources();
+    const inlineSource = decodeInlineCslParam(params.get(INLINE_CSL_PARAM));
+    if (inlineSource) {
+      const next = existing.some((source) => source.uuid === inlineSource.uuid || source.csl.id === inlineSource.csl.id)
+        ? existing
+        : [...existing, inlineSource];
+      setSourcesState(next);
+      if (next !== existing) saveSources(next);
+      params.delete(INLINE_CSL_PARAM);
+      try {
+        const search = params.toString();
+        window.history.replaceState({}, '', `${window.location.pathname}${search ? `?${search}` : ''}${window.location.hash}`);
+      } catch {
+        // URL cleanup is best-effort; the import itself has already succeeded.
+      }
+      return;
+    }
+
+    setSourcesState(existing);
 
     const website = params.get('website');
     const book = params.get('book');
@@ -91,8 +116,12 @@ export function useReferences(): UseReferencesReturn {
     const timeout = setTimeout(() => controller.abort(), 15_000);
     fetch(requestUrl, { signal: controller.signal })
       .then(async (res) => {
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        return res.json() as Promise<ApiEnvelope>;
+        const body = await res.json().catch(() => ({}));
+        if (!res.ok) {
+          if (website) return errorEnvelopeFromWebsite(website, body);
+          throw new Error(`HTTP ${res.status}`);
+        }
+        return body as ApiEnvelope;
       })
       .then((env) => {
         if (cancelled || !env?.csl) return;
@@ -100,7 +129,12 @@ export function useReferences(): UseReferencesReturn {
         // the user added between mount and fetch resolution aren't clobbered.
         setSources((prev) => prev.some((s) => s.uuid === env.uuid)
           ? prev
-          : [...prev, { uuid: env.uuid, csl: env.csl }]);
+          : [...prev, {
+            uuid: env.uuid,
+            csl: env.csl,
+            quality: env._quality,
+            provenance: env._provenance,
+          }]);
       })
       .catch((err) => { if (!cancelled) console.error('Citation fetch failed', err); })
       .finally(() => clearTimeout(timeout));
@@ -146,5 +180,46 @@ export function useReferences(): UseReferencesReturn {
     selectAll,
     setCitationFormat,
     handleDelete,
+  };
+}
+
+function stripProvenanceForStorage(source: StoredSource): StoredSource {
+  if (source.provenance === undefined) return source;
+  const copy = { ...source };
+  delete copy.provenance;
+  return copy;
+}
+
+function errorEnvelopeFromWebsite(website: string, body: any): ApiEnvelope {
+  const code = typeof body?.code === 'string' ? body.code : 'fetch_failed';
+  const blocked = code === 'blocked' || /blocked|captcha|access/i.test(String(body?.error || ''));
+  const message = blocked
+    ? 'This site blocked automated access. Use the browser extension, paste page text, or enter the citation details manually.'
+    : 'We could not fetch this source automatically. Use the browser extension, paste page text, or enter the citation details manually.';
+  return {
+    uuid: website,
+    type: 'webpage',
+    csl: {
+      id: website,
+      type: 'webpage',
+      URL: website,
+    },
+    _quality: {
+      score: 40,
+      warnings: [{
+        code: blocked ? 'fetch_blocked' : 'fetch_failed',
+        severity: blocked ? 'warning' : 'review',
+        message,
+        action: blocked ? 'use-extension' : 'enter-manually',
+      }],
+      acquisition: {
+        fetch: {
+          source: 'fetch',
+          status: blocked ? 'blocked' : 'error',
+          reason: String(body?.error || code),
+          url: website,
+        },
+      },
+    },
   };
 }

--- a/src/lib/references/warnings.ts
+++ b/src/lib/references/warnings.ts
@@ -1,0 +1,36 @@
+import type { CitationQualityWarning } from '../citations/csl-types';
+
+const NON_DISMISSIBLE_CODES = new Set([
+  'author_not_found',
+  'date_not_found',
+  'journal_volume_missing',
+  'title_missing',
+  'url_missing',
+  'journal_title_missing',
+  'journal_locator_missing',
+]);
+
+export function warningDismissalKey(warning: CitationQualityWarning): string {
+  return `${String(warning.field ?? 'global')}:${warning.code}`;
+}
+
+export function isDismissibleCitationWarning(warning: CitationQualityWarning): boolean {
+  if (warning.severity === 'error') return false;
+  if (NON_DISMISSIBLE_CODES.has(warning.code)) return false;
+  if (warning.code.endsWith('_conflict')) return true;
+  return false;
+}
+
+export function isCitationWarningDismissed(
+  warning: CitationQualityWarning,
+  dismissedWarningKeys: readonly string[] | undefined,
+): boolean {
+  return dismissedWarningKeys?.includes(warningDismissalKey(warning)) ?? false;
+}
+
+export function visibleCitationWarnings(
+  warnings: readonly CitationQualityWarning[] | undefined,
+  dismissedWarningKeys: readonly string[] | undefined,
+): CitationQualityWarning[] {
+  return (warnings ?? []).filter((warning) => !isCitationWarningDismissed(warning, dismissedWarningKeys));
+}

--- a/src/pages/admin/analytics.astro
+++ b/src/pages/admin/analytics.astro
@@ -394,7 +394,7 @@ function sparklinePath(rows: Array<Record<string, unknown>>, valueKey: string, w
 
     <footer>
       Server-rendered. Auth via HTTP basic. <br/>
-      Test traffic (X-Mla-Test:1 header or ?nocache=1 query) is filtered before emission.
+      Test traffic (X-Mla-Test:1 header) is filtered before emission.
     </footer>
   </div>
 </body>

--- a/src/pages/my-references.astro
+++ b/src/pages/my-references.astro
@@ -2,6 +2,8 @@
 import Layout from "../layouts/page.astro";
 import References from "../components/react/References";
 
+export const prerender = true;
+
 const title = "My References | Citation Generator";
 const description = "View and manage your saved citations and references. Easily copy, edit, and organize your bibliography in multiple citation styles.";
 ---

--- a/src/styles/references.module.css
+++ b/src/styles/references.module.css
@@ -48,6 +48,8 @@
 .citationSourceWrapper {
     margin-left: 48px;
     max-width: 800px;
+    padding-right: 26px;
+    position: relative;
 }
 
 .citationSource {
@@ -64,6 +66,87 @@
     -webkit-text-size-adjust: 100%;
     font-feature-settings: normal;
     font-variation-settings: normal;
+}
+
+.qualityIndicator {
+    align-items: center;
+    border-radius: 999px;
+    color: #a16207;
+    display: inline-flex;
+    height: 18px;
+    justify-content: center;
+    opacity: 0.78;
+    position: absolute;
+    right: 0;
+    top: 7px;
+    width: 18px;
+}
+
+.qualityIndicator[data-severity="error"] {
+    color: #8a1f11;
+    opacity: 0.86;
+}
+
+.qualityIndicator[data-severity="warning"] {
+    color: #a16207;
+    opacity: 0.82;
+}
+
+.qualityIcon {
+    height: 15px;
+    width: 15px;
+}
+
+.fieldWarningText {
+    color: #a16207;
+}
+
+.fieldWarningText[data-severity="error"] {
+    color: #8a1f11;
+}
+
+.fieldWarningText[data-severity="info"] {
+    color: hsl(var(--muted-foreground));
+}
+
+.fieldWarningText[data-severity="review"],
+.fieldWarningText[data-severity="warning"] {
+    color: #a16207;
+}
+
+.fieldWarningMessage {
+    min-width: 0;
+}
+
+.fieldWarningDismiss {
+    align-items: center;
+    background: transparent;
+    border: 0;
+    border-radius: 999px;
+    color: hsl(var(--muted-foreground));
+    display: inline-flex;
+    flex: 0 0 auto;
+    height: 16px;
+    justify-content: center;
+    margin-left: 2px;
+    opacity: 0.72;
+    padding: 0;
+    width: 16px;
+}
+
+.fieldWarningDismiss:hover {
+    background: rgba(161, 98, 7, 0.12);
+    opacity: 1;
+}
+
+.fieldWarningDismiss:focus-visible {
+    outline: 1px solid currentColor;
+    outline-offset: 2px;
+}
+
+.fieldWarningDismissIcon {
+    height: 12px;
+    width: 12px;
 }
 
 .citation span::selection,

--- a/tests/ai/gateway.test.ts
+++ b/tests/ai/gateway.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { createAiGatewayBinding } from '../../functions/lib/ai/gateway';
+
+describe('createAiGatewayBinding', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => { globalThis.fetch = originalFetch; });
+
+  it('posts chat-compatible payloads to a configured Gateway URL', async () => {
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({ response: '{"ok":true}' }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })) as any;
+    const ai = createAiGatewayBinding({
+      AI_GATEWAY_CHAT_URL: 'https://api.cloudflare.com/client/v4/accounts/acct/ai/v1/chat/completions',
+      AI_GATEWAY_TOKEN: 'token',
+      AI_GATEWAY_ID: 'default',
+    });
+
+    const result = await ai!.run('openai/gpt-5.4-nano', { messages: [{ role: 'user', content: 'hi' }] });
+
+    expect(result).toEqual({ response: '{"ok":true}' });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://api.cloudflare.com/client/v4/accounts/acct/ai/v1/chat/completions',
+      expect.objectContaining({
+        method: 'POST',
+        headers: expect.objectContaining({
+          authorization: 'Bearer token',
+          'cf-aig-gateway-id': 'default',
+        }),
+        body: expect.stringContaining('"model":"openai/gpt-5.4-nano"'),
+      }),
+    );
+  });
+});

--- a/tests/api/analytics-integration.test.ts
+++ b/tests/api/analytics-integration.test.ts
@@ -161,9 +161,12 @@ describe('analytics integration', () => {
 
       await handleCiteWebsite(url, cache, binding);   // miss → populates cache
       await handleCiteWebsite(url, cache, binding);   // hit
-      const hitPoint = shapeOf(writeDataPoint.mock.calls[1][0]);
-      expect(hitPoint.event).toBe('cite_website');
-      expect(hitPoint.metrics[2]).toBe(1);
+      const hitPoint = writeDataPoint.mock.calls
+        .map((call) => shapeOf(call[0]))
+        .find((point) => point.event === 'cite_website' && point.metrics[2] === 1);
+      expect(hitPoint).toBeTruthy();
+      expect(hitPoint?.event).toBe('cite_website');
+      expect(hitPoint?.metrics[2]).toBe(1);
     });
 
     it('emits error event on fetch_failed', async () => {

--- a/tests/api/cite-journal.test.ts
+++ b/tests/api/cite-journal.test.ts
@@ -36,6 +36,18 @@ describe('handleCiteJournal', () => {
     expect(env.csl.title).toBeTruthy();
   });
 
+  it('accepts a doi.org URL via the url parameter', async () => {
+    const body = loadFixtureFile(CR_FIX, '10.1038_s41586-021-03828-1.json');
+    seqMock(new Response(body, { status: 200 }));
+    const res = await handleCiteJournal(
+      new URL('https://m.com/api/cite-journal?url=https%3A%2F%2Fdoi.org%2F10.1038%2Fs41586-021-03828-1%3Futm_source%3Dcopy'),
+      null,
+    );
+    expect(res.status).toBe(200);
+    const env = await res.json() as any;
+    expect(env.uuid).toBe('10.1038/s41586-021-03828-1');
+  });
+
   it('falls back to OpenAlex when Crossref 404s', async () => {
     const oa = loadFixtureFile(OA_FIX, '10.1038_s41586-021-03828-1.json');
     seqMock(new Response('nope', { status: 404 }), new Response(oa, { status: 200 }));

--- a/tests/api/cite-website.test.ts
+++ b/tests/api/cite-website.test.ts
@@ -30,13 +30,19 @@ describe('handleCiteWebsite', () => {
 
   it('extracts CSL from a normal HTML page', async () => {
     mockHtml(HTML_OK);
-    const res = await handleCiteWebsite(new URL('https://m.com/api/cite-website?url=https://x.com/p'), null);
+    const res = await handleCiteWebsite(
+      new URL('https://m.com/api/cite-website?url=https://x.com/p'),
+      null,
+      undefined,
+      new Date(Date.UTC(2026, 5, 26)),
+    );
     expect(res.status).toBe(200);
     const body = await res.json() as any;
     expect(body.uuid).toBeTruthy();
     expect(body.type).toBe('webpage');
     expect(body.csl.title).toBe('Test Article');
     expect(body.csl.author).toEqual([{ family: 'Doe', given: 'Jane' }]);
+    expect(body.csl.accessed).toEqual({ 'date-parts': [[2026, 6, 26]] });
     expect(body._cached).toBe(false);
   });
 
@@ -60,5 +66,108 @@ describe('handleCiteWebsite', () => {
     expect(res.status).toBe(400);
     const body = await res.json() as any;
     expect(body.code).toBe('fetch_failed');
+  });
+
+  it('uses Browser Run rendered HTML when static fetch looks incomplete', async () => {
+    mockHtml(`<!doctype html><html><head><title>Loading...</title></head><body><script>${'x'.repeat(3000)}</script></body></html>`);
+    const renderedHtml = `<!doctype html><html><head>
+      <title>Rendered Article</title>
+      <script type="application/ld+json">${JSON.stringify({
+        '@type': 'NewsArticle',
+        headline: 'Rendered Article',
+        author: 'Jane Doe',
+        datePublished: '2026-01-15',
+      })}</script>
+    </head><body><article>By Jane Doe. ${'Rendered article text. '.repeat(80)}</article></body></html>`;
+    const browser = {
+      quickAction: vi.fn(async () => new Response(renderedHtml, {
+        headers: { 'content-type': 'text/html', 'X-Browser-Ms-Used': '1234' },
+      })),
+    };
+
+    const res = await handleCiteWebsite(
+      new URL('https://m.com/api/cite-website?url=https://x.com/p&acquisition=fetch&nocache=1'),
+      null,
+      undefined,
+      new Date(Date.UTC(2026, 5, 26)),
+      { browser },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(browser.quickAction).toHaveBeenCalledWith('content', expect.objectContaining({ url: 'https://x.com/p' }));
+    expect(body.csl.title).toBe('Rendered Article');
+    expect(body.csl.author).toEqual([{ family: 'Doe', given: 'Jane' }]);
+    expect(body._quality.acquisition.render.status).toBe('success');
+    expect(body._quality.acquisition.render.browserMs).toBe(1234);
+    expect(body._provenance.title.winner.acquisition).toBe('render');
+  });
+
+  it('uses AI only when a proposal is backed by source text evidence', async () => {
+    mockHtml(`<!doctype html><html><head><title>Thin Article</title></head>
+      <body><main>By Jane Doe. Published January 15, 2026. This is the article body.</main></body></html>`);
+    const ai = {
+      run: vi.fn(async () => ({
+        response: JSON.stringify({
+          proposals: [
+            {
+              field: 'author',
+              value: 'Jane Doe',
+              evidenceSnippet: 'Jane Doe',
+              evidenceSource: 'fetched',
+              confidence: 0.9,
+            },
+            {
+              field: 'issued',
+              value: 'January 15, 2026',
+              evidenceSnippet: 'January 15, 2026',
+              evidenceSource: 'fetched',
+              confidence: 0.9,
+            },
+            {
+              field: 'publisher',
+              value: 'Invented Publisher',
+              evidenceSnippet: 'Not in the page',
+              evidenceSource: 'fetched',
+              confidence: 0.95,
+            },
+          ],
+        }),
+      })),
+    };
+
+    const res = await handleCiteWebsite(
+      new URL('https://m.com/api/cite-website?url=https://x.com/p&ai=0'),
+      null,
+      undefined,
+      new Date(Date.UTC(2026, 5, 26)),
+      { ai },
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(ai.run).toHaveBeenCalled();
+    expect(body.csl.author).toEqual([{ family: 'Doe', given: 'Jane' }]);
+    expect(body.csl.issued).toEqual({ 'date-parts': [[2026, 1, 15]], raw: 'January 15, 2026' });
+    expect(body.csl.publisher).toBeUndefined();
+    expect(body._provenance.author.winner.source).toBe('ai-extract');
+    expect(body._quality.acquisition.ai.fieldsFound).toEqual(['author', 'issued']);
+  });
+
+  it('allows server policy, not public query params, to disable AI assist', async () => {
+    mockHtml(`<!doctype html><html><head><title>Thin Article</title></head>
+      <body><main>By Jane Doe. Published January 15, 2026.</main></body></html>`);
+    const ai = { run: vi.fn() };
+
+    const res = await handleCiteWebsite(
+      new URL('https://m.com/api/cite-website?url=https://x.com/p&ai=1'),
+      null,
+      undefined,
+      new Date(Date.UTC(2026, 5, 26)),
+      { ai, aiAssistEnabled: false },
+    );
+
+    expect(res.status).toBe(200);
+    expect(ai.run).not.toHaveBeenCalled();
   });
 });

--- a/tests/api/quality-check.test.ts
+++ b/tests/api/quality-check.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi } from 'vitest';
+import { handleQualityCheck } from '../../functions/api/quality/check/handler';
+
+describe('handleQualityCheck', () => {
+  it('returns deterministic quality warnings for a CSL item', async () => {
+    const req = new Request('https://m.com/api/quality/check', {
+      method: 'POST',
+      body: JSON.stringify({
+        csl: { id: 'https://example.com/p', type: 'webpage', title: 'Example', URL: 'https://example.com/p' },
+        style: 'mla-9',
+      }),
+    });
+    const res = await handleQualityCheck(req);
+    expect(res.status).toBe(200);
+    const body = await res.json() as any;
+    expect(body.quality.warnings.some((w: any) => w.code === 'author_not_found')).toBe(true);
+  });
+
+  it('can append AI sanity-check warnings without changing CSL', async () => {
+    const ai = {
+      run: vi.fn(async () => ({
+        response: JSON.stringify({
+          warnings: [{
+            code: 'source_type_review',
+            field: 'type',
+            severity: 'review',
+            message: 'Review whether this should be a journal article.',
+          }],
+        }),
+      })),
+    };
+    const req = new Request('https://m.com/api/quality/check?ai=0', {
+      method: 'POST',
+      body: JSON.stringify({
+        csl: { id: 'https://example.com/p', type: 'webpage', title: 'Example', URL: 'https://example.com/p' },
+        style: 'mla-9',
+      }),
+    });
+    const res = await handleQualityCheck(req, { ai, aiCheckEnabled: true });
+    const body = await res.json() as any;
+    expect(ai.run).toHaveBeenCalled();
+    expect(body.quality.warnings.some((w: any) => w.code === 'ai_source_type_review')).toBe(true);
+  });
+
+  it('does not allow query params to force AI checks', async () => {
+    const ai = { run: vi.fn() };
+    const req = new Request('https://m.com/api/quality/check?ai=1', {
+      method: 'POST',
+      body: JSON.stringify({
+        csl: { id: 'https://example.com/p', type: 'webpage', title: 'Example', URL: 'https://example.com/p' },
+      }),
+    });
+    await handleQualityCheck(req, { ai });
+    expect(ai.run).not.toHaveBeenCalled();
+  });
+});

--- a/tests/client/EditCitationForm.test.tsx
+++ b/tests/client/EditCitationForm.test.tsx
@@ -52,6 +52,153 @@ describe('EditCitationForm currentRef sync', () => {
   });
 });
 
+describe('EditCitationForm quality warnings', () => {
+  it('renders concise warning text under the affected fields instead of a generic review block', () => {
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: { id: 'u1', type: 'webpage', title: 'Extracted Title' },
+      quality: {
+        score: 62,
+        warnings: [
+          {
+            code: 'author_not_found',
+            field: 'author',
+            severity: 'review',
+            message: 'No author was found. If this source lists a person or organization, add it.',
+            action: 'confirm-no-listed-author',
+          },
+          {
+            code: 'date_not_found',
+            field: 'issued',
+            severity: 'review',
+            message: 'No publication date was found.',
+            action: 'review-field',
+          },
+          {
+            code: 'title_conflict',
+            field: 'title',
+            severity: 'warning',
+            message: 'We found conflicting title information.',
+            action: 'review-field',
+          },
+          {
+            code: 'fetch_partial',
+            severity: 'warning',
+            message: 'The page appeared to load only partially.',
+            action: 'paste-text',
+          },
+        ],
+      },
+    };
+
+    const { container, getByText, queryByText } = render(<EditCitationForm source={source} setSources={() => {}} />);
+
+    expect(getByText('Add the listed author or organization, if the source has one.')).toBeTruthy();
+    expect(getByText('Add the published or updated date, if the source lists one.')).toBeTruthy();
+    expect(getByText('Multiple titles were found; confirm this title.')).toBeTruthy();
+    expect(container.querySelectorAll('button[aria-label^="Dismiss warning:"]')).toHaveLength(1);
+    expect(queryByText('Review suggested fields')).toBeNull();
+    expect(queryByText(/No author was found/)).toBeNull();
+    expect(queryByText(/page appeared to load only partially/)).toBeNull();
+  });
+
+  it('dismisses optional warnings for only the current citation', () => {
+    const setSources = vi.fn();
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: { id: 'u1', type: 'webpage', title: 'Extracted Title' },
+      quality: {
+        score: 78,
+        warnings: [
+          {
+            code: 'title_conflict',
+            field: 'title',
+            severity: 'review',
+            message: 'We found conflicting title information.',
+            action: 'review-field',
+          },
+          {
+            code: 'url_missing',
+            field: 'URL',
+            severity: 'error',
+            message: 'No URL was found.',
+            action: 'review-field',
+          },
+        ],
+      },
+    };
+
+    const { container } = render(<EditCitationForm source={source} setSources={setSources} />);
+
+    const dismissButtons = container.querySelectorAll('button[aria-label^="Dismiss warning:"]');
+    expect(dismissButtons).toHaveLength(1);
+    expect(dismissButtons[0].getAttribute('aria-label')).toBe('Dismiss warning: Multiple titles were found; confirm this title.');
+    fireEvent.click(dismissButtons[0]);
+
+    expect(setSources).toHaveBeenCalledTimes(1);
+    const updater = setSources.mock.calls[0][0] as (prev: StoredSource[]) => StoredSource[];
+    const next = updater([
+      source,
+      { uuid: 'u2', csl: { id: 'u2', type: 'webpage', title: 'Other' } },
+    ]);
+    expect(next[0].dismissedWarningKeys).toEqual(['title:title_conflict']);
+    expect(next[1].dismissedWarningKeys).toBeUndefined();
+  });
+
+  it('does not render warnings that were already dismissed on the citation', () => {
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: { id: 'u1', type: 'webpage', title: 'Extracted Title' },
+      dismissedWarningKeys: ['title:title_conflict'],
+      quality: {
+        score: 88,
+        warnings: [
+          {
+            code: 'title_conflict',
+            field: 'title',
+            severity: 'review',
+            message: 'We found conflicting title information.',
+            action: 'review-field',
+          },
+        ],
+      },
+    };
+
+    const { container } = render(<EditCitationForm source={source} setSources={() => {}} />);
+
+    expect(container.textContent).not.toContain('Multiple titles were found; confirm this title.');
+    expect(container.querySelector('button[aria-label^="Dismiss warning:"]')).toBeNull();
+  });
+
+  it('does not show a missing-author warning once an author value exists locally', () => {
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: {
+        id: 'u1',
+        type: 'webpage',
+        title: 'Title',
+        author: [{ family: 'Doe', given: 'Jane' }],
+      },
+      quality: {
+        score: 80,
+        warnings: [
+          {
+            code: 'author_not_found',
+            field: 'author',
+            severity: 'review',
+            message: 'No author was found.',
+            action: 'confirm-no-listed-author',
+          },
+        ],
+      },
+    };
+
+    const { container } = render(<EditCitationForm source={source} setSources={() => {}} />);
+
+    expect(container.textContent).not.toContain('Add the listed author or organization, if the source has one.');
+  });
+});
+
 describe('EditCitationForm contributors', () => {
   // Regression: Add Person / Add Organization wrote to the global store instead
   // of the form's local state. The form renders contributors from local state,
@@ -95,5 +242,40 @@ describe('EditCitationForm contributors', () => {
     // The surviving row is Beta, not Alpha (correct identity mapping after delete).
     expect(rows[0].textContent).toContain('Beta');
     expect(rows[0].textContent).not.toContain('Alpha');
+  });
+});
+
+describe('EditCitationForm article-journal fields', () => {
+  it('renders and updates journal-specific metadata fields', () => {
+    const currentRef = React.createRef<CSLItem | null>() as React.MutableRefObject<CSLItem | null>;
+    currentRef.current = null;
+    const source: StoredSource = {
+      uuid: 'j1',
+      csl: {
+        id: 'j1',
+        type: 'article-journal',
+        title: 'Article',
+        'container-title': 'Nature',
+        volume: '634',
+        issue: '8035',
+        page: '818-823',
+        DOI: '10.1038/s41586-024-08025-4',
+      },
+    };
+    const { getByPlaceholderText } = render(
+      <EditCitationForm source={source} setSources={() => {}} currentRef={currentRef} />,
+    );
+
+    expect(getByPlaceholderText('Journal name')).toHaveProperty('value', 'Nature');
+    expect(getByPlaceholderText('Volume number')).toHaveProperty('value', '634');
+    expect(getByPlaceholderText('Issue number')).toHaveProperty('value', '8035');
+    expect(getByPlaceholderText('Page range')).toHaveProperty('value', '818-823');
+    expect(getByPlaceholderText('DOI')).toHaveProperty('value', '10.1038/s41586-024-08025-4');
+
+    fireEvent.change(getByPlaceholderText('Issue number'), { target: { value: '8036' } });
+    fireEvent.change(getByPlaceholderText('Page range'), { target: { value: '900-912' } });
+
+    expect(currentRef.current?.issue).toBe('8036');
+    expect(currentRef.current?.page).toBe('900-912');
   });
 });

--- a/tests/client/ReferenceItem.test.tsx
+++ b/tests/client/ReferenceItem.test.tsx
@@ -48,4 +48,83 @@ describe('ReferenceItem', () => {
     const italic = container.querySelector('i, em');
     expect(italic?.textContent).toContain('My Title');
   });
+
+  it('uses an icon-only marker for field warnings instead of inline warning copy', async () => {
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: { id: 'u1', type: 'webpage', title: 'My Title' },
+      quality: {
+        score: 70,
+        warnings: [
+          {
+            code: 'author_not_found',
+            field: 'author',
+            severity: 'review',
+            message: 'No author was found.',
+            action: 'confirm-no-listed-author',
+          },
+          {
+            code: 'date_not_found',
+            field: 'issued',
+            severity: 'review',
+            message: 'No publication date was found.',
+            action: 'review-field',
+          },
+        ],
+      },
+    };
+    const { container } = render(
+      <ReferenceItem
+        source={source}
+        checked={false}
+        onToggle={() => {}}
+        citationFormat="mla-9"
+        setSources={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('My Title');
+    });
+
+    expect(container.querySelector('[aria-label="Citation has fields to review"]')).toBeTruthy();
+    expect(container.textContent).not.toContain('citation fields need review');
+    expect(container.textContent).not.toContain('No author was found');
+    expect(container.textContent).not.toContain('No publication date was found');
+  });
+
+  it('does not show the row warning marker once all field warnings are dismissed', async () => {
+    const source: StoredSource = {
+      uuid: 'u1',
+      csl: { id: 'u1', type: 'webpage', title: 'My Title' },
+      dismissedWarningKeys: ['title:title_conflict'],
+      quality: {
+        score: 90,
+        warnings: [
+          {
+            code: 'title_conflict',
+            field: 'title',
+            severity: 'review',
+            message: 'We found conflicting title information.',
+            action: 'review-field',
+          },
+        ],
+      },
+    };
+    const { container } = render(
+      <ReferenceItem
+        source={source}
+        checked={false}
+        onToggle={() => {}}
+        citationFormat="mla-9"
+        setSources={() => {}}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(container.textContent).toContain('My Title');
+    });
+
+    expect(container.querySelector('[aria-label="Citation has fields to review"]')).toBeNull();
+  });
 });

--- a/tests/client/useReferences.test.ts
+++ b/tests/client/useReferences.test.ts
@@ -49,6 +49,91 @@ describe('useReferences', () => {
     expect((globalThis.fetch as any).mock.calls[0][0]).toContain('/api/cite-website');
   });
 
+  it('stores citation quality metadata returned by cite endpoints', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: new URL('http://localhost/my-references?website=https://x.com/p'),
+    });
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      uuid: 'https://x.com/p',
+      type: 'webpage',
+      csl: { id: 'u', type: 'webpage', title: 'T' },
+      _quality: {
+        score: 90,
+        warnings: [{
+          code: 'author_not_found',
+          field: 'author',
+          severity: 'review',
+          message: 'No author was found.',
+          action: 'confirm-no-listed-author',
+        }],
+      },
+      _provenance: {
+        title: {
+          winner: { field: 'title', normalizedValue: 'T', source: 'heuristic', confidence: 0.4 },
+          candidates: [],
+          conflicts: [],
+        },
+      },
+    }), { status: 200 })) as any;
+
+    const { result } = renderHook(() => useReferences());
+    await waitFor(() => expect(result.current.sourceCount).toBe(1));
+
+    expect(result.current.sources[0].quality?.warnings[0].code).toBe('author_not_found');
+    const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+    expect(saved[0].quality.warnings[0].code).toBe('author_not_found');
+  });
+
+  it('creates a reviewable placeholder when website fetching is blocked', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: new URL('http://localhost/my-references?website=https://blocked.example/p'),
+    });
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      code: 'blocked',
+      error: 'Access denied',
+    }), { status: 400 })) as any;
+
+    const { result } = renderHook(() => useReferences());
+    await waitFor(() => expect(result.current.sourceCount).toBe(1));
+
+    expect(result.current.sources[0].csl.URL).toBe('https://blocked.example/p');
+    expect(result.current.sources[0].quality?.warnings[0].code).toBe('fetch_blocked');
+    expect(result.current.sources[0].quality?.warnings[0].action).toBe('use-extension');
+  });
+
+  it('fetches /api/cite-journal when ?journal= present', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: new URL('http://localhost/my-references?journal=10.1038/s41586-021-03828-1'),
+    });
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      uuid: '10.1038/s41586-021-03828-1',
+      type: 'article-journal',
+      csl: { id: 'j', type: 'article-journal', title: 'Journal Article' },
+    }), { status: 200 })) as any;
+    const { result } = renderHook(() => useReferences());
+    await waitFor(() => expect(result.current.sourceCount).toBe(1));
+    expect((globalThis.fetch as any).mock.calls[0][0])
+      .toBe('/api/cite-journal?doi=10.1038%2Fs41586-021-03828-1');
+  });
+
+  it('also accepts ?doi= as a journal lookup alias', async () => {
+    Object.defineProperty(window, 'location', {
+      writable: true,
+      value: new URL('http://localhost/my-references?doi=10.1038/s41586-021-03828-1'),
+    });
+    globalThis.fetch = vi.fn(async () => new Response(JSON.stringify({
+      uuid: '10.1038/s41586-021-03828-1',
+      type: 'article-journal',
+      csl: { id: 'j', type: 'article-journal', title: 'Journal Article' },
+    }), { status: 200 })) as any;
+    const { result } = renderHook(() => useReferences());
+    await waitFor(() => expect(result.current.sourceCount).toBe(1));
+    expect((globalThis.fetch as any).mock.calls[0][0]).toContain('/api/cite-journal');
+  });
+
   it('setCitationFormat updates state', async () => {
     const { result } = renderHook(() => useReferences());
     await waitFor(() => expect(result.current.citationFormat).toBe('mla-9'));

--- a/tests/e2e/pipeline.test.ts
+++ b/tests/e2e/pipeline.test.ts
@@ -3,24 +3,326 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { runExtractionPipeline } from '../../functions/lib/extract/pipeline';
 import { formatCitation, registerStyle, registerLocale } from '../../functions/lib/format/citeproc';
+import { validateCitationQuality } from '../../functions/lib/validation/citation-quality';
+import type { CSLItem, CSLName, SupportedStyle } from '../../functions/lib/csl-types';
 
 const ROOT = join(__dirname, '..', '..');
-const FIXTURE_NAME = 'nature-paper';
+const STYLES = ['mla-9', 'apa-7', 'chicago-18', 'ama-11', 'harvard', 'ieee', 'vancouver'] as const;
+const ACQUIRED_AT = '2026-06-30T00:00:00.000Z';
+
+interface SmokeCase {
+  name: string;
+  url?: string;
+  html?: string;
+  fixture?: string;
+  type: CSLItem['type'];
+  title: string;
+  firstAuthor?: CSLName;
+  authorCount?: number;
+  containerTitle?: string;
+  publisher?: string;
+  DOI?: string;
+  issuedYear?: number;
+  expectedWarningCodes: string[];
+  absentWarningCodes?: string[];
+  styleTokens?: Partial<Record<SupportedStyle, string[]>>;
+}
 
 beforeAll(() => {
   registerLocale('en-US', readFileSync(join(ROOT, 'functions/lib/format/locales/locales-en-US.xml'), 'utf-8'));
-  registerStyle('mla-9', readFileSync(join(ROOT, 'functions/lib/format/styles/mla-9.csl'), 'utf-8'));
+  registerLocale('en-GB', readFileSync(join(ROOT, 'functions/lib/format/locales/locales-en-GB.xml'), 'utf-8'));
+  for (const style of STYLES) {
+    registerStyle(style, readFileSync(join(ROOT, `functions/lib/format/styles/${style}.csl`), 'utf-8'));
+  }
 });
 
-describe('end-to-end: HTML -> CSL -> MLA 9', () => {
-  it('produces a non-empty MLA 9 citation from a richly marked-up fixture', () => {
-    const dir = join(ROOT, `tests/extract/fixtures/${FIXTURE_NAME}`);
-    const html = readFileSync(join(dir, 'input.html'), 'utf-8');
-    const url = readFileSync(join(dir, 'input.url'), 'utf-8').trim();
-    const { csl } = runExtractionPipeline(html, url);
-    const rt = formatCitation(csl, 'mla-9');
-    const text = rt.map((r) => r.text).join('');
-    expect(text.length).toBeGreaterThan(20);
-    expect(text).toMatch(/\./); // contains at least a period
-  });
+const CASES: SmokeCase[] = [
+  {
+    name: 'scholarly article with citation meta and DOI',
+    fixture: 'academic-meta-rich',
+    type: 'article-journal',
+    title: 'A Reliable Metadata Extraction Study',
+    firstAuthor: { family: 'Smith', given: 'John' },
+    authorCount: 2,
+    containerTitle: 'Journal of Citation Testing',
+    publisher: 'Example University Press',
+    DOI: '10.5555/jct.2026.001',
+    issuedYear: 2026,
+    expectedWarningCodes: ['title_conflict'],
+    absentWarningCodes: ['author_not_found', 'date_not_found', 'journal_title_missing', 'journal_locator_missing'],
+    styleTokens: {
+      'mla-9': ['Smith, John, and Jane Doe.', '<i>Journal of Citation Testing</i>', 'https://doi.org/10.5555/jct.2026.001'],
+      'apa-7': ['Smith, J., & Doe, J. (2026).', '<i>Journal of Citation Testing</i>', 'https://doi.org/10.5555/jct.2026.001'],
+      'ama-11': ['Smith J, Doe J.', 'doi:10.5555/jct.2026.001'],
+      ieee: ['[1] J. Smith and J. Doe', 'doi: 10.5555/jct.2026.001'],
+      vancouver: ['Smith J, Doe J.', 'doi:10.5555/jct.2026.001'],
+    },
+  },
+  {
+    name: 'large-author scholarly article from Nature',
+    fixture: 'nature-paper',
+    type: 'article-journal',
+    title: 'Scalable watermarking for identifying large language model outputs',
+    firstAuthor: { family: 'Dathathri', given: 'Sumanth' },
+    authorCount: 24,
+    containerTitle: 'Nature',
+    DOI: '10.1038/s41586-024-08025-4',
+    issuedYear: 2024,
+    expectedWarningCodes: ['title_conflict', 'author_conflict', 'issued_conflict', 'publisher_conflict'],
+    absentWarningCodes: ['author_not_found', 'date_not_found', 'journal_title_missing', 'journal_locator_missing'],
+    styleTokens: {
+      'mla-9': ['Dathathri, Sumanth, et al.', '<i>Nature</i>', 'https://doi.org/10.1038/s41586-024-08025-4'],
+      'apa-7': ['Dathathri, S.', '… Kohli, P. (2024).', 'https://doi.org/10.1038/s41586-024-08025-4'],
+      'chicago-18': ['Dathathri, Sumanth, Abigail See, Sumedh Ghaisas, et al.', '<i>Nature</i> 634'],
+      'ama-11': ['Dathathri S, See A, Ghaisas S, et al.', 'doi:10.1038/s41586-024-08025-4'],
+      harvard: ['Dathathri, S. <i>et al.</i> (2024)', '<i>Nature</i>'],
+      ieee: ['[1] S. Dathathri <i>et al.</i>', 'doi: 10.1038/s41586-024-08025-4'],
+      vancouver: ['Dathathri S, See A, Ghaisas S, Huang PS, McAdam R, Welbl J, et al.', 'doi:10.1038/s41586-024-08025-4'],
+    },
+  },
+  {
+    name: 'news article with two reporters',
+    fixture: 'apnews-news',
+    type: 'webpage',
+    title: '1 dead and 9 missing after chemical tank implosion at Washington mill',
+    firstAuthor: { family: 'Rush', given: 'Claire' },
+    authorCount: 2,
+    containerTitle: 'AP News',
+    issuedYear: 2026,
+    expectedWarningCodes: ['title_conflict', 'author_conflict'],
+    absentWarningCodes: ['author_not_found', 'date_not_found', 'url_missing'],
+    styleTokens: {
+      'mla-9': ['Rush, Claire, and Rebecca Boone.', '<i>AP News</i>', '26 May 2026'],
+      'apa-7': ['Rush, C., & Boone, R. (2026, May 26).', 'AP News.'],
+      'chicago-18': ['AP News, May 26, 2026.'],
+      ieee: ['[1] C. Rush and R. Boone', '[Online]. Available:'],
+      vancouver: ['Rush C, Boone R.', 'Available from:'],
+    },
+  },
+  {
+    name: 'government page with corporate author',
+    fixture: 'cdc-gov-page',
+    type: 'webpage',
+    title: 'Diabetes Basics',
+    firstAuthor: { literal: 'CDC' },
+    authorCount: 1,
+    containerTitle: 'Diabetes',
+    issuedYear: 2026,
+    expectedWarningCodes: ['issued_conflict'],
+    absentWarningCodes: ['author_not_found', 'date_not_found', 'url_missing'],
+    styleTokens: {
+      'mla-9': ['CDC.', '<i>Diabetes</i>'],
+      'apa-7': ['CDC. (2026, January 26).'],
+      'ama-11': ['CDC. Diabetes Basics.'],
+      vancouver: ['CDC. Diabetes [Internet].'],
+    },
+  },
+  {
+    name: 'blog post with author inferred from page text',
+    fixture: 'blog-cloudflare',
+    type: 'webpage',
+    title: 'Announcing Claude Managed Agents on Cloudflare',
+    firstAuthor: { family: 'Nomitch', given: 'Mike' },
+    authorCount: 1,
+    containerTitle: 'The Cloudflare Blog',
+    issuedYear: 2026,
+    expectedWarningCodes: [],
+    absentWarningCodes: ['author_not_found', 'date_not_found', 'url_missing'],
+    styleTokens: {
+      'mla-9': ['Nomitch, Mike.', '<i>The Cloudflare Blog</i>'],
+      'apa-7': ['Nomitch, M. (2026, May 19).'],
+      'chicago-18': ['The Cloudflare Blog, May 19, 2026.'],
+      ieee: ['[1] M. Nomitch'],
+      vancouver: ['Nomitch M. The Cloudflare Blog [Internet].'],
+    },
+  },
+  {
+    name: 'encyclopedia page with host-specific title correction',
+    fixture: 'wikipedia-article',
+    type: 'webpage',
+    title: 'Citation',
+    firstAuthor: { literal: 'Contributors to Wikimedia projects' },
+    authorCount: 1,
+    publisher: 'Wikimedia Foundation, Inc.',
+    issuedYear: 2002,
+    expectedWarningCodes: ['title_conflict', 'author_conflict'],
+    absentWarningCodes: ['author_not_found', 'date_not_found', 'url_missing'],
+    styleTokens: {
+      'mla-9': ['Contributors to Wikimedia projects.', '<i>Citation</i>.'],
+      'apa-7': ['Contributors to Wikimedia projects. (2002, October 1).'],
+      ieee: ['[1] Contributors to Wikimedia projects'],
+      vancouver: ['Citation [Internet]. Wikimedia Foundation, Inc.; 2002.'],
+    },
+  },
+  {
+    name: 'bare static page with missing author and date',
+    fixture: 'bare-html',
+    type: 'webpage',
+    title: 'Example Domain',
+    authorCount: 0,
+    expectedWarningCodes: ['author_not_found', 'date_not_found'],
+    absentWarningCodes: ['title_missing', 'url_missing'],
+    styleTokens: {
+      'mla-9': ['<i>Example Domain</i>.'],
+      'apa-7': ['<i>Example Domain</i>. (n.d.).'],
+      harvard: ['<i>Example Domain</i> (no date).'],
+      ieee: ['[1] “Example Domain.”'],
+      vancouver: ['Example Domain [Internet].'],
+    },
+  },
+  {
+    name: 'fake DOI-only early-view scholarly article',
+    url: 'https://journal.example.test/articles/early-view-reliability',
+    html: `<!doctype html><html><head>
+      <title>Early View Reliability Study</title>
+      <link rel="canonical" href="/articles/early-view-reliability" />
+      <meta name="citation_title" content="Early View Reliability Study" />
+      <meta name="citation_author" content="Patel, Mira" />
+      <meta name="citation_publication_date" content="2026-06-15" />
+      <meta name="citation_journal_title" content="Journal of Citation Reliability" />
+      <meta name="citation_doi" content="https://doi.org/10.5555/jcr.2026.015" />
+    </head><body><article><h1>Early View Reliability Study</h1></article></body></html>`,
+    type: 'article-journal',
+    title: 'Early View Reliability Study',
+    firstAuthor: { family: 'Patel', given: 'Mira' },
+    authorCount: 1,
+    containerTitle: 'Journal of Citation Reliability',
+    DOI: '10.5555/jcr.2026.015',
+    issuedYear: 2026,
+    expectedWarningCodes: ['journal_volume_missing'],
+    absentWarningCodes: ['author_not_found', 'date_not_found', 'journal_title_missing', 'journal_locator_missing'],
+    styleTokens: {
+      'mla-9': ['Patel, Mira.', '<i>Journal of Citation Reliability</i>', 'June 2026', 'https://doi.org/10.5555/jcr.2026.015'],
+      'apa-7': ['Patel, M. (2026).', 'https://doi.org/10.5555/jcr.2026.015'],
+      'chicago-18': ['ahead of print, June 15, 2026'],
+      'ama-11': ['Patel M.', 'Published online June 15, 2026.', 'doi:10.5555/jcr.2026.015'],
+      ieee: ['[1] M. Patel', 'Jun. 2026', 'doi: 10.5555/jcr.2026.015'],
+      vancouver: ['Patel M.', '2026 Jun 15.', 'doi:10.5555/jcr.2026.015'],
+    },
+  },
+  {
+    name: 'fake news article with conflicting fallback metadata',
+    url: 'https://news.example.test/city/council-vote',
+    html: `<!doctype html><html><head>
+      <title>Fallback Title - Example Daily</title>
+      <meta property="og:title" content="Council vote draws regional attention" />
+      <meta property="og:site_name" content="Example Daily" />
+      <script type="application/ld+json">${JSON.stringify({
+        '@type': 'NewsArticle',
+        headline: 'Council Approves Transit Plan After Marathon Meeting',
+        author: [{ '@type': 'Person', givenName: 'Jordan', familyName: 'Lee' }],
+        datePublished: '2026-02-04T09:30:00-05:00',
+        publisher: { '@type': 'NewsMediaOrganization', name: 'Example Daily' },
+        mainEntityOfPage: 'https://news.example.test/city/council-vote',
+      })}</script>
+    </head><body><article><h1>Council Approves Transit Plan After Marathon Meeting</h1></article></body></html>`,
+    type: 'webpage',
+    title: 'Council Approves Transit Plan After Marathon Meeting',
+    firstAuthor: { family: 'Lee', given: 'Jordan' },
+    authorCount: 1,
+    containerTitle: 'Example Daily',
+    issuedYear: 2026,
+    expectedWarningCodes: ['title_conflict'],
+    absentWarningCodes: ['author_not_found', 'date_not_found', 'url_missing'],
+    styleTokens: {
+      'mla-9': ['Lee, Jordan.', '<i>Example Daily</i>', '4 Feb. 2026'],
+      'apa-7': ['Lee, J. (2026, February 4).'],
+      'chicago-18': ['Example Daily, February 4, 2026.'],
+      ieee: ['[1] J. Lee'],
+      vancouver: ['Lee J. Example Daily [Internet]. 2026.'],
+    },
+  },
+  {
+    name: 'fake government page with corporate author and no date',
+    url: 'https://agency.example.test/reports/water-safety',
+    html: `<!doctype html><html><head>
+      <title>Water Safety Field Guide</title>
+      <meta property="og:title" content="Water Safety Field Guide" />
+      <meta property="og:site_name" content="Public Health Notes" />
+      <script type="application/ld+json">${JSON.stringify({
+        '@type': 'WebPage',
+        name: 'Water Safety Field Guide',
+        author: { '@type': 'Organization', name: 'Office of Public Water Safety' },
+        publisher: { '@type': 'Organization', name: 'Office of Public Water Safety' },
+        url: 'https://agency.example.test/reports/water-safety',
+      })}</script>
+    </head><body><h1>Water Safety Field Guide</h1></body></html>`,
+    type: 'webpage',
+    title: 'Water Safety Field Guide',
+    firstAuthor: { literal: 'Office of Public Water Safety' },
+    authorCount: 1,
+    containerTitle: 'Public Health Notes',
+    publisher: 'Office of Public Water Safety',
+    expectedWarningCodes: ['date_not_found'],
+    absentWarningCodes: ['author_not_found', 'title_missing', 'url_missing'],
+    styleTokens: {
+      'mla-9': ['Office of Public Water Safety.', '<i>Public Health Notes</i>'],
+      'apa-7': ['Office of Public Water Safety. (n.d.).'],
+      harvard: ['Office of Public Water Safety (no date)'],
+      vancouver: ['Office of Public Water Safety. Public Health Notes [Internet].'],
+    },
+  },
+];
+
+describe('end-to-end citation smoke matrix', () => {
+  for (const item of CASES) {
+    it(`${item.name}: extracts fields, quality warnings, and all supported formats`, () => {
+      const { html, url } = loadCaseInput(item);
+      const result = runExtractionPipeline(html, url, { acquisition: 'fetch', acquiredAt: ACQUIRED_AT });
+      const quality = validateCitationQuality(result.csl, { provenance: result.provenance });
+      const warningCodes = quality.warnings.map((warning) => warning.code);
+
+      expect(result.csl.type).toBe(item.type);
+      expect(result.csl.title).toBe(item.title);
+      expect(result.csl.author?.length ?? 0).toBe(item.authorCount ?? 0);
+      if (item.firstAuthor) expect(result.csl.author?.[0]).toEqual(item.firstAuthor);
+      if (item.containerTitle) expect(result.csl['container-title']).toBe(item.containerTitle);
+      if (item.publisher) expect(result.csl.publisher).toBe(item.publisher);
+      if (item.DOI) expect(result.csl.DOI).toBe(item.DOI);
+      if (item.issuedYear) expect(result.csl.issued?.['date-parts']?.[0]?.[0]).toBe(item.issuedYear);
+
+      expect(warningCodes).toEqual(item.expectedWarningCodes);
+      for (const absent of item.absentWarningCodes ?? []) {
+        expect(warningCodes, `${item.name} should not warn ${absent}`).not.toContain(absent);
+      }
+
+      for (const style of STYLES) {
+        const actual = renderStyle(result.csl, style);
+        expect(actual.length, `${item.name} ${style}`).toBeGreaterThan(20);
+        expect(actual, `${item.name} ${style}`).toContain(styleLocatorToken(result.csl, style));
+        for (const token of item.styleTokens?.[style] ?? []) {
+          expect(actual, `${item.name} ${style}`).toContain(token);
+        }
+      }
+    });
+  }
 });
+
+function loadCaseInput(item: SmokeCase): { html: string; url: string } {
+  if (item.fixture) {
+    const dir = join(ROOT, 'tests/extract/fixtures', item.fixture);
+    return {
+      html: readFileSync(join(dir, 'input.html'), 'utf-8'),
+      url: readFileSync(join(dir, 'input.url'), 'utf-8').trim(),
+    };
+  }
+  if (!item.html || !item.url) throw new Error(`Smoke case ${item.name} is missing html or url`);
+  return { html: item.html, url: item.url };
+}
+
+function renderStyle(csl: CSLItem, style: SupportedStyle): string {
+  return formatCitation(csl, style)
+    .map((segment) => (segment.italic ? `<i>${segment.text}</i>` : segment.text))
+    .join('');
+}
+
+function styleLocatorToken(csl: CSLItem, style: SupportedStyle): string {
+  if (csl.DOI) {
+    return style === 'ieee' ? `doi: ${csl.DOI}` : style === 'mla-9' || style === 'apa-7' || style === 'chicago-18' || style === 'harvard'
+      ? `https://doi.org/${csl.DOI}`
+      : `doi:${csl.DOI}`;
+  }
+  if (style === 'ieee') return '[Online]. Available:';
+  if (style === 'vancouver') return 'Available from:';
+  return csl.URL ?? '';
+}

--- a/tests/evals/citation-acquisition-urls.json
+++ b/tests/evals/citation-acquisition-urls.json
@@ -1,0 +1,5 @@
+[
+  { "url": "https://www.cdc.gov/flu/about/index.html" },
+  { "url": "https://apnews.com/" },
+  { "url": "https://www.nature.com/articles/s41586-024-08025-4" }
+]

--- a/tests/extract/author-parse.test.ts
+++ b/tests/extract/author-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseAuthorName } from '../../functions/lib/extract/author-parse';
+import { parseAuthorList, parseAuthorName } from '../../functions/lib/extract/author-parse';
 
 describe('parseAuthorName', () => {
   it('parses "First Last"', () => {
@@ -14,9 +14,18 @@ describe('parseAuthorName', () => {
   it('parses single-token names', () => {
     expect(parseAuthorName('Cher')).toEqual({ family: 'Cher' });
   });
+  it('treats all-caps acronyms as literal organization names', () => {
+    expect(parseAuthorName('CDC')).toEqual({ literal: 'CDC' });
+    expect(parseAuthorName('NASA')).toEqual({ literal: 'NASA' });
+  });
   it('recognises non-dropping particles', () => {
     expect(parseAuthorName('John von Neumann')).toEqual({
       family: 'Neumann', given: 'John', 'non-dropping-particle': 'von',
+    });
+  });
+  it('keeps multi-token non-dropping particles together', () => {
+    expect(parseAuthorName('Ludwig van der Waals')).toEqual({
+      family: 'Waals', given: 'Ludwig', 'non-dropping-particle': 'van der',
     });
   });
   it('recognises trailing suffixes', () => {
@@ -58,5 +67,37 @@ describe('parseAuthorName', () => {
   it('returns null-ish for empty input', () => {
     expect(parseAuthorName('')).toBeNull();
     expect(parseAuthorName('   ')).toBeNull();
+  });
+});
+
+describe('parseAuthorList', () => {
+  it('keeps "Last, First" as a single author', () => {
+    expect(parseAuthorList('Smith, John')).toEqual([{ family: 'Smith', given: 'John' }]);
+  });
+
+  it('splits comma, semicolon, and conjunction separated author lists', () => {
+    expect(parseAuthorList('Jane Doe, John Smith; Carlos Ruiz and Acme News')).toEqual([
+      { family: 'Doe', given: 'Jane' },
+      { family: 'Smith', given: 'John' },
+      { family: 'Ruiz', given: 'Carlos' },
+      { literal: 'Acme News' },
+    ]);
+  });
+
+  it('strips leading byline labels', () => {
+    expect(parseAuthorList('By Jane Doe & John Smith')).toEqual([
+      { family: 'Doe', given: 'Jane' },
+      { family: 'Smith', given: 'John' },
+    ]);
+  });
+
+  it('does not split organization names that contain "and"', () => {
+    expect(parseAuthorList('Research and Development Office')).toEqual([
+      { literal: 'Research and Development Office' },
+    ]);
+  });
+
+  it('drops trailing et al. instead of parsing it as a surname', () => {
+    expect(parseAuthorList('Jane Doe et al.')).toEqual([{ family: 'Doe', given: 'Jane' }]);
   });
 });

--- a/tests/extract/date-parse.test.ts
+++ b/tests/extract/date-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { parseIsoDate, parseFreeformDate } from '../../functions/lib/extract/date-parse';
+import { parseIsoDate, parseFreeformDate, parseDate } from '../../functions/lib/extract/date-parse';
 
 describe('parseIsoDate', () => {
   it('parses YYYY-MM-DD', () => {
@@ -29,6 +29,7 @@ describe('parseIsoDate', () => {
     expect(parseIsoDate('2020-13-01')).toBeNull();
     expect(parseIsoDate('2020-00-10')).toBeNull();
     expect(parseIsoDate('2020-05-40')).toBeNull();
+    expect(parseIsoDate('2021-02-29')).toBeNull();
   });
 });
 
@@ -42,6 +43,13 @@ describe('parseFreeformDate', () => {
   it('parses month abbreviation', () => {
     expect(parseFreeformDate('Jan 5, 2026')).toEqual([2026, 1, 5]);
   });
+  it('parses weekday prefixes and ordinal days', () => {
+    expect(parseFreeformDate('Tuesday, 26th May 2026')).toEqual([2026, 5, 26]);
+    expect(parseFreeformDate('Tuesday, May 26th, 2026')).toEqual([2026, 5, 26]);
+  });
+  it('parses month and year without a day', () => {
+    expect(parseFreeformDate('May 2026')).toEqual([2026, 5]);
+  });
   it('returns null on bare year (use parseIsoDate for that)', () => {
     expect(parseFreeformDate('2026')).toBeNull();
   });
@@ -51,5 +59,17 @@ describe('parseFreeformDate', () => {
   it('rejects impossible days', () => {
     expect(parseFreeformDate('May 40, 2026')).toBeNull();
     expect(parseFreeformDate('0 May 2026')).toBeNull();
+    expect(parseFreeformDate('February 29, 2021')).toBeNull();
+  });
+});
+
+describe('parseDate', () => {
+  it('accepts common non-ISO dates through the shared parser', () => {
+    expect(parseDate('5/26/2026')).toEqual([2026, 5, 26]);
+    expect(parseDate('26/5/2026')).toEqual([2026, 5, 26]);
+  });
+
+  it('does not guess ambiguous numeric dates', () => {
+    expect(parseDate('04/05/2026')).toBeNull();
   });
 });

--- a/tests/extract/fixtures/academic-meta-rich/expected.csl.json
+++ b/tests/extract/fixtures/academic-meta-rich/expected.csl.json
@@ -1,0 +1,17 @@
+{
+  "type": "article-journal",
+  "title": "A Reliable Metadata Extraction Study",
+  "author": [
+    { "family": "Smith", "given": "John" },
+    { "family": "Doe", "given": "Jane" }
+  ],
+  "issued": { "date-parts": [[2026, 5, 26]] },
+  "publisher": "Example University Press",
+  "container-title": "Journal of Citation Testing",
+  "DOI": "10.5555/jct.2026.001",
+  "volume": "18",
+  "issue": "2",
+  "page": "45-62",
+  "abstract": "A study fixture for rich scholarly metadata extraction.",
+  "URL": "https://example.edu/research/reliable-metadata"
+}

--- a/tests/extract/fixtures/academic-meta-rich/input.html
+++ b/tests/extract/fixtures/academic-meta-rich/input.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <title>Fallback title that should not win</title>
+    <link rel="canonical" href="/research/reliable-metadata" />
+    <meta name="citation_title" content="A Reliable Metadata Extraction Study" />
+    <meta name="citation_author" content="Smith, John" />
+    <meta name="citation_author" content="Doe, Jane" />
+    <meta name="citation_publication_date" content="May 26, 2026" />
+    <meta name="citation_journal_title" content="Journal of Citation Testing" />
+    <meta name="citation_publisher" content="Example University Press" />
+    <meta name="citation_doi" content="doi:10.5555/jct.2026.001." />
+    <meta name="citation_volume" content="18" />
+    <meta name="citation_issue" content="2" />
+    <meta name="citation_firstpage" content="45" />
+    <meta name="citation_lastpage" content="62" />
+    <meta name="citation_abstract" content="A study fixture for rich scholarly metadata extraction." />
+  </head>
+  <body>
+    <article>
+      <h1>A Reliable Metadata Extraction Study</h1>
+    </article>
+  </body>
+</html>

--- a/tests/extract/fixtures/academic-meta-rich/input.url
+++ b/tests/extract/fixtures/academic-meta-rich/input.url
@@ -1,0 +1,1 @@
+https://example.edu/research/reliable-metadata?utm_source=newsletter

--- a/tests/extract/fixtures/apnews-news/expected.csl.json
+++ b/tests/extract/fixtures/apnews-news/expected.csl.json
@@ -6,6 +6,6 @@
     { "family": "Boone", "given": "Rebecca" }
   ],
   "issued": { "date-parts": [[2026, 5, 26]] },
-  "publisher": "AP News",
+  "container-title": "AP News",
   "URL": "https://apnews.com/article/washington-pulp-paper-mill-implosion-nippon-af71c2cbf329336d84a3fd77fa251669"
 }

--- a/tests/extract/fixtures/cdc-gov-page/expected.csl.json
+++ b/tests/extract/fixtures/cdc-gov-page/expected.csl.json
@@ -1,7 +1,7 @@
 {
   "type": "webpage",
   "title": "Diabetes Basics",
-  "author": [{ "family": "CDC" }],
+  "author": [{ "literal": "CDC" }],
   "issued": { "date-parts": [[2026, 1, 26]] },
   "container-title": "Diabetes",
   "URL": "https://www.cdc.gov/diabetes/about/index.html"

--- a/tests/extract/fixtures/guardian-news/expected.csl.json
+++ b/tests/extract/fixtures/guardian-news/expected.csl.json
@@ -3,6 +3,6 @@
   "title": "Italy’s top court rules against tourist refused tap water in Dolomites hotel",
   "author": [{ "family": "Giuffrida", "given": "Angela" }],
   "issued": { "date-parts": [[2026, 5, 26]] },
-  "publisher": "The Guardian",
+  "container-title": "The Guardian",
   "URL": "https://www.theguardian.com/world/2026/may/26/italy-court-tourist-tap-water-dolomites-hotel"
 }

--- a/tests/extract/fixtures/nature-paper/expected.csl.json
+++ b/tests/extract/fixtures/nature-paper/expected.csl.json
@@ -1,5 +1,5 @@
 {
-  "type": "webpage",
+  "type": "article-journal",
   "title": "Scalable watermarking for identifying large language model outputs",
   "author": [
     { "family": "Dathathri", "given": "Sumanth" },
@@ -30,5 +30,9 @@
   "issued": { "date-parts": [[2024, 10, 23]] },
   "publisher": "Nature Publishing Group UK",
   "container-title": "Nature",
+  "DOI": "10.1038/s41586-024-08025-4",
+  "volume": "634",
+  "issue": "8035",
+  "page": "818-823",
   "URL": "https://www.nature.com/articles/s41586-024-08025-4"
 }

--- a/tests/extract/merge-provenance.test.ts
+++ b/tests/extract/merge-provenance.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { mergeSignals } from '../../functions/lib/extract/merge';
+
+describe('mergeSignals provenance', () => {
+  it('records winner, candidates, and conflicts for each field', () => {
+    const result = mergeSignals([
+      {
+        name: 'heuristic',
+        fields: { title: 'Heuristic Title' },
+        confidence: { title: 0.4 },
+      },
+      {
+        name: 'jsonld',
+        fields: { title: 'Structured Title' },
+        confidence: { title: 0.95 },
+      },
+    ], { acquisition: 'fetch', acquiredAt: '2026-06-30T00:00:00.000Z' });
+
+    expect(result.csl.title).toBe('Structured Title');
+    expect(result.signals.title).toBe('jsonld');
+    expect(result.provenance.title?.winner?.source).toBe('jsonld');
+    expect(result.provenance.title?.winner?.acquisition).toBe('fetch');
+    expect(result.provenance.title?.candidates).toHaveLength(2);
+    expect(result.provenance.title?.conflicts).toHaveLength(1);
+  });
+});

--- a/tests/extract/pipeline.test.ts
+++ b/tests/extract/pipeline.test.ts
@@ -40,6 +40,59 @@ describe('runExtractionPipeline', () => {
     expect(result.csl.URL).toBe('https://example.com/p');
   });
 
+  it('resolves relative canonical URLs against the input URL', () => {
+    const result = runExtractionPipeline(
+      `<html><head><link rel="canonical" href="/canonical/article" /></head></html>`,
+      'https://example.com/path/article?utm_source=x',
+    );
+    expect(result.csl.URL).toBe('https://example.com/canonical/article');
+    expect(result.signals.URL).toBe('heuristic');
+  });
+
+  it('deduplicates matching publisher and container-title fields', () => {
+    const html = `<!DOCTYPE html><html><head>
+      <meta property="og:site_name" content="AP News" />
+      <script type="application/ld+json">${JSON.stringify({
+        '@type': 'NewsArticle',
+        headline: 'T',
+        publisher: { '@type': 'Organization', name: 'AP News' },
+      })}</script>
+    </head></html>`;
+    const result = runExtractionPipeline(html, 'https://example.com/p');
+    expect(result.csl['container-title']).toBe('AP News');
+    expect(result.csl.publisher).toBeUndefined();
+  });
+
+  it('promotes journal landing pages when volume, issue, or page metadata is present', () => {
+    const html = `<!DOCTYPE html><html><head>
+      <meta name="citation_title" content="Scholarly Article" />
+      <meta name="citation_journal_title" content="Journal of Testing" />
+      <meta name="citation_volume" content="12" />
+    </head></html>`;
+    const result = runExtractionPipeline(html, 'https://example.com/article');
+    expect(result.csl.type).toBe('article-journal');
+  });
+
+  it('promotes DOI-only journal landing pages when a journal title is present', () => {
+    const html = `<!DOCTYPE html><html><head>
+      <meta name="citation_title" content="Early View Reliability Study" />
+      <meta name="citation_journal_title" content="Journal of Citation Testing" />
+      <meta name="citation_doi" content="https://doi.org/10.5555/jct.2026.early" />
+    </head></html>`;
+    const result = runExtractionPipeline(html, 'https://example.com/article');
+    expect(result.csl.type).toBe('article-journal');
+    expect(result.csl.DOI).toBe('10.5555/jct.2026.early');
+  });
+
+  it('keeps ordinary site containers as webpages', () => {
+    const html = `<!DOCTYPE html><html><head>
+      <meta property="og:title" content="News Article" />
+      <meta property="og:site_name" content="Example News" />
+    </head></html>`;
+    const result = runExtractionPipeline(html, 'https://example.com/news');
+    expect(result.csl.type).toBe('webpage');
+  });
+
   describe('wikipedia title override', () => {
     // Wikipedia's JSON-LD `headline` is the article description, not the title.
     // The override prefers the heuristic <title> tag for *.wikipedia.org hosts.

--- a/tests/extract/signals/heuristic.test.ts
+++ b/tests/extract/signals/heuristic.test.ts
@@ -24,9 +24,27 @@ describe('heuristicSignal', () => {
     expect(heuristicSignal($).fields.author).toEqual([{ family: 'Doe', given: 'Jane' }]);
   });
 
+  it('reads multiple authors from flexible byline selectors', () => {
+    const $ = cheerio.load(`<div data-testid="article-author">By Jane Doe and John Smith</div>`);
+    expect(heuristicSignal($).fields.author).toEqual([
+      { family: 'Doe', given: 'Jane' },
+      { family: 'Smith', given: 'John' },
+    ]);
+  });
+
+  it('strips trailing published text from bylines', () => {
+    const $ = cheerio.load(`<div class="article-author">By Jane Doe Published May 26, 2026</div>`);
+    expect(heuristicSignal($).fields.author).toEqual([{ family: 'Doe', given: 'Jane' }]);
+  });
+
   it('reads <time datetime>', () => {
     const $ = cheerio.load(`<time datetime="2026-05-26">May 26</time>`);
     expect(heuristicSignal($).fields.issued).toEqual({ 'date-parts': [[2026, 5, 26]] });
+  });
+
+  it('reads a canonical link URL', () => {
+    const $ = cheerio.load(`<link rel="canonical" href="/articles/canonical" />`);
+    expect(heuristicSignal($).fields.URL).toBe('/articles/canonical');
   });
 
   it('returns empty when nothing present', () => {

--- a/tests/extract/signals/jsonld.test.ts
+++ b/tests/extract/signals/jsonld.test.ts
@@ -65,6 +65,15 @@ describe('jsonldSignal', () => {
     ]);
   });
 
+  it('handles organization authors with array-typed @type', () => {
+    const $ = load(`<html><head><script type="application/ld+json">${JSON.stringify({
+      '@type': 'Article',
+      headline: 'h',
+      author: { '@type': ['Organization', 'NewsMediaOrganization'], name: 'Example News' },
+    })}</script></head></html>`);
+    expect(jsonldSignal($).fields.author).toEqual([{ literal: 'Example News' }]);
+  });
+
   it('silently ignores malformed JSON', () => {
     const $ = load(`<html><head><script type="application/ld+json">{not json}</script></head></html>`);
     const r = jsonldSignal($);
@@ -101,5 +110,56 @@ describe('jsonldSignal', () => {
     const $ = cheerio.load(html);
     const r = jsonldSignal($);
     expect(r.fields.URL).toBe('https://mysite.com/2026/article/');
+  });
+
+  it('handles creator, isPartOf, mainEntityOfPage, and non-ISO dates', () => {
+    const html = `<html><head><script type="application/ld+json">${JSON.stringify({
+      '@type': ['WebPage', 'NewsArticle'],
+      headline: 'The Article',
+      creator: 'Jane Doe',
+      datePublished: 'May 26, 2026',
+      isPartOf: { '@type': 'WebSite', name: 'Example News' },
+      mainEntityOfPage: { '@id': 'https://example.com/article' },
+    })}</script></head></html>`;
+    const r = jsonldSignal(load(html));
+    expect(r.fields.author).toEqual([{ family: 'Doe', given: 'Jane' }]);
+    expect(r.fields.issued).toEqual({ 'date-parts': [[2026, 5, 26]] });
+    expect(r.fields['container-title']).toBe('Example News');
+    expect(r.fields.URL).toBe('https://example.com/article');
+  });
+
+  it('does not take titles from array-typed non-article containers', () => {
+    const html = `<html><head><script type="application/ld+json">${JSON.stringify({
+      '@type': ['Organization', 'WebSite'],
+      name: 'Site Root',
+    })}</script></head></html>`;
+    expect(jsonldSignal(load(html)).fields.title).toBeUndefined();
+  });
+
+  it('extracts scholarly DOI, volume, issue, pages, and abstract from JSON-LD', () => {
+    const html = `<html><head><script type="application/ld+json">${JSON.stringify({
+      '@type': 'ScholarlyArticle',
+      headline: 'A Scholarly Article',
+      identifier: [
+        { '@type': 'PropertyValue', propertyID: 'DOI', value: 'https://doi.org/10.5555/example.2026.001.' },
+      ],
+      isPartOf: {
+        '@type': 'PublicationIssue',
+        issueNumber: '4',
+        isPartOf: {
+          '@type': 'PublicationVolume',
+          volumeNumber: '22',
+        },
+      },
+      pageStart: '101',
+      pageEnd: '118',
+      abstract: 'A concise article abstract.',
+    })}</script></head></html>`;
+    const r = jsonldSignal(load(html));
+    expect(r.fields.DOI).toBe('10.5555/example.2026.001');
+    expect(r.fields.volume).toBe('22');
+    expect(r.fields.issue).toBe('4');
+    expect(r.fields.page).toBe('101-118');
+    expect(r.fields.abstract).toBe('A concise article abstract.');
   });
 });

--- a/tests/extract/signals/meta.test.ts
+++ b/tests/extract/signals/meta.test.ts
@@ -18,6 +18,11 @@ describe('metaSignal', () => {
     ]);
   });
 
+  it('does not split inverted single-author names on the comma', () => {
+    const $ = cheerio.load(`<meta name="author" content="Smith, John" />`);
+    expect(metaSignal($).fields.author).toEqual([{ family: 'Smith', given: 'John' }]);
+  });
+
   it('reads <meta name="publisher">', () => {
     const $ = cheerio.load(`<meta name="publisher" content="Example Pub" />`);
     expect(metaSignal($).fields.publisher).toBe('Example Pub');
@@ -42,6 +47,38 @@ describe('metaSignal', () => {
     }
   });
 
+  it('reads common non-ISO publication-date meta fields', () => {
+    const $ = cheerio.load(`<meta name="parsely-pub-date" content="May 26, 2026" />`);
+    expect(metaSignal($).fields.issued).toEqual({ 'date-parts': [[2026, 5, 26]] });
+  });
+
+  it('extracts and normalizes DOI metadata', () => {
+    const $ = cheerio.load(`<meta name="DC.identifier" content="https://doi.org/10.1234/ABC.567." />`);
+    expect(metaSignal($).fields.DOI).toBe('10.1234/ABC.567');
+  });
+
+  it('extracts scholarly volume, issue, page range, and abstract metadata', () => {
+    const $ = cheerio.load(`
+      <meta name="citation_volume" content="12" />
+      <meta name="citation_issue" content="3" />
+      <meta name="citation_firstpage" content="101" />
+      <meta name="citation_lastpage" content="118" />
+      <meta name="citation_abstract" content="  A compact study abstract.  " />
+    `);
+    const r = metaSignal($);
+    expect(r.fields.volume).toBe('12');
+    expect(r.fields.issue).toBe('3');
+    expect(r.fields.page).toBe('101-118');
+    expect(r.fields.abstract).toBe('A compact study abstract.');
+  });
+
+  it('keeps generic application-name below OpenGraph confidence', () => {
+    const $ = cheerio.load(`<meta name="application-name" content="Short Site" />`);
+    const r = metaSignal($);
+    expect(r.fields['container-title']).toBe('Short Site');
+    expect(r.confidence['container-title']).toBeLessThan(0.75);
+  });
+
   it('returns empty when no relevant meta', () => {
     expect(metaSignal(cheerio.load(`<meta name="viewport" content="x" />`)).fields).toEqual({});
   });
@@ -58,5 +95,23 @@ describe('metaSignal', () => {
       { family: 'Doe', given: 'Jane' },
       { family: 'Garcia', given: 'Carlos' },
     ]);
+  });
+
+  it('parses author lists inside citation_author content', () => {
+    const $ = cheerio.load(`<meta name="citation_author" content="Jane Doe and John Smith" />`);
+    expect(metaSignal($).fields.author).toEqual([
+      { family: 'Doe', given: 'Jane' },
+      { family: 'Smith', given: 'John' },
+    ]);
+  });
+
+  it('prefers citation_author over generic meta author', () => {
+    const $ = cheerio.load(`
+      <meta name="author" content="Example Site" />
+      <meta name="citation_author" content="Smith, John" />
+    `);
+    const r = metaSignal($);
+    expect(r.fields.author).toEqual([{ family: 'Smith', given: 'John' }]);
+    expect(r.confidence.author).toBeGreaterThan(0.8);
   });
 });

--- a/tests/extract/signals/microdata.test.ts
+++ b/tests/extract/signals/microdata.test.ts
@@ -28,6 +28,39 @@ describe('microdataSignal', () => {
     expect(r.fields.issued).toEqual({ 'date-parts': [[2024, 1, 15]] });
   });
 
+  it('collects repeated author itemprops', () => {
+    const $ = cheerio.load(`
+      <span itemprop="author">Jane Doe</span>
+      <span itemprop="author">John Smith</span>
+    `);
+    expect(microdataSignal($).fields.author).toEqual([
+      { family: 'Doe', given: 'Jane' },
+      { family: 'Smith', given: 'John' },
+    ]);
+  });
+
+  it('extracts scholarly metadata itemprops', () => {
+    const $ = cheerio.load(`<article itemscope itemtype="https://schema.org/ScholarlyArticle">
+      <h1 itemprop="headline">A Microdata Paper</h1>
+      <meta itemprop="identifier" content="https://doi.org/10.5555/micro.2026.001." />
+      <div itemprop="isPartOf" itemscope>
+        <span itemprop="name">Journal of Structured Data</span>
+      </div>
+      <meta itemprop="volumeNumber" content="8" />
+      <meta itemprop="issueNumber" content="4" />
+      <meta itemprop="pageStart" content="44" />
+      <meta itemprop="pageEnd" content="59" />
+      <meta itemprop="abstract" content="A microdata extraction abstract." />
+    </article>`);
+    const r = microdataSignal($);
+    expect(r.fields.DOI).toBe('10.5555/micro.2026.001');
+    expect(r.fields['container-title']).toBe('Journal of Structured Data');
+    expect(r.fields.volume).toBe('8');
+    expect(r.fields.issue).toBe('4');
+    expect(r.fields.page).toBe('44-59');
+    expect(r.fields.abstract).toBe('A microdata extraction abstract.');
+  });
+
   it('returns empty when nothing matches', () => {
     const $ = cheerio.load(`<html><body><p>plain</p></body></html>`);
     const r = microdataSignal($);

--- a/tests/extract/signals/opengraph.test.ts
+++ b/tests/extract/signals/opengraph.test.ts
@@ -21,12 +21,28 @@ describe('openGraphSignal', () => {
     expect(r.fields.issued).toEqual({ 'date-parts': [[2026, 5, 26]] });
   });
 
+  it('falls back to modified/updated OpenGraph dates and freeform date text', () => {
+    const $ = cheerio.load(`<meta property="article:modified_time" content="May 26, 2026" />`);
+    expect(openGraphSignal($).fields.issued).toEqual({ 'date-parts': [[2026, 5, 26]] });
+  });
+
   it('reads article:author only when it is a name, not a URL', () => {
     const $1 = cheerio.load(`<meta property="article:author" content="Jane Doe" />`);
     expect(openGraphSignal($1).fields.author).toEqual([{ family: 'Doe', given: 'Jane' }]);
 
     const $2 = cheerio.load(`<meta property="article:author" content="https://example.com/author/jane" />`);
     expect(openGraphSignal($2).fields.author).toBeUndefined();
+  });
+
+  it('collects repeated article:author tags', () => {
+    const $ = cheerio.load(`
+      <meta property="article:author" content="Jane Doe" />
+      <meta property="article:author" content="John Smith" />
+    `);
+    expect(openGraphSignal($).fields.author).toEqual([
+      { family: 'Doe', given: 'Jane' },
+      { family: 'Smith', given: 'John' },
+    ]);
   });
 
   it('returns empty when no OG tags', () => {

--- a/tests/journal/doi-detect.test.ts
+++ b/tests/journal/doi-detect.test.ts
@@ -10,8 +10,20 @@ describe('validateDoi', () => {
     expect(validateDoi('https://doi.org/10.1038/s41586-021-03828-1'))
       .toBe('10.1038/s41586-021-03828-1');
   });
+  it('strips copied URL wrappers, query strings, and trailing sentence punctuation', () => {
+    expect(validateDoi('<https://doi.org/10.1038/s41586-021-03828-1?utm_source=x>.'))
+      .toBe('10.1038/s41586-021-03828-1');
+    expect(validateDoi('10.1038/s41586-021-03828-1,'))
+      .toBe('10.1038/s41586-021-03828-1');
+  });
   it('strips a "doi:" prefix', () => {
     expect(validateDoi('doi:10.1038/foo')).toBe('10.1038/foo');
+  });
+  it('keeps balanced suffix punctuation but removes unmatched closing wrappers', () => {
+    expect(validateDoi('10.1002/(SICI)1097-4571(199505)46:4<327::AID-ASI5>3.0.CO;2-0'))
+      .toBe('10.1002/(SICI)1097-4571(199505)46:4<327::AID-ASI5>3.0.CO;2-0');
+    expect(validateDoi('(10.1038/foo)')).toBe('10.1038/foo');
+    expect(validateDoi('10.1038/foo).')).toBe('10.1038/foo');
   });
   it('returns null for garbage', () => {
     expect(validateDoi('not a doi')).toBeNull();
@@ -30,6 +42,10 @@ describe('extractDoi (from HTML)', () => {
   });
   it('falls back to scanning text content for a DOI pattern', () => {
     const $ = cheerio.load(`<p>See https://doi.org/10.1038/baz for details.</p>`);
+    expect(extractDoi($)).toBe('10.1038/baz');
+  });
+  it('removes sentence punctuation from DOI text matches', () => {
+    const $ = cheerio.load(`<p>DOI: 10.1038/baz.</p>`);
     expect(extractDoi($)).toBe('10.1038/baz');
   });
   it('returns null when no DOI present', () => {

--- a/tests/journal/normalize.test.ts
+++ b/tests/journal/normalize.test.ts
@@ -55,4 +55,34 @@ describe('normalizeOpenAlex', () => {
     expect(csl.volume).toBe('596');
     expect(csl.page).toBe('583-589');
   });
+
+  it('maps current OpenAlex primary_location and biblio fields', () => {
+    const csl = normalizeOpenAlex({
+      display_name: 'Highly accurate protein structure prediction for the human proteome',
+      authorships: [
+        { author: { display_name: 'Kathryn Tunyasuvunakool' } },
+      ],
+      primary_location: {
+        id: 'doi:10.1038/s41586-021-03828-1',
+        source: { display_name: 'Nature' },
+        raw_source_name: 'Nature',
+      },
+      publication_date: '2021-07-22',
+      biblio: {
+        volume: '596',
+        issue: '7873',
+        first_page: '590',
+        last_page: '596',
+      },
+    } as any);
+
+    expect(csl.title).toBe('Highly accurate protein structure prediction for the human proteome');
+    expect(csl.author).toEqual([{ family: 'Tunyasuvunakool', given: 'Kathryn' }]);
+    expect(csl['container-title']).toBe('Nature');
+    expect(csl.issued).toEqual({ 'date-parts': [[2021, 7, 22]] });
+    expect(csl.DOI).toBe('10.1038/s41586-021-03828-1');
+    expect(csl.volume).toBe('596');
+    expect(csl.issue).toBe('7873');
+    expect(csl.page).toBe('590-596');
+  });
 });

--- a/tests/test-context.test.ts
+++ b/tests/test-context.test.ts
@@ -18,9 +18,9 @@ describe('isTestRequest', () => {
     expect(isTestRequest(r)).toBe(true);
   });
 
-  it('returns true on ?nocache=1 query param', () => {
+  it('ignores ?nocache=1 query param', () => {
     const r = new Request('https://m.com/api/cite-website?url=https://x.com&nocache=1');
-    expect(isTestRequest(r)).toBe(true);
+    expect(isTestRequest(r)).toBe(false);
   });
 
   it('returns false on a normal request', () => {
@@ -40,7 +40,7 @@ describe('isTestRequest', () => {
     expect(isTestRequest(r)).toBe(false);
   });
 
-  it('header takes priority over query (either signal sufficient)', () => {
+  it('returns true when the test header is present', () => {
     const r = new Request('https://m.com/api/cite-website?url=https://x.com', {
       headers: { 'x-mla-test': '1' },
     });

--- a/tests/validation/citation-quality.test.ts
+++ b/tests/validation/citation-quality.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { validateCitationQuality } from '../../functions/lib/validation/citation-quality';
+import type { CSLItem, FieldEvidence, FieldProvenance } from '../../functions/lib/csl-types';
+
+describe('validateCitationQuality', () => {
+  it('treats missing author and date as review warnings, not hard errors', () => {
+    const csl: CSLItem = {
+      id: 'https://example.com/p',
+      type: 'webpage',
+      title: 'Example',
+      URL: 'https://example.com/p',
+    };
+    const quality = validateCitationQuality(csl);
+    expect(quality.warnings.map((w) => [w.code, w.severity])).toContainEqual(['author_not_found', 'review']);
+    expect(quality.warnings.map((w) => [w.code, w.severity])).toContainEqual(['date_not_found', 'review']);
+    expect(quality.warnings.some((w) => w.severity === 'error')).toBe(false);
+  });
+
+  it('does not count blank author entries as a present author', () => {
+    const quality = validateCitationQuality({
+      id: 'https://example.com/p',
+      type: 'webpage',
+      title: 'Example',
+      URL: 'https://example.com/p',
+      author: [{ literal: '   ' }, { family: '', given: ' ' }],
+      issued: { 'date-parts': [[2026, 6, 30]] },
+    });
+
+    expect(quality.warnings.map((w) => w.code)).toContain('author_not_found');
+  });
+
+  it('flags conflicting evidence without overwriting the winner', () => {
+    const winner: FieldEvidence = {
+      field: 'issued',
+      normalizedValue: { 'date-parts': [[2026, 1, 15]] },
+      source: 'jsonld',
+      acquisition: 'fetch',
+      confidence: 0.95,
+    };
+    const conflict: FieldEvidence = {
+      field: 'issued',
+      normalizedValue: { 'date-parts': [[2026, 1, 16]] },
+      source: 'opengraph',
+      acquisition: 'fetch',
+      confidence: 0.75,
+    };
+    const provenance: Partial<Record<keyof CSLItem, FieldProvenance>> = {
+      issued: { winner, candidates: [winner, conflict], conflicts: [conflict] },
+    };
+    const quality = validateCitationQuality({
+      id: 'https://example.com/p',
+      type: 'webpage',
+      title: 'Example',
+      URL: 'https://example.com/p',
+      issued: { 'date-parts': [[2026, 1, 15]] },
+      author: [{ family: 'Doe', given: 'Jane' }],
+    }, { provenance });
+
+    expect(quality.warnings.some((w) => w.code === 'issued_conflict')).toBe(true);
+  });
+});

--- a/workers/browser-renderer/README.md
+++ b/workers/browser-renderer/README.md
@@ -1,0 +1,21 @@
+# MLA Browser Renderer
+
+This Worker owns the Cloudflare Browser Run binding. The Pages app calls it
+through a Pages Service binding named `BROWSER_RENDERER`.
+
+Deploy:
+
+```bash
+npx wrangler deploy --config workers/browser-renderer/wrangler.toml
+```
+
+Cloudflare setup:
+
+- Worker `mla-browser-renderer`: Browser Run binding `BROWSER`.
+- Pages project: Service binding `BROWSER_RENDERER` pointing at
+  `mla-browser-renderer`.
+- Optional hardening: set the same secret value as `RENDERER_SHARED_SECRET` on
+  this Worker and `BROWSER_RENDERER_TOKEN` on the Pages project.
+
+If workers.dev is disabled and there is no public route, the service binding is
+already private. The shared secret is still useful as a defense-in-depth guard.

--- a/workers/browser-renderer/src/index.ts
+++ b/workers/browser-renderer/src/index.ts
@@ -1,0 +1,58 @@
+const UA = 'Mozilla/5.0 (compatible; mlagenerator/1.0; +https://mlagenerator.com)';
+
+interface Env {
+  BROWSER: {
+    quickAction(action: string, body: Record<string, unknown>): Promise<Response | string | Record<string, unknown>>;
+  };
+  RENDERER_SHARED_SECRET?: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    if (env.RENDERER_SHARED_SECRET) {
+      const provided = request.headers.get('x-browser-renderer-token');
+      if (provided !== env.RENDERER_SHARED_SECRET) {
+        return json({ error: 'Unauthorized', code: 'unauthorized' }, 401);
+      }
+    }
+
+    if (request.method !== 'POST') {
+      return json({ error: 'Method not allowed', code: 'method_not_allowed' }, 405);
+    }
+
+    let body: Record<string, unknown>;
+    try {
+      body = await request.json() as Record<string, unknown>;
+    } catch {
+      return json({ error: 'Invalid JSON', code: 'bad_request' }, 400);
+    }
+
+    const action = body.action;
+    const url = body.url;
+    if (action !== 'content' || typeof url !== 'string') {
+      return json({ error: 'Unsupported Browser Run request', code: 'bad_request' }, 400);
+    }
+
+    const rendered = await env.BROWSER.quickAction('content', {
+      url,
+      userAgent: UA,
+      gotoOptions: { waitUntil: 'networkidle2' },
+      rejectResourceTypes: ['image', 'font', 'media'],
+    });
+
+    if (rendered instanceof Response) return rendered;
+    if (typeof rendered === 'string') {
+      return new Response(rendered, {
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      });
+    }
+    return json(rendered);
+  },
+};
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}


### PR DESCRIPTION
Integrates the reliability backend + My References citation-quality warnings onto main (module-first from WIP snapshot 6f1c856; SEO half excluded, chrome-extension separate). **Always-on:** cite endpoints emit `_provenance` + `_quality` (humble review/warning codes + score); My References shows per-field warning badges. **Gated off (opt-in `=== '1'`):** Browser Run + AI assist/check — dormant despite bindings being set, until enabled + verified. Pre-flight-vetted (go-after-fixes); build-blockers fixed. Known follow-up: `*_conflict` warnings over-fire on cosmetic diffs — proper value-normalization fix in the next PR. Local build is broken here, so CI is the gate.