### PR TITLE
Enable AI field-assist by binding presence (drop opt-in flag)

### DIFF
--- a/functions/api/cite-website/index.ts
+++ b/functions/api/cite-website/index.ts
@@ -14,7 +14,6 @@ interface Env extends AiGatewayEnv {
   AI_CITATION_MODEL?: string;
   AI_GATEWAY_MODEL?: string;
   CITATION_INTERNAL_DEBUG_TOKEN?: string;
-  CITATION_AI_ASSIST_ENABLED?: string;
   BROWSER_RENDERER_TOKEN?: string;
 }
 
@@ -36,7 +35,12 @@ export const onRequest: PagesFunction<Env> = async (context) => {
     aiModel: context.env.AI_CITATION_MODEL || context.env.AI_GATEWAY_MODEL,
     acquisitionMode: internalDebug ? acquisitionMode(url.searchParams.get('acquisition')) : 'auto',
     bypassCache: internalDebug && url.searchParams.get('nocache') === '1',
-    aiAssistEnabled: context.env.CITATION_AI_ASSIST_ENABLED === '1',
+    // AI field-assist is enabled whenever an AI binding is present (the binding
+    // is the enablement signal — no separate flag). It still only runs on pages
+    // still missing core fields after fetch+render (shouldRunAiAssist), every
+    // proposal must be verbatim-verified against the page (see citation-assist),
+    // and AI-filled fields are surfaced as "AI-suggested — verify" in the UI.
+    aiAssistEnabled: !!ai,
     // Browser Run is enabled whenever a browser binding is present — the binding
     // IS the enablement signal (no separate flag). Rendering still only fires for
     // thin/blocked/JS-heavy pages (see shouldRender) and degrades gracefully to


### PR DESCRIPTION
## What
Gate AI field-assist on **binding presence** (`aiAssistEnabled: !!ai`) instead of the `CITATION_AI_ASSIST_ENABLED` flag — consistent with Browser Run (#62) and per direction (no arbitrary flags; the provisioned binding is the enablement signal).

## Why now / safety
All prerequisites are met:
- **Guardrail hardened + tested** (#61): every AI proposal must appear verbatim in a cited page snippet (value ⊆ snippet ⊆ single source); no fabrication; numbers/structured values rejected; DOI shape-checked.
- **"AI-suggested — verify" UI** (#63): every AI-filled field is flagged for user verification (addresses the documented misattribution residual).
- **Bounded**: `shouldRunAiAssist` only fires when core fields are STILL missing after fetch **and** render, AI fills only empty fields, confidence-capped at 0.82, never overrides extraction.
- **Self-protecting**: if no AI binding exists, `!!ai` is false → AI stays off.

## Verification
Post-merge I'll smoke-test in production: confirm AI runs on a thin page (example.com — has HTML but no real author/date) and correctly adds **nothing** (guardrail rejects unverifiable proposals — no fabrication), that a genuinely thin content page gets real fields flagged `*_ai_suggested`, and that normal pages + latency are unaffected. Ready to revert if prod shows issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)