### PR TITLE
AI guardrail: proposed value must appear verbatim in its cited snippet (close fabrication hole)

### DIFF
--- a/functions/lib/ai/citation-assist.ts
+++ b/functions/lib/ai/citation-assist.ts
@@ -64,7 +64,9 @@ export async function runAiFieldAssist(input: AiAssistInput): Promise<FieldEvide
         content: [
           'You extract citation fields only from provided source text.',
           'Do not invent missing fields.',
-          'Return only fields with a direct evidenceSnippet copied from the provided text.',
+          'For every proposal, evidenceSnippet MUST be copied verbatim from the provided text, and value MUST appear verbatim inside that evidenceSnippet.',
+          'Copy each value exactly as written in the text — do not reformat, translate, abbreviate, or normalize it (e.g. keep a date as "January 15, 2026" exactly as printed; do not convert it to another format).',
+          'If a field is not stated verbatim in the text, omit it rather than guessing.',
           'Do not format citations.',
         ].join(' '),
       },
@@ -151,7 +153,15 @@ function evidenceFromProposal(
 ): FieldEvidence | null {
   if (!Number.isFinite(proposal.confidence) || proposal.confidence < MIN_CONFIDENCE || proposal.confidence > 1) return null;
   const snippet = normalizeText(proposal.evidenceSnippet);
+  // The cited snippet must appear verbatim in the page text.
   if (!snippet || !normalizeText(sourceText).includes(snippet)) return null;
+  // ...and the proposed value must itself appear verbatim inside that snippet.
+  // Snippet-in-page alone is NOT sufficient: without this gate a model can quote
+  // any real page sentence as evidence and pair it with a fabricated value
+  // (hallucinated author/date/DOI). Requiring value ⊆ snippet ⊆ page is the core
+  // guardrail invariant — the AI may only surface a value already present on the
+  // page, never one it invented.
+  if (!valueSupportedBySnippet(proposal.value, snippet)) return null;
   const normalizedValue = normalizeFieldValue(proposal.field, proposal.value);
   if (normalizedValue === undefined) return null;
   if ((input.csl as any)[proposal.field] !== undefined) return null;
@@ -165,6 +175,37 @@ function evidenceFromProposal(
     confidence: Math.min(0.82, proposal.confidence),
     acquiredAt: input.acquiredAt,
   };
+}
+
+// A proposed value is only trustworthy if it literally appears inside the cited
+// evidence snippet (which itself must be verbatim page text — see caller). This
+// enforces the guardrail invariant that the AI may only surface a value already
+// present on the page, never one it invented. Values we cannot reduce to plain
+// strings for this check — structured objects, notably `{ 'date-parts': ... }` —
+// are treated as unverifiable and rejected, so a model must quote dates/values as
+// text (per the system prompt) to have them accepted.
+function valueSupportedBySnippet(value: unknown, normalizedSnippet: string): boolean {
+  const parts = supportStrings(value);
+  if (!parts.length) return false;
+  return parts.every((part) => {
+    const norm = normalizeText(part);
+    return norm.length > 0 && normalizedSnippet.includes(norm);
+  });
+}
+
+function supportStrings(value: unknown): string[] {
+  if (typeof value === 'string') return [value];
+  if (typeof value === 'number' && Number.isFinite(value)) return [String(value)];
+  if (Array.isArray(value)) {
+    const out: string[] = [];
+    for (const item of value) {
+      if (typeof item === 'string') out.push(item);
+      else if (typeof item === 'number' && Number.isFinite(item)) out.push(String(item));
+      else return []; // an unverifiable element invalidates the whole list
+    }
+    return out;
+  }
+  return []; // objects (including { 'date-parts': ... }) are unverifiable here
 }
 
 function normalizeFieldValue(field: keyof CSLItem, value: unknown): unknown {

--- a/functions/lib/ai/citation-assist.ts
+++ b/functions/lib/ai/citation-assist.ts
@@ -54,8 +54,14 @@ const FIELD_SCHEMA = {
 };
 
 export async function runAiFieldAssist(input: AiAssistInput): Promise<FieldEvidence[]> {
-  const sourceText = combinedSourceText(input);
-  if (sourceText.length < 50) return [];
+  // Keep each source document separate. A snippet must live verbatim inside ONE
+  // document — never spanning a fetched/rendered boundary — or a value could be
+  // synthesized across the join of two unrelated texts.
+  const normalizedSources = [input.fetchedText, input.renderedText]
+    .filter((text): text is string => typeof text === 'string' && text.trim().length > 0)
+    .map(normalizeText);
+  const totalLength = normalizedSources.reduce((sum, text) => sum + text.length, 0);
+  if (totalLength < 50) return [];
 
   const response = await input.ai.run(input.model || DEFAULT_MODEL, {
     messages: [
@@ -65,7 +71,8 @@ export async function runAiFieldAssist(input: AiAssistInput): Promise<FieldEvide
           'You extract citation fields only from provided source text.',
           'Do not invent missing fields.',
           'For every proposal, evidenceSnippet MUST be copied verbatim from the provided text, and value MUST appear verbatim inside that evidenceSnippet.',
-          'Copy each value exactly as written in the text — do not reformat, translate, abbreviate, or normalize it (e.g. keep a date as "January 15, 2026" exactly as printed; do not convert it to another format).',
+          'Return every value as a string, copied exactly as written in the text — do not reformat, translate, abbreviate, or normalize it (e.g. keep a date as "January 15, 2026" exactly as printed; do not convert it to another format).',
+          'A snippet must be copied from a single source field; never stitch text across fetchedText and renderedText.',
           'If a field is not stated verbatim in the text, omit it rather than guessing.',
           'Do not format citations.',
         ].join(' '),
@@ -87,9 +94,19 @@ export async function runAiFieldAssist(input: AiAssistInput): Promise<FieldEvide
     },
   });
 
-  return parseAiProposals(response)
-    .map((proposal) => evidenceFromProposal(proposal, input, sourceText))
+  const accepted = parseAiProposals(response)
+    .map((proposal) => evidenceFromProposal(proposal, input, normalizedSources))
     .filter((item): item is FieldEvidence => !!item);
+
+  // Deterministic one-evidence-per-field: if the model proposes a field twice,
+  // keep the highest-confidence acceptance (first wins on a tie) so a later
+  // proposal can't silently overwrite an earlier one downstream.
+  const byField = new Map<keyof CSLItem, FieldEvidence>();
+  for (const item of accepted) {
+    const prev = byField.get(item.field);
+    if (!prev || item.confidence > prev.confidence) byField.set(item.field, item);
+  }
+  return [...byField.values()];
 }
 
 function parseAiProposals(response: unknown): AiProposal[] {
@@ -149,12 +166,14 @@ function parseJson(value: string): any {
 function evidenceFromProposal(
   proposal: AiProposal,
   input: AiAssistInput,
-  sourceText: string,
+  normalizedSources: string[],
 ): FieldEvidence | null {
   if (!Number.isFinite(proposal.confidence) || proposal.confidence < MIN_CONFIDENCE || proposal.confidence > 1) return null;
   const snippet = normalizeText(proposal.evidenceSnippet);
-  // The cited snippet must appear verbatim in the page text.
-  if (!snippet || !normalizeText(sourceText).includes(snippet)) return null;
+  // The cited snippet must appear verbatim within a SINGLE source document (not
+  // across the fetched/rendered join — that would let a value be stitched from
+  // two unrelated texts).
+  if (!snippet || !normalizedSources.some((source) => source.includes(snippet))) return null;
   // ...and the proposed value must itself appear verbatim inside that snippet.
   // Snippet-in-page alone is NOT sufficient: without this gate a model can quote
   // any real page sentence as evidence and pair it with a fabricated value
@@ -164,6 +183,11 @@ function evidenceFromProposal(
   if (!valueSupportedBySnippet(proposal.value, snippet)) return null;
   const normalizedValue = normalizeFieldValue(proposal.field, proposal.value);
   if (normalizedValue === undefined) return null;
+  // Cheap field-shape sanity: reject values whose surface form can't be that
+  // field (e.g. body prose misattributed to DOI). This does not — and cannot by
+  // substring alone — catch semantic misattribution of plausibly-shaped text
+  // (a person named in the body proposed as author); ai-extract stays low-trust.
+  if (!fieldShapeValid(proposal.field, normalizedValue)) return null;
   if ((input.csl as any)[proposal.field] !== undefined) return null;
   return {
     field: proposal.field,
@@ -194,18 +218,31 @@ function valueSupportedBySnippet(value: unknown, normalizedSnippet: string): boo
 }
 
 function supportStrings(value: unknown): string[] {
-  if (typeof value === 'string') return [value];
-  if (typeof value === 'number' && Number.isFinite(value)) return [String(value)];
+  // Only strings (or arrays of strings) are verifiable against the text. Numbers
+  // are rejected so a bare digit-run on the page (e.g. a year "2026") can't be
+  // coerced into volume/issue/page, nor a number slipped into an author list.
+  if (typeof value === 'string') return value.trim() ? [value] : [];
   if (Array.isArray(value)) {
+    if (value.length === 0) return [];
     const out: string[] = [];
     for (const item of value) {
-      if (typeof item === 'string') out.push(item);
-      else if (typeof item === 'number' && Number.isFinite(item)) out.push(String(item));
-      else return []; // an unverifiable element invalidates the whole list
+      if (typeof item === 'string' && item.trim()) out.push(item);
+      else return []; // an unverifiable/empty element invalidates the whole list
     }
     return out;
   }
-  return []; // objects (including { 'date-parts': ... }) are unverifiable here
+  return []; // numbers, objects (incl. { 'date-parts': ... }), booleans, null
+}
+
+// Cheap, surface-form-only validation that a normalized value could plausibly be
+// the given field. Intentionally minimal — it guards the egregious cases (random
+// text into DOI) without pretending to verify semantic correctness.
+function fieldShapeValid(field: keyof CSLItem, normalizedValue: unknown): boolean {
+  if (field === 'DOI') {
+    const doi = String(normalizedValue).replace(/^doi:\s*/i, '').replace(/^https?:\/\/(dx\.)?doi\.org\//i, '');
+    return /^10\.\d{4,9}\/\S+$/.test(doi);
+  }
+  return true;
 }
 
 function normalizeFieldValue(field: keyof CSLItem, value: unknown): unknown {
@@ -247,10 +284,18 @@ function missingFields(csl: CSLItem): string[] {
   return out;
 }
 
-function combinedSourceText(input: AiAssistInput): string {
-  return `${input.fetchedText || ''}\n${input.renderedText || ''}`.trim();
-}
-
+// Canonicalize text for verbatim comparison. Folds only *cosmetic* differences
+// (unicode form, curly quotes/apostrophes, en/em dashes) that would otherwise
+// drop legitimate values whose surface form differs trivially from the page.
+// Applied symmetrically to both value and page text, so it never admits a
+// semantically different value — same principle as the conflict-normalization.
 function normalizeText(value: string): string {
-  return value.replace(/\s+/g, ' ').trim().toLowerCase();
+  return value
+    .normalize('NFC')
+    .replace(/[‘’ʼ]/g, "'")
+    .replace(/[“”]/g, '"')
+    .replace(/[–—]/g, '-')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .toLowerCase();
 }

--- a/tests/ai/citation-assist.test.ts
+++ b/tests/ai/citation-assist.test.ts
@@ -15,7 +15,7 @@ function aiWith(proposals: unknown[]) {
 
 async function assist(
   proposals: unknown[],
-  opts: { csl?: Partial<CSLItem>; text?: string } = {},
+  opts: { csl?: Partial<CSLItem>; text?: string; rendered?: string } = {},
 ) {
   const ai = aiWith(proposals);
   const evidence = await runAiFieldAssist({
@@ -23,6 +23,7 @@ async function assist(
     csl: { type: 'webpage', ...(opts.csl ?? {}) } as CSLItem,
     url: 'https://example.com/article',
     fetchedText: opts.text ?? PAGE,
+    renderedText: opts.rendered,
     acquiredAt: '2026-07-03T00:00:00.000Z',
   });
   return { ai, evidence, fields: evidence.map((e) => e.field) };
@@ -180,5 +181,82 @@ describe('runAiFieldAssist — evidence guardrail', () => {
     );
     expect(evidence).toEqual([]);
     expect(ai.run).not.toHaveBeenCalled();
+  });
+
+  // ---- Hardening from adversarial review. ----
+
+  it('drops a value synthesized across the fetched/rendered boundary', async () => {
+    // "Jane Fakeman" appears on NEITHER document; only across the join.
+    const { fields } = await assist(
+      [P({
+        field: 'author',
+        value: 'Jane Fakeman',
+        evidenceSnippet: 'writing to Jane Fakeman covers technology',
+        confidence: 0.9,
+      })],
+      {
+        text: 'Reach the newsroom by writing to Jane',
+        rendered: 'Fakeman covers technology for the outlet and edits weekend features here.',
+      },
+    );
+    expect(fields).not.toContain('author');
+  });
+
+  it('accepts a snippet that lives entirely within the rendered source', async () => {
+    const { evidence } = await assist(
+      [P({ field: 'author', value: 'Jane Doe', evidenceSnippet: 'By Jane Doe and John Smith, staff writers' })],
+      { text: 'A short stub with almost no metadata at all in it whatsoever.', rendered: PAGE },
+    );
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].field).toBe('author');
+  });
+
+  it('rejects a numeric value coerced into a non-date field (page year → volume)', async () => {
+    const { fields } = await assist([
+      P({ field: 'volume', value: 2026, evidenceSnippet: 'Published January 15, 2026' }),
+    ]);
+    expect(fields).not.toContain('volume');
+  });
+
+  it('rejects an author list containing a bare number', async () => {
+    const { fields } = await assist([
+      P({ field: 'author', value: ['Jane Doe', 2026], evidenceSnippet: 'By Jane Doe and John Smith, staff writers' }),
+    ]);
+    expect(fields).not.toContain('author');
+  });
+
+  it('rejects body prose misattributed to DOI (shape check)', async () => {
+    const { fields } = await assist([
+      P({ field: 'DOI', value: 'the article body text', evidenceSnippet: 'This is the article body text used for testing' }),
+    ]);
+    expect(fields).not.toContain('DOI');
+  });
+
+  it('accepts a real DOI present on the page', async () => {
+    const { evidence } = await assist(
+      [P({ field: 'DOI', value: '10.1038/s41586-020-2649-2', evidenceSnippet: 'doi:10.1038/s41586-020-2649-2 for reference' })],
+      { text: 'Full text below. Cite as doi:10.1038/s41586-020-2649-2 for reference in your bibliography.' },
+    );
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].field).toBe('DOI');
+    expect(evidence[0].normalizedValue).toBe('10.1038/s41586-020-2649-2');
+  });
+
+  it('emits at most one evidence per field when the model proposes it twice', async () => {
+    const { evidence, fields } = await assist([
+      P({ field: 'author', value: 'Jane Doe', evidenceSnippet: 'By Jane Doe and John Smith, staff writers', confidence: 0.8 }),
+      P({ field: 'author', value: 'John Smith', evidenceSnippet: 'By Jane Doe and John Smith, staff writers', confidence: 0.9 }),
+    ]);
+    expect(fields.filter((f) => f === 'author')).toHaveLength(1);
+    expect(evidence).toHaveLength(1);
+  });
+
+  it('matches across a curly/straight apostrophe difference (recall)', async () => {
+    const { evidence } = await assist(
+      [P({ field: 'title', value: "Cat's Cradle Study", evidenceSnippet: 'The Cat’s Cradle Study appears' })],
+      { text: 'Reviewed here: The Cat’s Cradle Study appears widely across schools and libraries this year.' },
+    );
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].field).toBe('title');
   });
 });

