### PR TITLE
Enable Browser Run by binding presence (drop opt-in flag)

### DIFF
--- a/functions/api/cite-website/index.ts
+++ b/functions/api/cite-website/index.ts
@@ -14,7 +14,6 @@ interface Env extends AiGatewayEnv {
   AI_CITATION_MODEL?: string;
   AI_GATEWAY_MODEL?: string;
   CITATION_INTERNAL_DEBUG_TOKEN?: string;
-  CITATION_RENDERING_ENABLED?: string;
   CITATION_AI_ASSIST_ENABLED?: string;
   BROWSER_RENDERER_TOKEN?: string;
 }
@@ -38,7 +37,12 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     acquisitionMode: internalDebug ? acquisitionMode(url.searchParams.get('acquisition')) : 'auto',
     bypassCache: internalDebug && url.searchParams.get('nocache') === '1',
     aiAssistEnabled: context.env.CITATION_AI_ASSIST_ENABLED === '1',
-    renderingEnabled: context.env.CITATION_RENDERING_ENABLED === '1',
+    // Browser Run is enabled whenever a browser binding is present — the binding
+    // IS the enablement signal (no separate flag). Rendering still only fires for
+    // thin/blocked/JS-heavy pages (see shouldRender) and degrades gracefully to
+    // the fetch result on failure, so a bound-but-broken renderer never breaks a
+    // request.
+    renderingEnabled: !!browser,
   });
 };
 


### PR DESCRIPTION
## What & why
Browser Run (rendered acquisition for JS-heavy pages) was gated behind `CITATION_RENDERING_ENABLED === '1'`. Per direction — the Cloudflare Browser binding is already provisioned and *is* the enablement signal — this drops the separate flag and gates rendering on **binding presence**: `renderingEnabled: !!browser`.

## Behavior
- **Binding present → on by default.** Rendering still only fires for thin / blocked / JS-heavy pages (`shouldRender` → `shouldTryRenderedAcquisition`), so Browser Rendering cost is bounded to pages a plain fetch can't handle.
- **Graceful failure.** A render error/timeout degrades to the fetch result (auto mode) — a bound-but-unreachable renderer never breaks a request; it just records a `render` attempt error in `_quality.acquisition`.
- **No binding → cleanly off** (`renderWanted` is false; never hits the `render_unavailable` path).
- AI assist unchanged (still opt-in; deferred pending a "verify" UI signal).

## Verification
Handler render-decision + graceful-degradation traced against `handler.ts`. Handler tests call `handleCiteWebsite` directly (unaffected by this wiring change); CI runs them. Post-merge I'll smoke-test production: confirm `_quality.acquisition.render` fires on a JS-heavy page and that normal pages + `/my-references/` are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)