### PR TITLE
References: instant loading skeleton on submit

### DIFF
--- a/src/components/react/ReferenceSkeleton.tsx
+++ b/src/components/react/ReferenceSkeleton.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import styles from '../../styles/references.module.css';
+
+interface ReferenceSkeletonProps {
+    url?: string;
+}
+
+// A non-interactive placeholder row shown while a citation request is in flight.
+// It mirrors ReferenceItem's outer box + grid so the resolved item drops into the
+// same slot without a layout shift, but renders only shimmer bars — it never
+// calls useFormattedCitation, so a loading row triggers zero /api/format traffic
+// and cannot be selected, copied, or edited.
+export default function ReferenceSkeleton({ url }: ReferenceSkeletonProps) {
+    return (
+        <li className={styles.citationSourceItem}>
+            <div
+                className={styles.citation}
+                role="status"
+                aria-busy="true"
+                aria-label={url ? `Fetching citation for ${url}…` : 'Fetching citation…'}
+            >
+                <div className={styles.checkbox} aria-hidden="true"></div>
+                <div className={styles.citationSourceWrapper}>
+                    <span className={styles.skeletonBar} aria-hidden="true"></span>
+                    <span className={styles.skeletonBar} aria-hidden="true"></span>
+                </div>
+            </div>
+        </li>
+    );
+}

--- a/src/components/react/References.tsx
+++ b/src/components/react/References.tsx
@@ -4,6 +4,7 @@ import citationStyles from '../citationStyles';
 import Dropdown from './Dropdown';
 import CitationSearch from './CitationSearch';
 import ReferenceItem from './ReferenceItem';
+import ReferenceSkeleton from './ReferenceSkeleton';
 import { useReferences } from '../../lib/references/useReferences';
 import type { StoredSource } from '../../lib/references/storage';
 import type { SupportedStyle, RichText } from '../../lib/citations/csl-types';