--- a/tests/ai/citation-assist.test.ts
+++ b/tests/ai/citation-assist.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runAiFieldAssist } from '../../functions/lib/ai/citation-assist';
+import type { CSLItem } from '../../functions/lib/csl-types';
+
+// A realistic page body (>50 chars, or runAiFieldAssist early-returns []). Every
+// snippet used below is a verbatim substring of this text.
+const PAGE = 'By Jane Doe and John Smith, staff writers. Published January 15, 2026. '
+  + 'Appears in the journal Nature. This is the article body text used for testing the guardrail.';
+
+// Build a mocked AI binding that returns the given proposals, exactly like the
+// Cloudflare Workers-AI response shape ({ response: "<json string>" }).
+function aiWith(proposals: unknown[]) {
+  return { run: vi.fn(async () => ({ response: JSON.stringify({ proposals }) })) };
+}
+
+async function assist(
+  proposals: unknown[],
+  opts: { csl?: Partial<CSLItem>; text?: string } = {},
+) {
+  const ai = aiWith(proposals);
+  const evidence = await runAiFieldAssist({
+    ai,
+    csl: { type: 'webpage', ...(opts.csl ?? {}) } as CSLItem,
+    url: 'https://example.com/article',
+    fetchedText: opts.text ?? PAGE,
+    acquiredAt: '2026-07-03T00:00:00.000Z',
+  });
+  return { ai, evidence, fields: evidence.map((e) => e.field) };
+}
+
+const P = (over: Record<string, unknown>) => ({
+  field: 'author',
+  value: 'Jane Doe',
+  evidenceSnippet: 'By Jane Doe and John Smith, staff writers',
+  evidenceSource: 'fetched',
+  confidence: 0.9,
+  ...over,
+});
+
+describe('runAiFieldAssist — evidence guardrail', () => {
+  // ---- The core invariant (HOLE A): snippet in page is NOT enough; the value
+  // itself must be supported by (appear verbatim within) the cited snippet. ----
+
+  it('drops an author value that is absent from its (real) cited snippet', async () => {
+    const { evidence, fields } = await assist([
+      P({
+        field: 'author',
+        value: 'Fabricated McMadeup',
+        evidenceSnippet: 'This is the article body text used for testing', // real page text
+      }),
+    ]);
+    expect(fields).not.toContain('author');
+    expect(evidence).toEqual([]);
+  });
+
+  it('drops a date value absent from its cited snippet', async () => {
+    const { fields } = await assist([
+      P({
+        field: 'issued',
+        value: 'December 1, 1999', // not anywhere in the page
+        evidenceSnippet: 'This is the article body text used for testing',
+      }),
+    ]);
+    expect(fields).not.toContain('issued');
+  });
+
+  it('drops a fabricated DOI backed by an unrelated real snippet', async () => {
+    const { fields } = await assist([
+      P({
+        field: 'DOI',
+        value: '10.9999/totally-fake',
+        evidenceSnippet: 'Appears in the journal Nature',
+        confidence: 0.95,
+      }),
+    ]);
+    expect(fields).not.toContain('DOI');
+  });
+
+  it('drops a structured date object (unverifiable by substring)', async () => {
+    const { fields } = await assist([
+      P({
+        field: 'issued',
+        value: { 'date-parts': [[1999, 1, 1]] }, // object -> cannot verify against text
+        evidenceSnippet: 'Published January 15, 2026',
+      }),
+    ]);
+    expect(fields).not.toContain('issued');
+  });
+
+  it('rejects a one-common-word snippet paired with an unrelated value (HOLE B)', async () => {
+    const { fields } = await assist([
+      P({ field: 'title', value: 'Anything At All', evidenceSnippet: 'the' }),
+    ]);
+    expect(fields).not.toContain('title');
+  });
+
+  // ---- The guardrail must not over-reject genuine, on-page values. ----
+
+  it('accepts a value that is a verbatim substring of its snippet', async () => {
+    const { evidence } = await assist([
+      P({ field: 'author', value: 'Jane Doe', evidenceSnippet: 'By Jane Doe and John Smith, staff writers' }),
+    ]);
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].field).toBe('author');
+    expect(evidence[0].normalizedValue).toEqual([{ family: 'Doe', given: 'Jane' }]);
+  });
+
+  it('accepts a verbatim date and parses it', async () => {
+    const { evidence } = await assist([
+      P({ field: 'issued', value: 'January 15, 2026', evidenceSnippet: 'Published January 15, 2026' }),
+    ]);
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].normalizedValue).toEqual({ 'date-parts': [[2026, 1, 15]], raw: 'January 15, 2026' });
+  });
+
+  it('accepts an author list only when every name is in the snippet', async () => {
+    const ok = await assist([
+      P({ field: 'author', value: ['Jane Doe', 'John Smith'], evidenceSnippet: 'By Jane Doe and John Smith, staff writers' }),
+    ]);
+    expect(ok.evidence).toHaveLength(1);
+    expect(ok.evidence[0].normalizedValue).toEqual([
+      { family: 'Doe', given: 'Jane' },
+      { family: 'Smith', given: 'John' },
+    ]);
+
+    const bad = await assist([
+      P({ field: 'author', value: ['Jane Doe', 'Ghost Writer'], evidenceSnippet: 'By Jane Doe and John Smith, staff writers' }),
+    ]);
+    expect(bad.fields).not.toContain('author'); // one unsupported name invalidates the list
+  });
+
+  it('matches case- and whitespace-insensitively (does not over-reject)', async () => {
+    const { evidence } = await assist(
+      [P({ field: 'title', value: 'the ARTICLE body', evidenceSnippet: 'This is the article body text' })],
+      { text: 'This  is   the ARTICLE   body text used for testing the citation guardrail thoroughly.' },
+    );
+    expect(evidence).toHaveLength(1);
+    expect(evidence[0].field).toBe('title');
+    expect(evidence[0].normalizedValue).toBe('the ARTICLE body');
+  });
+
+  // ---- Supporting gates. ----
+
+  it('drops an empty / whitespace-only snippet', async () => {
+    const { fields } = await assist([P({ evidenceSnippet: '   ' })]);
+    expect(fields).not.toContain('author');
+  });
+
+  it('drops a proposal with confidence below the floor', async () => {
+    const { fields } = await assist([P({ confidence: 0.69 })]);
+    expect(fields).not.toContain('author');
+  });
+
+  it('drops a proposal with confidence above 1', async () => {
+    const { fields } = await assist([P({ confidence: 2 })]);
+    expect(fields).not.toContain('author');
+  });
+
+  it('never overrides a field already present in the CSL (additive only)', async () => {
+    const { fields } = await assist(
+      [P({ field: 'author', value: 'Jane Doe', evidenceSnippet: 'By Jane Doe and John Smith, staff writers' })],
+      { csl: { author: [{ family: 'Existing', given: 'Author' }] } },
+    );
+    expect(fields).not.toContain('author');
+  });
+
+  it('caps accepted confidence at 0.82 and tags provenance as ai-extract', async () => {
+    const { evidence } = await assist([
+      P({ field: 'author', value: 'Jane Doe', evidenceSnippet: 'By Jane Doe and John Smith, staff writers', confidence: 0.99 }),
+    ]);
+    expect(evidence[0].confidence).toBe(0.82);
+    expect(evidence[0].source).toBe('ai-extract');
+    expect(evidence[0].acquisition).toBe('ai');
+  });
+
+  it('returns nothing when the page text is too short to trust', async () => {
+    const { ai, evidence } = await assist(
+      [P({ field: 'author', value: 'Jane Doe', evidenceSnippet: 'Jane Doe' })],
+      { text: 'too short' },
+    );
+    expect(evidence).toEqual([]);
+    expect(ai.run).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## The flaw (found while prepping AI enablement)
A read-only audit of the **field-assist** guardrail (`functions/lib/ai/citation-assist.ts`) found that `evidenceFromProposal` verified only that the model's `evidenceSnippet` was verbatim page text — it **never checked that the proposed `value` was supported by that snippet**. So a model could quote any real page sentence and pair it with a **fabricated value**:

```
page:     "…This is the article body…"
proposal: { field:'author', value:'Fabricated McMadeup',
            evidenceSnippet:'This is the article body', confidence:0.9 }
→ ACCEPTED  → hallucinated author written into the (empty) field
```

Fabricated bibliographic data is the worst failure mode for a citation tool. The stated invariant — *never fill a field without a verbatim snippet that **supports the value*** — was not implemented; only snippet-presence was. (Blast radius was bounded: AI only ever fills **empty** fields — it never overrides extraction — but an empty author/date/DOI getting a hallucinated value is still unacceptable.)

## The fix (1 production file)
Add the missing gate in `evidenceFromProposal`: the normalized value must appear **verbatim inside the normalized snippet**, which is already required to be verbatim page text. Net: **value ⊆ snippet ⊆ page**.
- Author lists: **every** name must be in the snippet, or the whole proposal is dropped.
- Structured values (`{date-parts}` objects) are unverifiable by substring → **rejected**; the model must quote dates as text.
- System prompt tightened to instruct verbatim value-copying (keeps the feature useful: dates/authors quoted as printed still pass).
- Unchanged: winner selection, confidence cap (0.82), source rank, additive-only (never overrides a populated field).

Edge cases resolve in the **safe direction** — a reformatted/normalized value that isn't a verbatim substring is dropped (field left empty for manual entry), never fabricated.

## Tests — `tests/ai/citation-assist.test.ts` (new; field-assist had ~zero unit coverage)
Covers the previously-untested fabrication path (author/date/DOI value absent from a real snippet → dropped), the structured-date rejection, the one-common-word-snippet attack, plus acceptance cases proving it doesn't over-reject (verbatim author, verbatim date parsed, author-list all-in-snippet, case/whitespace-insensitive), and the supporting gates (empty snippet, confidence floor/ceiling, additive-only, 0.82 cap, short-page skip).

## Rollout note
**AI stays gated OFF** (`CITATION_AI_ASSIST_ENABLED` unset ≠ `'1'`). This hardens the guardrail *before* any enablement; nothing about live behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)