### PR TITLE
Bound AI field-assist with a 10s timeout (cap latency)

### DIFF
--- a/functions/lib/ai/citation-assist.ts
+++ b/functions/lib/ai/citation-assist.ts
@@ -7,6 +7,10 @@ import { parseDate } from '../extract/date-parse';
 // AI_CITATION_MODEL / AI_GATEWAY_MODEL.
 const DEFAULT_MODEL = '@cf/meta/llama-3.3-70b-instruct-fp8-fast';
 const MIN_CONFIDENCE = 0.7;
+// Bound the model call: the 70B model can take 15s+, and AI only runs on already
+// slow (thin) pages. On timeout we return no proposals and the extraction result
+// stands — AI is strictly additive, so a skipped call never degrades the result.
+const AI_TIMEOUT_MS = 10_000;
 
 export interface AiBinding {
   run(model: string, input: Record<string, unknown>): Promise<unknown>;
@@ -66,7 +70,7 @@ export async function runAiFieldAssist(input: AiAssistInput): Promise<FieldEvide
   const totalLength = normalizedSources.reduce((sum, text) => sum + text.length, 0);
   if (totalLength < 50) return [];
 
-  const response = await input.ai.run(input.model || DEFAULT_MODEL, {
+  const response = await runModelWithTimeout(input.ai.run(input.model || DEFAULT_MODEL, {
     messages: [
       {
         role: 'system',
@@ -95,8 +99,9 @@ export async function runAiFieldAssist(input: AiAssistInput): Promise<FieldEvide
       type: 'json_schema',
       json_schema: FIELD_SCHEMA,
     },
-  });
+  }), AI_TIMEOUT_MS);
 
+  // response is null on timeout/model failure → parseAiProposals yields [].
   const accepted = parseAiProposals(response)
     .map((proposal) => evidenceFromProposal(proposal, input, normalizedSources))
     .filter((item): item is FieldEvidence => !!item);
@@ -110,6 +115,24 @@ export async function runAiFieldAssist(input: AiAssistInput): Promise<FieldEvide
     if (!prev || item.confidence > prev.confidence) byField.set(item.field, item);
   }
   return [...byField.values()];
+}
+
+// Resolve the model call, or null if it exceeds the timeout or fails. A null
+// result flows through parseAiProposals as "no proposals", so the caller adds no
+// AI fields and the deterministic extraction result is used unchanged.
+async function runModelWithTimeout(call: Promise<unknown>, ms: number): Promise<unknown | null> {
+  call.catch(() => {}); // avoid an unhandled rejection if the timeout wins the race
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      call,
+      new Promise<null>((resolve) => { timer = setTimeout(() => resolve(null), ms); }),
+    ]);
+  } catch {
+    return null; // model error → treated as no proposals
+  } finally {
+    clearTimeout(timer); // don't leave a dangling timer when the model wins the race
+  }
 }
 
 function parseAiProposals(response: unknown): AiProposal[] {

--- a/tests/ai/citation-assist.test.ts
+++ b/tests/ai/citation-assist.test.ts
@@ -259,4 +259,23 @@ describe('runAiFieldAssist — evidence guardrail', () => {
     expect(evidence).toHaveLength(1);
     expect(evidence[0].field).toBe('title');
   });
+
+  it('returns no fields when the model call exceeds the timeout', async () => {
+    vi.useFakeTimers();
+    try {
+      const ai = { run: vi.fn(() => new Promise(() => {})) }; // never resolves
+      const promise = runAiFieldAssist({
+        ai: ai as never,
+        csl: { type: 'webpage' } as CSLItem,
+        url: 'https://example.com/a',
+        fetchedText: PAGE,
+        acquiredAt: '2026-07-04T00:00:00.000Z',
+      });
+      await vi.advanceTimersByTimeAsync(10_000);
+      await expect(promise).resolves.toEqual([]);
+      expect(ai.run).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });


### PR DESCRIPTION
## What & why
The upgraded 70B model can take 15s+ (observed 16.2s on one prod page — which added nothing), stalling the whole `/api/cite-website` request. This bounds the model call at **10s**.

On timeout (or model error) `runAiFieldAssist` returns **no proposals** and the deterministic extraction result stands. AI is strictly additive (only fills empty fields), so a skipped call **never degrades** the result — it just caps worst-case latency. The timer is cleared when the model wins the race, and late rejections are swallowed to avoid unhandled rejections.

10s preserves observed successes (a real acceptance took ~7s of model time on brendangregg.com) while cutting the pathological 16s cases that were adding nothing anyway.

## Test
Fake-timer test: a never-resolving model call → `runAiFieldAssist` resolves `[]` after the timeout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)