### PR TITLE
My References: 'AI-suggested — verify' signal (prerequisite for enabling AI)

### DIFF
--- a/functions/lib/validation/citation-quality.ts
+++ b/functions/lib/validation/citation-quality.ts
@@ -100,6 +100,19 @@ export function validateCitationQuality(csl: CSLItem, options: ValidateCitationO
         evidence: compactEvidence([item.winner, ...item.conflicts]),
       });
     }
+    // Flag any field an LLM filled so the user knows to verify it against the
+    // source (AI proposes only empty fields, low-trust). Keyed on the winner
+    // source, so it is inert until AI field-assist is enabled.
+    if (item.winner?.source === 'ai-extract') {
+      warnings.push({
+        code: `${String(field)}_ai_suggested`,
+        field,
+        severity: 'review',
+        message: 'This value was suggested by AI. Verify it against the source before relying on this citation.',
+        action: 'review-field',
+        evidence: compactEvidence([item.winner]),
+      });
+    }
   }
 
   for (const attempt of Object.values(options.acquisition ?? {})) {

--- a/src/components/react/EditCitationForm.tsx
+++ b/src/components/react/EditCitationForm.tsx
@@ -184,6 +184,7 @@ function conciseWarningMessage(warning: CitationQualityWarning): string {
         case 'title_conflict':
             return 'Multiple titles were found; confirm this title.';
         default:
+            if (warning.code.endsWith('_ai_suggested')) return 'AI-suggested — verify this value against the source.';
             if (warning.code.endsWith('_conflict')) return 'Conflicting source data was found; confirm this value.';
             return warning.message;
     }

--- a/src/lib/references/warnings.ts
+++ b/src/lib/references/warnings.ts
@@ -18,6 +18,7 @@ export function isDismissibleCitationWarning(warning: CitationQualityWarning): b
   if (warning.severity === 'error') return false;
   if (NON_DISMISSIBLE_CODES.has(warning.code)) return false;
   if (warning.code.endsWith('_conflict')) return true;
+  if (warning.code.endsWith('_ai_suggested')) return true; // "I verified this"
   return false;
 }
 

--- a/tests/client/EditCitationForm.test.tsx
+++ b/tests/client/EditCitationForm.test.tsx
@@ -102,6 +102,31 @@ describe('EditCitationForm quality warnings', () => {
     expect(queryByText(/page appeared to load only partially/)).toBeNull();
   });
 
