### PR TITLE
Track browser-renderer wrangler.toml (unblocks Browser Run deploy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,7 @@ pnpm-debug.log*
 # functions/api/
 
 wrangler.toml
+# ...except the browser-renderer worker config: no secrets, needed for a reproducible `wrangler deploy`
+!workers/browser-renderer/wrangler.toml
 # Claude Code local state
 .claude/

--- a/workers/browser-renderer/wrangler.toml
+++ b/workers/browser-renderer/wrangler.toml
@@ -1,0 +1,7 @@
+name = "mla-browser-renderer"
+main = "src/index.ts"
+compatibility_date = "2026-06-02"
+workers_dev = false
+
+[browser]
+binding = "BROWSER"


### PR DESCRIPTION
## What & why
The `mla-browser-renderer` Worker (which owns the Cloudflare **Browser Run** binding) has source on main but its `wrangler.toml` was never tracked — the blanket `wrangler.toml` line in `.gitignore` swept it up. So the documented deploy command had nothing to read:
```
npx wrangler deploy --config workers/browser-renderer/wrangler.toml
```
This un-ignores **just that one file** and commits it.

## Safety
- The file carries **no secrets** — only `name`, `main`, `compatibility_date`, `workers_dev = false`, and the `[browser]` binding. (Account IDs / tokens are supplied by `wrangler` auth + Cloudflare env, never this file.)
- **Inert to the production deploy**: Cloudflare Pages builds `astro build`; `workers/` is outside the build and the Functions routing. Nothing about the live site changes.
- All other `wrangler.toml` files stay ignored (the negation is path-specific).

## Follow-up (ops, not in this PR)
Browser Run stays **gated OFF** (`CITATION_RENDERING_ENABLED` unset ≠ `'1'`). Enabling it is a separate ops step: deploy this Worker, confirm the Pages `BROWSER_RENDERER` service binding points at it, then set `CITATION_RENDERING_ENABLED=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)