### PR TITLE
Muted color for the month-select placeholder

### DIFF
--- a/src/components/react/SimpleDropdown.tsx
+++ b/src/components/react/SimpleDropdown.tsx
@@ -48,7 +48,7 @@ export default function SimpleDropdown({
                     className
                 )}
             >
-                <span className="truncate leading-none">{value?.label || placeholder}</span>
+                <span className={cn("truncate leading-none", !value?.label && "text-muted-foreground")}>{value?.label || placeholder}</span>
                 <ChevronDownIcon className="h-4 w-4 opacity-50" />
             </button>
             {isOpen && (


### PR DESCRIPTION
The publication/access-date **Month** select showed its placeholder in the primary (black) text color, so an empty select looked populated. `SimpleDropdown` rendered `value?.label || placeholder` in one span with no color distinction (the button's `placeholder:text-muted-foreground` only applies to real `<input>` placeholders). Now the span gets `text-muted-foreground` when nothing is selected — gray placeholder, primary once a month is picked. Applies to every `SimpleDropdown` (all correct). One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)