+  it('renders an AI-suggested field note that the user can dismiss', () => {
+    const source: StoredSource = {
+      uuid: 'u2',
+      csl: { id: 'u2', type: 'webpage', title: 'AI-suggested Title', URL: 'https://x.com/p' },
+      quality: {
+        score: 80,
+        warnings: [
+          {
+            code: 'title_ai_suggested',
+            field: 'title',
+            severity: 'review',
+            message: 'This value was suggested by AI. Verify it against the source before relying on this citation.',
+            action: 'review-field',
+          },
+        ],
+      },
+    };
+
+    const { getByText, container } = render(<EditCitationForm source={source} setSources={() => {}} />);
+
+    expect(getByText('AI-suggested — verify this value against the source.')).toBeTruthy();
+    // The note is dismissible ("I verified this").
+    expect(container.querySelectorAll('button[aria-label^="Dismiss warning:"]')).toHaveLength(1);
+  });
+
   it('dismisses optional warnings for only the current citation', () => {
     const setSources = vi.fn();
     const source: StoredSource = {

--- a/tests/client/warnings.test.ts
+++ b/tests/client/warnings.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isDismissibleCitationWarning,
+  isCitationWarningDismissed,
+  visibleCitationWarnings,
+  warningDismissalKey,
+} from '../../src/lib/references/warnings';
+import type { CitationQualityWarning } from '../../src/lib/citations/csl-types';
+
+const w = (over: Partial<CitationQualityWarning>): CitationQualityWarning => ({
+  code: 'title_ai_suggested',
+  field: 'title',
+  severity: 'review',
+  message: 'This value was suggested by AI.',
+  action: 'review-field',
+  ...over,
+});
+
+describe('citation warning dismissal', () => {
+  it('allows dismissing an AI-suggested warning ("I verified this")', () => {
+    expect(isDismissibleCitationWarning(w({}))).toBe(true);
+  });
+
+  it('still allows dismissing conflicts but never hard errors / missing fields', () => {
+    expect(isDismissibleCitationWarning(w({ code: 'issued_conflict' }))).toBe(true);
+    expect(isDismissibleCitationWarning(w({ code: 'title_missing', severity: 'error' }))).toBe(false);
+    expect(isDismissibleCitationWarning(w({ code: 'author_not_found' }))).toBe(false);
+  });
+
+  it('hides an AI-suggested warning once dismissed by its key', () => {
+    const warning = w({ field: 'publisher', code: 'publisher_ai_suggested' });
+    const key = warningDismissalKey(warning);
+    expect(key).toBe('publisher:publisher_ai_suggested');
+    expect(isCitationWarningDismissed(warning, [key])).toBe(true);
+    expect(visibleCitationWarnings([warning], [key])).toEqual([]);
+    expect(visibleCitationWarnings([warning], [])).toHaveLength(1);
+  });
+});

--- a/tests/validation/citation-quality.test.ts
+++ b/tests/validation/citation-quality.test.ts
@@ -58,4 +58,55 @@ describe('validateCitationQuality', () => {
 
     expect(quality.warnings.some((w) => w.code === 'issued_conflict')).toBe(true);
   });
+
+  it('flags an AI-filled field so the user verifies it', () => {
+    const winner: FieldEvidence = {
+      field: 'publisher',
+      normalizedValue: 'Example Press',
+      source: 'ai-extract',
+      acquisition: 'ai',
+      confidence: 0.82,
+    };
+    const provenance: Partial<Record<keyof CSLItem, FieldProvenance>> = {
+      publisher: { winner, candidates: [winner], conflicts: [] },
+    };
+    const quality = validateCitationQuality({
+      id: 'https://example.com/p',
+      type: 'webpage',
+      title: 'Example',
+      URL: 'https://example.com/p',
+      publisher: 'Example Press',
+      author: [{ family: 'Doe', given: 'Jane' }],
+      issued: { 'date-parts': [[2026, 1, 15]] },
+    }, { provenance });
+
+    const warning = quality.warnings.find((w) => w.code === 'publisher_ai_suggested');
+    expect(warning).toBeDefined();
+    expect(warning?.field).toBe('publisher');
+    expect(warning?.severity).toBe('review');
+  });
+
+  it('does not flag AI-suggested for a normally-extracted winner', () => {
+    const winner: FieldEvidence = {
+      field: 'publisher',
+      normalizedValue: 'Example Press',
+      source: 'jsonld',
+      acquisition: 'fetch',
+      confidence: 0.9,
+    };
+    const provenance: Partial<Record<keyof CSLItem, FieldProvenance>> = {
+      publisher: { winner, candidates: [winner], conflicts: [] },
+    };
+    const quality = validateCitationQuality({
+      id: 'https://example.com/p',
+      type: 'webpage',
+      title: 'Example',
+      URL: 'https://example.com/p',
+      publisher: 'Example Press',
+      author: [{ family: 'Doe', given: 'Jane' }],
+      issued: { 'date-parts': [[2026, 1, 15]] },
+    }, { provenance });
+
+    expect(quality.warnings.some((w) => w.code.endsWith('_ai_suggested'))).toBe(false);
+  });
 });


### PR DESCRIPTION
## What & why
Before enabling AI field-assist, users need to see **which** fields an LLM filled so they can verify them — the guardrail closes *fabrication*, but *misattribution* of real page text to the wrong field is an inherent residual (see #61). This adds that signal.

When AI fills a missing field, that field's provenance winner has `source === 'ai-extract'`. The server validator now emits a per-field **`${field}_ai_suggested`** warning (severity `review`), which:
- **Survives storage** — it rides in `_quality.warnings` (persisted), whereas `_provenance` is stripped at save, so a provenance-keyed badge would vanish on reload.
- **Reuses the existing per-field UI** — renders under the affected field in the edit form ("AI-suggested — verify this value against the source.") and shows the row's review badge.
- **Is dismissible** — an "I verified this" X, matching the `_conflict` pattern (otherwise the note would never clear).
- **Is inert until AI is enabled** — keyed on `winner.source`, so no field qualifies while AI is gated OFF. Zero live behavior change today.

## Changes (3 source + 3 test)
- `functions/lib/validation/citation-quality.ts` — emit `${field}_ai_suggested` when `winner.source === 'ai-extract'`.
- `src/lib/references/warnings.ts` — make `_ai_suggested` dismissible.
- `src/components/react/EditCitationForm.tsx` — concise message for the code.
- Tests: validator emits/omits correctly (node); dismissibility unit test; form renders the note + dismiss control (jsdom).

## Notes
- Can't be smoke-tested end-to-end in prod (AI is off → no `ai-extract` data), so coverage is via unit tests with hand-built provenance — called out in the recon.
- Follow-up (optional polish): a distinct icon (e.g. Sparkles) to visually separate "AI-suggested" from "conflict" review notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)