### PR TITLE
Upgrade AI model to Llama-3.3-70B + enable AI sanity-check (P5)

### DIFF
--- a/functions/api/quality/check/index.ts
+++ b/functions/api/quality/check/index.ts
@@ -6,7 +6,6 @@ interface Env extends AiGatewayEnv {
   AI?: AiBinding;
   AI_CITATION_MODEL?: string;
   AI_GATEWAY_MODEL?: string;
-  CITATION_AI_CHECK_ENABLED?: string;
 }
 
 export const onRequest: PagesFunction<Env> = async (context) => {
@@ -14,6 +13,9 @@ export const onRequest: PagesFunction<Env> = async (context) => {
   return handleQualityCheck(context.request, {
     ai,
     aiModel: context.env.AI_CITATION_MODEL || context.env.AI_GATEWAY_MODEL,
-    aiCheckEnabled: context.env.CITATION_AI_CHECK_ENABLED === '1',
+    // Enabled by binding presence (consistent with field-assist / Browser Run).
+    // The sanity-check only adds advisory `ai_*` review warnings — it never
+    // modifies citation fields — so binding-presence gating is low-risk.
+    aiCheckEnabled: !!ai,
   });
 };

--- a/functions/lib/ai/citation-assist.ts
+++ b/functions/lib/ai/citation-assist.ts
@@ -2,7 +2,10 @@ import type { CSLDate, CSLItem, FieldEvidence } from '../csl-types';
 import { parseAuthorList } from '../extract/author-parse';
 import { parseDate } from '../extract/date-parse';
 
-const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
+// Stronger default model: the 8B was too weak to produce verbatim-verifiable
+// proposals in practice (added nothing in prod smoke tests). Overridable via
+// AI_CITATION_MODEL / AI_GATEWAY_MODEL.
+const DEFAULT_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
 const MIN_CONFIDENCE = 0.7;
 
 export interface AiBinding {

--- a/functions/lib/ai/citation-check.ts
+++ b/functions/lib/ai/citation-check.ts
@@ -1,7 +1,7 @@
 import type { CitationQualityWarning, CSLItem, SupportedStyle } from '../csl-types';
 import type { AiBinding } from './citation-assist';
 
-const DEFAULT_MODEL = '@cf/meta/llama-3.1-8b-instruct-fast';
+const DEFAULT_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
 
 export interface AiCitationCheckInput {
   ai: AiBinding;


### PR DESCRIPTION
## What
1. **Upgrade the AI model** for both field-assist and sanity-check: `@cf/meta/llama-3.1-8b-instruct-fast` → **`@cf/meta/llama-3.3-70b-instruct-fp8-fast`** (Workers AI, fp8, fast variant). Overridable via `AI_CITATION_MODEL` / `AI_GATEWAY_MODEL`.
2. **Enable AI sanity-check (P5)** by binding presence: `aiCheckEnabled: !!ai` (was `CITATION_AI_CHECK_ENABLED === '1'`), consistent with field-assist and Browser Run.

## Why
Prod smoke of field-assist showed the 8B model added **nothing** across 7 pages — too weak to produce verbatim-verifiable proposals (safe, but no value). A 70B model should surface real fields. **The guardrail is unchanged**, so a stronger model yields *more real fields*, not more fabrication — every proposal still must appear verbatim in a cited page snippet.

The sanity-check only **adds advisory `ai_*` review warnings** (never modifies citation fields, capped at 3), so enabling it on binding presence is low-risk and needs no new UI (warnings already render in My References).

## Verification
Post-merge prod smoke:
- Field-assist: confirm AI now returns `status: 'success'` (adds fields) on pages the 8B left empty — and that added fields are genuinely on the page (guardrail holds) and flagged `*_ai_suggested`. Model-ID validity is provable: an invalid ID would surface as `acquisition.ai.status === 'error'`.
- Sanity-check: confirm `/api/quality/check` now returns `ai_*` advisory warnings on a citation.
- No 500s; latency acceptable (70B is slower than 8B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)