@@ -22,6 +23,7 @@ function emptySource(): StoredSource {
 export default function References() {
     const {
         sources,
+        pending,
         sourceCount,
         selected,
         selectedCount,
@@ -148,7 +150,7 @@ export default function References() {
                         <span>Add Manually</span>
                     </Button>
                 </div>
-                {sources.length > 0 && (
+                {(sources.length > 0 || pending.length > 0) && (
                     <ul className={styles.citationSourceContainer} role="list">
                         {sources.map((source) => (
                             <ReferenceItem
@@ -160,6 +162,9 @@ export default function References() {
                                 citationFormat={citationFormat}
                                 autoOpenEdit={source.uuid === lastAddedId}
                             />
+                        ))}
+                        {pending.map((p) => (
+                            <ReferenceSkeleton key={p.id} url={p.url} />
                         ))}
                     </ul>
                 )}

--- a/src/lib/references/useReferences.ts
+++ b/src/lib/references/useReferences.ts
@@ -3,8 +3,17 @@ import { loadSources, saveSources, STORAGE_KEY, type StoredSource } from './stor
 import { decodeInlineCslParam, INLINE_CSL_PARAM } from './inline-csl';
 import type { CSLItem, ExtractQuality, FieldProvenance, SupportedStyle } from '../citations/csl-types';
 
+// A citation request that is in flight. Kept in component-only state and NEVER
+// persisted, so a loading placeholder can never leak into localStorage.
+export interface PendingSource {
+  id: string;
+  kind: 'website' | 'book' | 'journal';
+  url?: string;
+}
+
 export interface UseReferencesReturn {
   sources: StoredSource[];
+  pending: PendingSource[];
   sourceCount: number;
   selected: ReadonlySet<string>;
   selectedCount: number;
@@ -32,6 +41,7 @@ interface ApiEnvelope {
 
 export function useReferences(): UseReferencesReturn {
   const [sources, setSourcesState] = useState<StoredSource[]>([]);
+  const [pending, setPending] = useState<PendingSource[]>([]);
   const [selected, setSelected] = useState<ReadonlySet<string>>(() => new Set());
   const [citationFormat, setCitationFormatState] = useState<SupportedStyle>('mla-9');
 
@@ -109,6 +119,27 @@ export function useReferences(): UseReferencesReturn {
     else if (journal) requestUrl = `/api/cite-journal?doi=${encodeURIComponent(journal)}`;
     if (!requestUrl) return;
 
+    // Show a loading skeleton for this request immediately (component-only
+    // state, never persisted) so the user sees what they're waiting for.
+    const kind: PendingSource['kind'] = website ? 'website' : book ? 'book' : 'journal';
+    const pendingValue = website || book || journal || '';
+    const pendingId = `pending:${kind}:${pendingValue}`;
+    setPending((p) => (p.some((x) => x.id === pendingId) ? p : [...p, { id: pendingId, kind, url: pendingValue }]));
+    const clearPending = () => setPending((p) => p.filter((x) => x.id !== pendingId));
+
+    // Functional updater (not a closed-over `existing`) so manual citations the
+    // user added between mount and fetch resolution aren't clobbered.
+    const addEnvelope = (env: ApiEnvelope) => {
+      setSources((prev) => prev.some((s) => s.uuid === env.uuid)
+        ? prev
+        : [...prev, {
+          uuid: env.uuid,
+          csl: env.csl,
+          quality: env._quality,
+          provenance: env._provenance,
+        }]);
+    };
+
     let cancelled = false;
     // Bound the request so a slow/hung backend can't leave the page spinning
     // forever; abort on unmount so a late response can't update stale state.
@@ -125,20 +156,17 @@ export function useReferences(): UseReferencesReturn {
       })
       .then((env) => {
         if (cancelled || !env?.csl) return;
-        // Functional updater (not a closed-over `existing`) so manual citations
-        // the user added between mount and fetch resolution aren't clobbered.
-        setSources((prev) => prev.some((s) => s.uuid === env.uuid)
-          ? prev
-          : [...prev, {
-            uuid: env.uuid,
-            csl: env.csl,
-            quality: env._quality,
-            provenance: env._provenance,
-          }]);
+        addEnvelope(env);
       })
-      .catch((err) => { if (!cancelled) console.error('Citation fetch failed', err); })
-      .finally(() => clearTimeout(timeout));
-    return () => { cancelled = true; controller.abort(); clearTimeout(timeout); };
+      .catch((err) => {
+        if (cancelled) return;
+        console.error('Citation fetch failed', err);
+        // A timeout / network abort still resolves the skeleton to an actionable
+        // card for websites, instead of letting the placeholder vanish silently.
+        if (website) addEnvelope(errorEnvelopeFromWebsite(website, {}));
+      })
+      .finally(() => { clearTimeout(timeout); clearPending(); });
+    return () => { cancelled = true; controller.abort(); clearTimeout(timeout); clearPending(); };
   }, [setSources]);
 
   // Reload when another tab writes our localStorage key so two open tabs don't
@@ -171,6 +199,7 @@ export function useReferences(): UseReferencesReturn {
   // would only pay the shallow-compare cost without benefit.
   return {
     sources,
+    pending,
     sourceCount: sources.length,
     selected,
     selectedCount: selected.size,

--- a/src/styles/references.module.css
+++ b/src/styles/references.module.css
@@ -420,3 +420,35 @@
     }
 }
 
+/* Loading skeleton (ReferenceSkeleton) — two shimmer bars sized to mimic a
+   wrapped ~2-line citation, so the resolved row drops in without a height jump. */
+.skeletonBar {
+    display: block;
+    height: 16px;
+    margin: 8px 0;
+    border-radius: 6px;
+    background: linear-gradient(
+        90deg,
+        var(--color-background-3) 25%,
+        var(--color-border-2) 50%,
+        var(--color-background-3) 75%
+    );
+    background-size: 400% 100%;
+    animation: skeleton-shimmer 1.4s ease-in-out infinite;
+}
+
+.skeletonBar:last-child {
+    width: 60%;
+}
+
+@keyframes skeleton-shimmer {
+    0% { background-position: 100% 50%; }
+    100% { background-position: 0 50%; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .skeletonBar {
+        animation: none;
+    }
+}
+

--- a/tests/client/ReferenceSkeleton.test.tsx
+++ b/tests/client/ReferenceSkeleton.test.tsx
@@ -1,8 +1,12 @@
 // @vitest-environment jsdom
-import { describe, it, expect } from 'vitest';
-import { render } from '@testing-library/react';
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, cleanup } from '@testing-library/react';
 import React from 'react';
 import ReferenceSkeleton from '../../src/components/react/ReferenceSkeleton';
+
+// This project runs vitest without globals, so @testing-library's automatic
+// afterEach cleanup isn't registered — unmount renders between tests ourselves.
+afterEach(cleanup);
 
 describe('ReferenceSkeleton', () => {
   it('renders an accessible loading placeholder with two shimmer bars', () => {

--- a/tests/client/ReferenceSkeleton.test.tsx
+++ b/tests/client/ReferenceSkeleton.test.tsx
@@ -1,0 +1,23 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import React from 'react';
+import ReferenceSkeleton from '../../src/components/react/ReferenceSkeleton';
+
+describe('ReferenceSkeleton', () => {
+  it('renders an accessible loading placeholder with two shimmer bars', () => {
+    const { getByRole, container } = render(<ReferenceSkeleton url="https://example.com/post" />);
+    const status = getByRole('status');
+    expect(status.getAttribute('aria-busy')).toBe('true');
+    expect(status.getAttribute('aria-label')).toContain('Fetching citation for https://example.com/post');
+    // Two shimmer bars (aria-hidden spans); no interactive controls.
+    expect(container.querySelectorAll('span[aria-hidden="true"]')).toHaveLength(2);
+    expect(container.querySelector('input')).toBeNull();
+    expect(container.querySelector('button')).toBeNull();
+  });
+
+  it('falls back to a generic label when no url is given', () => {
+    const { getByRole } = render(<ReferenceSkeleton />);
+    expect(getByRole('status').getAttribute('aria-label')).toBe('Fetching citation…');
+  });
+});

--- a/tests/client/References.test.tsx
+++ b/tests/client/References.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, act } from '@testing-library/react';
 import React from 'react';
 import References from '../../src/components/react/References';
 import { _resetCacheForTests } from '../../src/lib/citations/useFormattedCitation';
@@ -53,5 +53,44 @@ describe('References selection label', () => {
       expect(container.textContent).toContain('2 sources');
       expect(container.textContent).not.toContain('selected');
     });
+  });
+});
+
+describe('References loading skeleton', () => {
+  function makeDeferred() {
+    let resolve!: (v: any) => void;
+    const promise = new Promise((res) => { resolve = res; });
+    return { promise, resolve };
+  }
+
+  it('shows a skeleton row while a submitted URL is fetching, then replaces it in place', async () => {
+    localStorage.clear();
+    Object.defineProperty(window, 'location', {
+      writable: true, value: new URL('http://localhost/my-references?website=https://x.com/p'),
+    });
+    const cite = makeDeferred();
+    globalThis.fetch = vi.fn((url: any) => {
+      if (String(url).includes('/api/cite-website')) return cite.promise;
+      // /api/format for any resolved rows.
+      return Promise.resolve(new Response(JSON.stringify({ formatted: [{ text: 'Formatted' }] }), { status: 200 }));
+    }) as any;
+
+    const { container, queryByRole } = render(<References />);
+
+    // Skeleton appears immediately — the list renders even with 0 real sources.
+    await waitFor(() => expect(queryByRole('status')).not.toBeNull());
+    expect(queryByRole('status')?.getAttribute('aria-busy')).toBe('true');
+    expect(container.querySelectorAll('input[aria-label^="Select reference"]').length).toBe(0);
+
+    // Resolve the citation → skeleton is replaced by a real, selectable row.
+    await act(async () => {
+      cite.resolve(new Response(JSON.stringify({
+        uuid: 'https://x.com/p', type: 'webpage',
+        csl: { id: 'u', type: 'webpage', title: 'Resolved Title', URL: 'https://x.com/p' },
+      }), { status: 200 }));
+    });
+
+    await waitFor(() => expect(queryByRole('status')).toBeNull());
+    expect(container.querySelectorAll('input[aria-label^="Select reference"]').length).toBe(1);
   });
 });

--- a/tests/client/useReferences.test.ts
+++ b/tests/client/useReferences.test.ts
@@ -224,4 +224,94 @@ describe('useReferences', () => {
       expect(result.current.selectedCount).toBe(1);
     });
   });
+
+  describe('optimistic loading (pending skeleton)', () => {
+    function makeDeferred() {
+      let resolve!: (v: any) => void;
+      let reject!: (e: any) => void;
+      const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+      return { promise, resolve, reject };
+    }
+    const atUrl = (search: string) => Object.defineProperty(window, 'location', {
+      writable: true, value: new URL(`http://localhost/my-references?${search}`),
+    });
+
+    it('shows a non-persisted placeholder while a website request is in flight', async () => {
+      atUrl('website=https://x.com/p');
+      const d = makeDeferred();
+      globalThis.fetch = vi.fn(() => d.promise) as any;
+
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.pending.length).toBe(1));
+
+      expect(result.current.pending[0].kind).toBe('website');
+      expect(result.current.pending[0].url).toBe('https://x.com/p');
+      expect(result.current.sourceCount).toBe(0);
+      // The placeholder must never reach localStorage.
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')).toEqual([]);
+    });
+
+    it('replaces the placeholder with the real citation on success, persisting only the real item', async () => {
+      atUrl('website=https://x.com/p');
+      const d = makeDeferred();
+      globalThis.fetch = vi.fn(() => d.promise) as any;
+
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.pending.length).toBe(1));
+
+      await act(async () => {
+        d.resolve(new Response(JSON.stringify({
+          uuid: 'https://x.com/p', type: 'webpage', csl: { id: 'u', type: 'webpage', title: 'T' },
+        }), { status: 200 }));
+      });
+
+      await waitFor(() => expect(result.current.pending.length).toBe(0));
+      expect(result.current.sourceCount).toBe(1);
+      expect(result.current.sources[0].uuid).toBe('https://x.com/p');
+      const saved = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+      expect(saved.map((s: any) => s.uuid)).toEqual(['https://x.com/p']);
+    });
+
+    it('clears the placeholder and shows a reviewable card when a website request rejects', async () => {
+      atUrl('website=https://slow.example/p');
+      const d = makeDeferred();
+      globalThis.fetch = vi.fn(() => d.promise) as any;
+
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.pending.length).toBe(1));
+
+      await act(async () => { d.reject(new Error('network')); });
+
+      await waitFor(() => expect(result.current.sourceCount).toBe(1));
+      expect(result.current.pending.length).toBe(0);
+      expect(result.current.sources[0].quality?.warnings[0].code).toBe('fetch_failed');
+    });
+
+    it('clears the placeholder without a card when a book request rejects', async () => {
+      atUrl('book=9780000000000');
+      const d = makeDeferred();
+      globalThis.fetch = vi.fn(() => d.promise) as any;
+
+      const { result } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.pending.length).toBe(1));
+      expect(result.current.pending[0].kind).toBe('book');
+
+      await act(async () => { d.reject(new Error('network')); });
+
+      await waitFor(() => expect(result.current.pending.length).toBe(0));
+      expect(result.current.sourceCount).toBe(0);
+    });
+
+    it('drops the placeholder on unmount and persists nothing', async () => {
+      atUrl('website=https://x.com/p');
+      const d = makeDeferred();
+      globalThis.fetch = vi.fn(() => d.promise) as any;
+
+      const { result, unmount } = renderHook(() => useReferences());
+      await waitFor(() => expect(result.current.pending.length).toBe(1));
+
+      unmount();
+      expect(JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]')).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## What
When a user submits a URL (or ISBN/DOI) to cite, a **shimmer skeleton row appears immediately** in the references list — so they see what they're waiting for — then it's replaced in place by the real citation once `/api/cite-website` resolves (requests can take several seconds through fetch + Browser Run + AI). For websites, a failure/timeout resolves the skeleton to the existing **actionable error card** instead of vanishing silently.

## Design (minimal-risk)
- **Non-persisted `pending` state** in `useReferences` — a separate array that never flows through `setSources`/`saveSources`, so a loading placeholder can **never** reach localStorage. Pushed synchronously before `fetch()`, removed in `.finally` + effect cleanup.
- **In-place swap**: the resolved item appends at the same tail slot the skeleton occupied; no existing row reorders.
- **`ReferenceSkeleton`** mirrors a real row's footprint (grid + checkbox alignment + two shimmer bars) but **never calls `useFormattedCitation`** → zero `/api/format` traffic, and it can't be selected/copied/edited. `role=status` + `aria-busy` + `aria-label`; `prefers-reduced-motion` disables the shimmer.
- Storage/persistence path (`storage.ts`, `saveSources`, `isStoredSource`) is **untouched**.

## Edge cases handled
Error → reviewable card (existing); website timeout/network reject → `fetch_failed` card (new, so it doesn't vanish); book/journal reject → skeleton removed; unmount/reload while pending → aborted + nothing persisted; concurrent submits are structurally impossible (each is a full-page navigation).

## Tests (jsdom)
- `useReferences`: placeholder appears + **not persisted**; reconciles to real item on success (only real item saved); error card on website reject; skeleton removed on book reject; clean unmount.
- `ReferenceSkeleton`: a11y (role/aria/two bars, no interactive controls).
- `References`: integration — skeleton shows while fetching, replaced by a selectable row on resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)