### PR TITLE
Reliability warnings: field-aware conflict detection (kill spurious *_conflict noise)

### DIFF
--- a/functions/lib/extract/merge.ts
+++ b/functions/lib/extract/merge.ts
@@ -1,4 +1,5 @@
 import type { AcquisitionSource, CSLItem, EvidenceSource, FieldEvidence, FieldProvenance } from '../csl-types';
+import { parseAuthorName } from './author-parse';
 
 export interface NamedSignal {
   name: string;
@@ -51,7 +52,7 @@ export function mergeSignals(signals: NamedSignal[], options: MergeOptions = {})
       provenance[field] = {
         winner,
         candidates,
-        conflicts: candidates.filter((candidate) => !sameEvidenceValue(candidate.normalizedValue, winner.normalizedValue)),
+        conflicts: candidates.filter((candidate) => conflictsForField(field, candidate.normalizedValue, winner.normalizedValue)),
       };
     }
   }
@@ -97,4 +98,166 @@ function stableEvidenceValue(value: unknown): string {
   if (Array.isArray(value)) return `[${value.map(stableEvidenceValue).join(',')}]`;
   const obj = value as Record<string, unknown>;
   return `{${Object.keys(obj).sort().map((key) => `${JSON.stringify(key)}:${stableEvidenceValue(obj[key])}`).join(',')}}`;
+}
+
+// -----------------------------------------------------------------------------
+// Field-aware conflict detection.
+//
+// This decides ONLY whether a candidate should be flagged as *conflicting* with
+// the winner (i.e. surfaced as a `${field}_conflict` review warning). It is used
+// exclusively at the conflict-filter site above and never influences winner
+// selection or the value written to `csl`. The strict `sameEvidenceValue` /
+// `stableEvidenceValue` pair is left untouched for its other callers.
+//
+// The goal is to stop cosmetic differences from masquerading as real conflicts:
+//   - URLs that differ only by protocol / `www.` / trailing slash / tracking params
+//   - dates that differ only in precision (`[2024]` vs `[2024,3,15]`)
+//   - author/editor names in different shapes (`{literal}` vs `{family,given}`)
+// while still flagging genuinely different values. Any value we cannot confidently
+// normalize falls back to the original strict structural comparison.
+function conflictsForField(field: keyof CSLItem, candidate: unknown, winner: unknown): boolean {
+  try {
+    if (field === 'URL') {
+      const a = normalizeUrlForCompare(candidate);
+      const b = normalizeUrlForCompare(winner);
+      if (a !== undefined && b !== undefined) return a !== b;
+    } else if (field === 'issued') {
+      const verdict = datesConflict(candidate, winner);
+      if (verdict !== undefined) return verdict;
+    } else if (field === 'author' || field === 'editor') {
+      const verdict = namesConflict(candidate, winner);
+      if (verdict !== undefined) return verdict;
+    }
+  } catch {
+    // Any unexpected shape falls through to the strict comparison below.
+  }
+  return !sameEvidenceValue(candidate, winner);
+}
+
+const TRACKING_PARAM_RE = /^(?:utm_.*|fbclid|gclid|ref|mc_.*)$/i;
+
+// Canonicalizes a URL for equality comparison: strips protocol, lowercases the
+// host, drops a leading `www.`, removes a single trailing slash, and filters out
+// known tracking query params. Returns undefined for non-strings / empty values
+// so the caller can fall back to a strict compare.
+function normalizeUrlForCompare(value: unknown): string | undefined {
+  if (typeof value !== 'string') return undefined;
+  const trimmed = value.trim();
+  if (!trimmed) return undefined;
+
+  // Drop the fragment, then split off the query string.
+  let rest = trimmed.replace(/#.*$/, '');
+  let query = '';
+  const qIndex = rest.indexOf('?');
+  if (qIndex !== -1) {
+    query = rest.slice(qIndex + 1);
+    rest = rest.slice(0, qIndex);
+  }
+
+  // Strip protocol / protocol-relative prefix.
+  rest = rest.replace(/^https?:\/\//i, '').replace(/^\/\//, '');
+
+  // Lowercase and de-`www.` the host (everything up to the first `/`); keep the
+  // path's case since paths can be case-sensitive.
+  const slash = rest.indexOf('/');
+  const host = (slash === -1 ? rest : rest.slice(0, slash)).toLowerCase().replace(/^www\./, '');
+  let path = slash === -1 ? '' : rest.slice(slash);
+  path = path.replace(/\/+$/, '');
+
+  const kept = query
+    .split('&')
+    .filter((pair) => pair && !TRACKING_PARAM_RE.test(pair.split('=')[0]));
+
+  const base = host + path;
+  return kept.length ? `${base}?${kept.join('&')}` : base;
+}
+
+// Compares two CSL dates at the coarsest granularity they share. Returns:
+//   true  -> they disagree on a part they both provide (real conflict)
+//   false -> they agree on every shared part (only a precision difference)
+//   undefined -> not comparable as dates; caller should fall back to strict
+function datesConflict(a: unknown, b: unknown): boolean | undefined {
+  const pa = firstDateParts(a);
+  const pb = firstDateParts(b);
+  if (!pa || !pb || pa.length === 0 || pb.length === 0) return undefined;
+  const shared = Math.min(pa.length, pb.length);
+  for (let i = 0; i < shared; i += 1) {
+    if (pa[i] !== pb[i]) return true;
+  }
+  return false;
+}
+
+// Extracts the first date-parts tuple as an array of finite numbers. Accepts
+// `{ 'date-parts': [[y,m,d]] }`, `[[y,m,d]]`, or a bare `[y,m,d]`.
+function firstDateParts(value: unknown): number[] | undefined {
+  let dp: unknown = value;
+  if (value && typeof value === 'object' && !Array.isArray(value)) {
+    dp = (value as Record<string, unknown>)['date-parts'];
+  }
+  if (!Array.isArray(dp)) return undefined;
+  const first: unknown = Array.isArray(dp[0]) ? dp[0] : dp;
+  if (!Array.isArray(first)) return undefined;
+  const nums = first.map((n) => (typeof n === 'number' ? n : Number(n)));
+  if (nums.some((n) => !Number.isFinite(n))) return undefined;
+  return nums as number[];
+}
+
+// Compares two name lists (author/editor) as sets of canonical keys, so the same
+// people in different shapes/orders/duplication don't count as a conflict.
+// Returns true/false, or undefined when either side isn't a well-formed name list.
+function namesConflict(a: unknown, b: unknown): boolean | undefined {
+  const ka = nameKeySet(a);
+  const kb = nameKeySet(b);
+  if (!ka || !kb) return undefined;
+  if (ka.size !== kb.size) return true;
+  for (const key of ka) {
+    if (!kb.has(key)) return true;
+  }
+  return false;
+}
+
+function nameKeySet(value: unknown): Set<string> | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const set = new Set<string>();
+  for (const item of value) {
+    const key = nameKey(item);
+    if (key === undefined) return undefined; // odd entry -> bail to strict compare
+    set.add(key);
+  }
+  return set;
+}
+
+// Produces a canonical, case-insensitive key for a single CSL name. A `literal`
+// is parsed through the shared author parser so `{literal:"Jane Roe"}` and
+// `{family:"Roe",given:"Jane"}` collapse to the same key. Organizations
+// (literals the parser leaves intact) key on the literal text.
+function nameKey(name: unknown): string | undefined {
+  if (!name || typeof name !== 'object') return undefined;
+  const raw = name as Record<string, unknown>;
+
+  let canonical: Record<string, unknown> = raw;
+  if (typeof raw.literal === 'string' && raw.literal.trim()) {
+    const parsed = parseAuthorName(raw.literal);
+    if (parsed) canonical = parsed as unknown as Record<string, unknown>;
+  }
+
+  if (typeof canonical.literal === 'string' && canonical.literal.trim()) {
+    return `lit:${normalizeNamePart(canonical.literal)}`;
+  }
+
+  const family = typeof canonical.family === 'string' ? canonical.family : '';
+  const given = typeof canonical.given === 'string' ? canonical.given : '';
+  const particle = typeof canonical['non-dropping-particle'] === 'string'
+    ? String(canonical['non-dropping-particle'])
+    : '';
+  if (!family.trim() && !given.trim()) return undefined;
+  return `per:${normalizeNamePart(`${particle} ${family}`)}|${normalizeNamePart(given)}`;
+}
+
+function normalizeNamePart(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/\./g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
 }

--- a/tests/e2e/pipeline.test.ts
+++ b/tests/e2e/pipeline.test.ts
@@ -68,7 +68,12 @@ const CASES: SmokeCase[] = [
     containerTitle: 'Nature',
     DOI: '10.1038/s41586-024-08025-4',
     issuedYear: 2024,
-    expectedWarningCodes: ['title_conflict', 'author_conflict', 'issued_conflict', 'publisher_conflict'],
+    // No issued_conflict: the only differing date candidate is the meta
+    // citation_publication_date "2024/10" (month precision), which agrees with the
+    // JSON-LD "2024-10-23" winner on every shared part. author_conflict remains —
+    // the heuristic byline reads the on-page author list (with ORCID text), which
+    // is a genuinely different value, not just a reshaped copy of the 24 authors.
+    expectedWarningCodes: ['title_conflict', 'author_conflict', 'publisher_conflict'],
     absentWarningCodes: ['author_not_found', 'date_not_found', 'journal_title_missing', 'journal_locator_missing'],
     styleTokens: {
       'mla-9': ['Dathathri, Sumanth, et al.', '<i>Nature</i>', 'https://doi.org/10.1038/s41586-024-08025-4'],
@@ -89,7 +94,10 @@ const CASES: SmokeCase[] = [
     authorCount: 2,
     containerTitle: 'AP News',
     issuedYear: 2026,
-    expectedWarningCodes: ['title_conflict', 'author_conflict'],
+    // No author_conflict: the only differing author candidate is the heuristic
+    // byline "By CLAIRE RUSH and REBECCA BOONE", which matches the JSON-LD authors
+    // once name comparison is case-insensitive.
+    expectedWarningCodes: ['title_conflict'],
     absentWarningCodes: ['author_not_found', 'date_not_found', 'url_missing'],
     styleTokens: {
       'mla-9': ['Rush, Claire, and Rebecca Boone.', '<i>AP News</i>', '26 May 2026'],

--- a/tests/extract/conflict-normalize.test.ts
+++ b/tests/extract/conflict-normalize.test.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect } from 'vitest';
+import { mergeSignals, type NamedSignal } from '../../functions/lib/extract/merge';
+
+// These tests lock in the field-aware conflict detection in mergeSignals: cosmetic
+// differences (URL protocol/www/slash/tracking, date precision, name shape) must
+// NOT surface as `${field}_conflict`, while genuinely different values still do.
+// A higher-confidence "winner" plus a lower-confidence "candidate" are supplied so
+// the winner is deterministic and the candidate is what conflict detection judges.
+
+function merge(field: string, winnerValue: unknown, candidateValue: unknown) {
+  const winner: NamedSignal = {
+    name: 'jsonld',
+    fields: { [field]: winnerValue } as any,
+    confidence: { [field]: 0.95 } as any,
+  };
+  const candidate: NamedSignal = {
+    name: 'heuristic',
+    fields: { [field]: candidateValue } as any,
+    confidence: { [field]: 0.4 } as any,
+  };
+  const result = mergeSignals([winner, candidate]);
+  return result;
+}
+
+describe('mergeSignals field-aware conflict detection', () => {
+  describe('URL', () => {
+    it('does not flag URLs differing only by protocol, www, trailing slash, or tracking params', () => {
+      const { csl, provenance } = merge(
+        'URL',
+        'https://www.example.com/article/',
+        'http://example.com/article?utm_source=news&fbclid=abc&gclid=xyz&ref=home&mc_cid=1',
+      );
+      expect(provenance.URL?.conflicts).toHaveLength(0);
+      // Winner value must be untouched by conflict normalization.
+      expect(csl.URL).toBe('https://www.example.com/article/');
+    });
+
+    it('still flags URLs that point at genuinely different pages', () => {
+      const { provenance } = merge(
+        'URL',
+        'https://example.com/article',
+        'https://example.com/other-article',
+      );
+      expect(provenance.URL?.conflicts).toHaveLength(1);
+    });
+
+    it('keeps non-tracking query params significant', () => {
+      const { provenance } = merge(
+        'URL',
+        'https://example.com/search?q=cats',
+        'https://example.com/search?q=dogs',
+      );
+      expect(provenance.URL?.conflicts).toHaveLength(1);
+    });
+  });
+
+  describe('issued (date precision)', () => {
+    it('does not flag a year-only date against a full date that agrees on the year', () => {
+      const { csl, provenance } = merge(
+        'issued',
+        { 'date-parts': [[2024, 3, 15]] },
+        { 'date-parts': [[2024]] },
+      );
+      expect(provenance.issued?.conflicts).toHaveLength(0);
+      expect(csl.issued).toEqual({ 'date-parts': [[2024, 3, 15]] });
+    });
+
+    it('flags dates that disagree on a shared part (same month, different day)', () => {
+      const { provenance } = merge(
+        'issued',
+        { 'date-parts': [[2024, 1, 2]] },
+        { 'date-parts': [[2024, 1, 26]] },
+      );
+      expect(provenance.issued?.conflicts).toHaveLength(1);
+    });
+
+    it('flags dates that disagree on the year', () => {
+      const { provenance } = merge(
+        'issued',
+        { 'date-parts': [[2024]] },
+        { 'date-parts': [[2023]] },
+      );
+      expect(provenance.issued?.conflicts).toHaveLength(1);
+    });
+  });
+
+  describe('author / editor (name shape)', () => {
+    it('does not flag the same person expressed as a literal vs family/given', () => {
+      const { csl, provenance } = merge(
+        'author',
+        [{ family: 'Roe', given: 'Jane' }],
+        [{ literal: 'Jane Roe' }],
+      );
+      expect(provenance.author?.conflicts).toHaveLength(0);
+      expect(csl.author).toEqual([{ family: 'Roe', given: 'Jane' }]);
+    });
+
+    it('treats a "Family, Given" literal as the same person', () => {
+      const { provenance } = merge(
+        'author',
+        [{ family: 'Roe', given: 'Jane' }],
+        [{ literal: 'Roe, Jane' }],
+      );
+      expect(provenance.author?.conflicts).toHaveLength(0);
+    });
+
+    it('ignores order and duplicate entries (same set of people)', () => {
+      const winner = [{ family: 'Smith', given: 'John' }, { family: 'Doe', given: 'Jane' }];
+      // Same two people, reversed and with a duplicate — mirrors the citation_author
+      // + DC.creator double-listing seen on real journal pages.
+      const candidate = [
+        { family: 'Doe', given: 'Jane' },
+        { family: 'Smith', given: 'John' },
+        { family: 'Doe', given: 'Jane' },
+      ];
+      const { provenance } = merge('author', winner, candidate);
+      expect(provenance.author?.conflicts).toHaveLength(0);
+    });
+
+    it('is case-insensitive (structured vs upper-case byline)', () => {
+      const { provenance } = merge(
+        'author',
+        [{ family: 'Rush', given: 'Claire' }, { family: 'Boone', given: 'Rebecca' }],
+        [{ family: 'RUSH', given: 'CLAIRE' }, { family: 'BOONE', given: 'REBECCA' }],
+      );
+      expect(provenance.author?.conflicts).toHaveLength(0);
+    });
+
+    it('flags a genuinely different set of authors', () => {
+      const { provenance } = merge(
+        'author',
+        [{ family: 'Roe', given: 'Jane' }],
+        [{ family: 'Smith', given: 'John' }],
+      );
+      expect(provenance.author?.conflicts).toHaveLength(1);
+    });
+
+    it('flags when one side lists an extra author', () => {
+      const { provenance } = merge(
+        'author',
+        [{ family: 'Roe', given: 'Jane' }],
+        [{ family: 'Roe', given: 'Jane' }, { family: 'Smith', given: 'John' }],
+      );
+      expect(provenance.author?.conflicts).toHaveLength(1);
+    });
+  });
+
+  describe('unrelated fields fall back to strict comparison', () => {
+    it('still flags conflicting publisher values', () => {
+      const { provenance } = merge('publisher', 'Example University Press', 'Different Press');
+      expect(provenance.publisher?.conflicts).toHaveLength(1);
+    });
+
+    it('does not flag identical publisher values', () => {
+      const { provenance } = merge('publisher', 'Example University Press', 'Example University Press');
+      expect(provenance.publisher?.conflicts).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## What & why

The reliability core (PR #58) ships `*_conflict` My-References warnings whenever two extraction signals disagree on a field. But the conflict check used **strict structural equality**, so *cosmetic* differences fired spurious warnings:

- **URL**: `https://x.com/a/` vs `x.com/a?utm_source=rss` → "conflict" (same page)
- **date**: `[2024]` vs `[2024,3,15]` → "conflict" (agree at every shared part)
- **author**: `{literal:"Jane Roe"}` vs `{family:"Roe",given:"Jane"}`, or the same names in a different order / different case → "conflict"

This makes the warning field-aware so it flags **only genuine disagreements**, while real conflicts (e.g. cdc's *published* Jan-2 vs *updated* Jan-26 dates) still fire.

## Change (production: 1 file)

`functions/lib/extract/merge.ts` — the per-field conflict filter now calls `conflictsForField(field, candidate, winner)`:
- **URL** → normalize away protocol/`www.`/trailing-slash/fragment and `utm_*`/`fbclid`/`gclid`/`ref`/`mc_*` tracking params before comparing.
- **issued** → compare CSL date-parts at the **coarsest shared granularity**; disagreement on any shared part is a conflict.
- **author/editor** → compare a set of canonical name-keys (`literal` routed through the same `parseAuthorName`); order/dupe/case-insensitive.
- **everything else / any odd shape** → falls back to the original strict `sameEvidenceValue` (wrapped in try/catch).

**Winner selection and the `csl` output are untouched** — only the `conflicts[]` array (which drives warnings) changes.

## Tests
- **New** `tests/extract/conflict-normalize.test.ts` — drives real `mergeSignals`; covers each normalization + the negative cases (genuinely different page, `?q=` non-tracking param, different/extra author, day-level date diff) + asserts `csl.URL` is unchanged.
- **e2e reconciliation** `tests/e2e/pipeline.test.ts` — two fixtures lose a now-cosmetic code: `nature-paper` drops `issued_conflict`, `apnews-news` drops `author_conflict`. **cdc-gov-page keeps `issued_conflict`** (real published-vs-updated day diff), wikipedia/academic unchanged.

## For the reviewer — two arrays I want CI to confirm
The agent that traced these could not execute vitest (Windows native-module crash locally), so two suppressions rest on static analysis of heuristic **byline** parsing:
- `nature-paper` author_conflict — *kept* (byline polluted with ORCID/superscripts → genuinely different names). If the byline actually parses to empty, the correct array is `['title_conflict','publisher_conflict']`.
- `apnews-news` author_conflict — *removed* (pure case diff "By CLAIRE RUSH…" vs jsonld). Depends on cheerio including `<template>` text so the "Leer en español" tail is stripped.

CI is the oracle for both; I'll reconcile from the actual vitest output if either mispredicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
